### PR TITLE
Create new lifecycle exception module

### DIFF
--- a/db/adapters/sqlite/run_adapter.py
+++ b/db/adapters/sqlite/run_adapter.py
@@ -7,7 +7,7 @@ from typing import Optional
 from db.adapters.base import RunDatabaseAdapter
 from db.adapters.sqlite.schema_utils import required_column_names
 from db.adapters.sqlite.sqlite import get_connection, validate_required_fields
-from db.exceptions import DuplicateTurnMetadataError, RunNotFoundError
+from simulation.core.exceptions import DuplicateTurnMetadataError, RunNotFoundError
 from db.schema import runs
 from simulation.core.models.actions import TurnAction
 from simulation.core.models.runs import Run, RunStatus

--- a/db/exceptions.py
+++ b/db/exceptions.py
@@ -1,109 +1,18 @@
-"""Domain-specific exceptions for database operations."""
+"""Database-specific exceptions only.
+
+Domain exceptions (RunNotFoundError, InvalidTransitionError, RunCreationError,
+RunStatusUpdateError, DuplicateTurnMetadataError) live in simulation.core.exceptions.
+The DB layer (adapters, repositories) maps low-level DB failures to those domain
+exceptions; use simulation.core.exceptions for imports.
+"""
 
 
-class RunNotFoundError(Exception):
-    """Raised when a run with the specified ID cannot be found."""
+class DatabaseError(Exception):
+    """Base for truly database-specific errors (e.g. connection, schema, driver)."""
 
-    def __init__(self, run_id: str):
-        """Initialize RunNotFoundError.
-
-        Args:
-            run_id: The run ID that was not found
-        """
-        self.run_id = run_id
-        super().__init__(f"Run '{run_id}' not found")
-
-
-class InvalidTransitionError(Exception):
-    """Raised when an invalid status transition is attempted."""
-
-    def __init__(
-        self,
-        run_id: str,
-        current_status: str,
-        target_status: str,
-        valid_transitions: list[str] | None = None,
-    ):
-        """Initialize InvalidTransitionError.
-
-        Args:
-            run_id: The run ID for which the transition was attempted
-            current_status: The current status of the run
-            target_status: The target status that was attempted
-            valid_transitions: List of valid transition targets from current_status, or None if terminal state
-        """
-        self.run_id = run_id
-        self.current_status = current_status
-        self.target_status = target_status
-        self.valid_transitions = valid_transitions
-
-        if valid_transitions:
-            transitions_str = ", ".join(valid_transitions)
-        else:
-            transitions_str = "none (terminal state)"
-
-        message = (
-            f"Invalid status transition for run '{run_id}': "
-            f"{current_status} -> {target_status}. "
-            f"Valid transitions from {current_status} are: {transitions_str}"
-        )
+    def __init__(self, message: str, cause: Exception | None = None):
+        self.message = message
+        self.cause = cause
         super().__init__(message)
-
-
-class RunCreationError(Exception):
-    """Raised when a run cannot be created."""
-
-    def __init__(self, run_id: str, reason: str | None = None):
-        """Initialize RunCreationError.
-
-        Args:
-            run_id: The run ID that failed to be created
-            reason: Optional reason for the failure
-        """
-        self.run_id = run_id
-        self.reason = reason
-
-        if reason:
-            message = f"Failed to create run '{run_id}': {reason}"
-        else:
-            message = f"Failed to create run '{run_id}'"
-
-        super().__init__(message)
-
-
-class RunStatusUpdateError(Exception):
-    """Raised when a run status cannot be updated."""
-
-    def __init__(self, run_id: str, reason: str | None = None):
-        """Initialize RunStatusUpdateError.
-
-        Args:
-            run_id: The run ID that failed to be updated
-            reason: Optional reason for the failure
-        """
-        self.run_id = run_id
-        self.reason = reason
-
-        if reason:
-            message = f"Failed to update run status for '{run_id}': {reason}"
-        else:
-            message = f"Failed to update run status for '{run_id}'"
-
-        super().__init__(message)
-
-
-class DuplicateTurnMetadataError(Exception):
-    """Raised when turn metadata already exists."""
-
-    def __init__(self, run_id: str, turn_number: int):
-        """Initialize DuplicateTurnMetadataError.
-
-        Args:
-            run_id: The run ID that has duplicate turn metadata
-            turn_number: The turn number that has duplicate metadata
-        """
-        self.run_id = run_id
-        self.turn_number = turn_number
-
-        message = f"Turn metadata already exists for run '{run_id}', turn {turn_number}"
-        super().__init__(message)
+        if cause is not None:
+            self.__cause__ = cause

--- a/db/repositories/run_repository.py
+++ b/db/repositories/run_repository.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 from db.adapters.base import RunDatabaseAdapter
-from db.exceptions import (
+from simulation.core.exceptions import (
     InvalidTransitionError,
     RunCreationError,
     RunNotFoundError,

--- a/simulation/core/command_service.py
+++ b/simulation/core/command_service.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections.abc import Callable
 
-from db.exceptions import DuplicateTurnMetadataError, RunStatusUpdateError
+from simulation.core.exceptions import DuplicateTurnMetadataError, RunStatusUpdateError
 from db.repositories.feed_post_repository import FeedPostRepository
 from db.repositories.generated_bio_repository import GeneratedBioRepository
 from db.repositories.generated_feed_repository import GeneratedFeedRepository

--- a/simulation/core/exceptions.py
+++ b/simulation/core/exceptions.py
@@ -57,3 +57,114 @@ class InsufficientAgentsError(SimulationError):
             f"Not enough agents: requested {requested}, but only {available} available."
         )
         super().__init__(message, run_id=run_id, turn_number=turn_number)
+
+
+# Run lifecycle and persistence (raised by simulation core and by DB layer when mapping failures)
+
+
+class RunNotFoundError(Exception):
+    """Raised when a run with the specified ID cannot be found."""
+
+    def __init__(self, run_id: str):
+        """Initialize RunNotFoundError.
+
+        Args:
+            run_id: The run ID that was not found
+        """
+        self.run_id = run_id
+        super().__init__(f"Run '{run_id}' not found")
+
+
+class InvalidTransitionError(Exception):
+    """Raised when an invalid status transition is attempted."""
+
+    def __init__(
+        self,
+        run_id: str,
+        current_status: str,
+        target_status: str,
+        valid_transitions: list[str] | None = None,
+    ):
+        """Initialize InvalidTransitionError.
+
+        Args:
+            run_id: The run ID for which the transition was attempted
+            current_status: The current status of the run
+            target_status: The target status that was attempted
+            valid_transitions: List of valid transition targets from current_status, or None if terminal state
+        """
+        self.run_id = run_id
+        self.current_status = current_status
+        self.target_status = target_status
+        self.valid_transitions = valid_transitions
+
+        if valid_transitions:
+            transitions_str = ", ".join(valid_transitions)
+        else:
+            transitions_str = "none (terminal state)"
+
+        message = (
+            f"Invalid status transition for run '{run_id}': "
+            f"{current_status} -> {target_status}. "
+            f"Valid transitions from {current_status} are: {transitions_str}"
+        )
+        super().__init__(message)
+
+
+class RunCreationError(Exception):
+    """Raised when a run cannot be created."""
+
+    def __init__(self, run_id: str, reason: str | None = None):
+        """Initialize RunCreationError.
+
+        Args:
+            run_id: The run ID that failed to be created
+            reason: Optional reason for the failure
+        """
+        self.run_id = run_id
+        self.reason = reason
+
+        if reason:
+            message = f"Failed to create run '{run_id}': {reason}"
+        else:
+            message = f"Failed to create run '{run_id}'"
+
+        super().__init__(message)
+
+
+class RunStatusUpdateError(Exception):
+    """Raised when a run status cannot be updated."""
+
+    def __init__(self, run_id: str, reason: str | None = None):
+        """Initialize RunStatusUpdateError.
+
+        Args:
+            run_id: The run ID that failed to be updated
+            reason: Optional reason for the failure
+        """
+        self.run_id = run_id
+        self.reason = reason
+
+        if reason:
+            message = f"Failed to update run status for '{run_id}': {reason}"
+        else:
+            message = f"Failed to update run status for '{run_id}'"
+
+        super().__init__(message)
+
+
+class DuplicateTurnMetadataError(Exception):
+    """Raised when turn metadata already exists."""
+
+    def __init__(self, run_id: str, turn_number: int):
+        """Initialize DuplicateTurnMetadataError.
+
+        Args:
+            run_id: The run ID that has duplicate turn metadata
+            turn_number: The turn number that has duplicate metadata
+        """
+        self.run_id = run_id
+        self.turn_number = turn_number
+
+        message = f"Turn metadata already exists for run '{run_id}', turn {turn_number}"
+        super().__init__(message)

--- a/simulation/core/query_service.py
+++ b/simulation/core/query_service.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from db.exceptions import RunNotFoundError
+from simulation.core.exceptions import RunNotFoundError
 from db.repositories.feed_post_repository import FeedPostRepository
 from db.repositories.generated_feed_repository import GeneratedFeedRepository
 from db.repositories.run_repository import RunRepository

--- a/simulation/core/validators.py
+++ b/simulation/core/validators.py
@@ -1,6 +1,6 @@
 from typing import Iterable
 
-from db.exceptions import InvalidTransitionError, RunNotFoundError
+from simulation.core.exceptions import InvalidTransitionError, RunNotFoundError
 from simulation.core.exceptions import InsufficientAgentsError
 from simulation.core.models.agents import SocialMediaAgent
 from simulation.core.models.posts import BlueskyFeedPost

--- a/simulation/main.py
+++ b/simulation/main.py
@@ -1,7 +1,7 @@
 import sys
 
 from db.adapters.sqlite.sqlite import initialize_database
-from db.exceptions import (
+from simulation.core.exceptions import (
     InvalidTransitionError,
     RunCreationError,
     RunNotFoundError,

--- a/tests/db/adapters/sqlite/test_run_adapter.py
+++ b/tests/db/adapters/sqlite/test_run_adapter.py
@@ -354,7 +354,7 @@ class TestSQLiteRunAdapterWriteTurnMetadata:
     ):
         """Test that write_turn_metadata raises DuplicateTurnMetadataError when metadata already exists."""
         # Arrange
-        from db.exceptions import DuplicateTurnMetadataError
+        from simulation.core.exceptions import DuplicateTurnMetadataError
 
         run_id = default_test_data["run_id"]
         turn_number = default_test_data["turn_number"]
@@ -496,7 +496,7 @@ class TestSQLiteRunAdapterWriteTurnMetadata:
         but the INSERT fails due to a PRIMARY KEY constraint violation.
         """
         # Arrange
-        from db.exceptions import DuplicateTurnMetadataError
+        from simulation.core.exceptions import DuplicateTurnMetadataError
 
         run_id = default_test_data["run_id"]
         turn_number = default_test_data["turn_number"]
@@ -537,7 +537,7 @@ class TestSQLiteRunAdapterWriteTurnMetadata:
     ):
         """Test that commit is not called when IntegrityError is raised."""
         # Arrange
-        from db.exceptions import DuplicateTurnMetadataError
+        from simulation.core.exceptions import DuplicateTurnMetadataError
 
         run_id = default_test_data["run_id"]
         turn_number = default_test_data["turn_number"]

--- a/tests/db/repositories/test_run_repository.py
+++ b/tests/db/repositories/test_run_repository.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from db.adapters.base import RunDatabaseAdapter
-from db.exceptions import (
+from simulation.core.exceptions import (
     DuplicateTurnMetadataError,
     InvalidTransitionError,
     RunCreationError,

--- a/tests/db/repositories/test_run_repository_integration.py
+++ b/tests/db/repositories/test_run_repository_integration.py
@@ -10,7 +10,7 @@ import time
 import pytest
 
 from db.adapters.sqlite.sqlite import DB_PATH, get_connection, initialize_database
-from db.exceptions import (
+from simulation.core.exceptions import (
     DuplicateTurnMetadataError,
     InvalidTransitionError,
     RunNotFoundError,

--- a/tests/simulation/core/test_command_service.py
+++ b/tests/simulation/core/test_command_service.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from db.exceptions import RunStatusUpdateError
+from simulation.core.exceptions import RunStatusUpdateError
 from db.repositories.feed_post_repository import FeedPostRepository
 from db.repositories.generated_bio_repository import GeneratedBioRepository
 from db.repositories.generated_feed_repository import GeneratedFeedRepository

--- a/tests/simulation/core/test_query_service.py
+++ b/tests/simulation/core/test_query_service.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from db.exceptions import RunNotFoundError
+from simulation.core.exceptions import RunNotFoundError
 from db.repositories.feed_post_repository import FeedPostRepository
 from db.repositories.generated_feed_repository import GeneratedFeedRepository
 from db.repositories.run_repository import RunRepository


### PR DESCRIPTION
# PR Description

We have a catch-all exceptions file in `db/exceptions.py`, but we have domain-specific exceptions that don't fit that paradigm. We move those to their own exceptions module.