### PR TITLE
Migrate repository abstract classes to their own module

### DIFF
--- a/db/repositories/__init__.py
+++ b/db/repositories/__init__.py
@@ -15,7 +15,7 @@ from db.repositories.profile_repository import (
     create_sqlite_profile_repository,
 )
 from db.repositories.run_repository import SQLiteRunRepository, create_sqlite_repository
-from simulation.core.ports import (
+from db.repositories.interfaces import (
     FeedPostRepository,
     GeneratedBioRepository,
     GeneratedFeedRepository,

--- a/db/repositories/feed_post_repository.py
+++ b/db/repositories/feed_post_repository.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 
 from db.adapters.base import FeedPostDatabaseAdapter
 from simulation.core.models.posts import BlueskyFeedPost
-from simulation.core.ports import FeedPostRepository
+from db.repositories.interfaces import FeedPostRepository
 from simulation.core.validators import (
     validate_handle_exists,
     validate_posts_exist,

--- a/db/repositories/generated_bio_repository.py
+++ b/db/repositories/generated_bio_repository.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from db.adapters.base import GeneratedBioDatabaseAdapter
 from simulation.core.models.generated.bio import GeneratedBio
-from simulation.core.ports import GeneratedBioRepository
+from db.repositories.interfaces import GeneratedBioRepository
 from simulation.core.validators import validate_handle_exists
 
 

--- a/db/repositories/generated_feed_repository.py
+++ b/db/repositories/generated_feed_repository.py
@@ -2,7 +2,7 @@
 
 from db.adapters.base import GeneratedFeedDatabaseAdapter
 from simulation.core.models.feeds import GeneratedFeed
-from simulation.core.ports import GeneratedFeedRepository
+from db.repositories.interfaces import GeneratedFeedRepository
 from simulation.core.validators import (
     validate_handle_exists,
     validate_run_id,

--- a/db/repositories/interfaces.py
+++ b/db/repositories/interfaces.py
@@ -1,8 +1,8 @@
-"""Application ports (repository interfaces).
+"""Repository interfaces.
 
-Repository and adapter port definitions live here so that the application
-layer does not depend on db for interface types. Implementations (e.g. SQLite)
-live in db/repositories and implement these interfaces.
+Abstract repository port definitions live here, close to but decoupled from
+implementations in this package. Concrete implementations (e.g. SQLite*)
+implement these interfaces.
 """
 
 from abc import ABC, abstractmethod

--- a/db/repositories/profile_repository.py
+++ b/db/repositories/profile_repository.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from db.adapters.base import ProfileDatabaseAdapter
 from simulation.core.models.profiles import BlueskyProfile
-from simulation.core.ports import ProfileRepository
+from db.repositories.interfaces import ProfileRepository
 from simulation.core.validators import validate_handle_exists
 
 

--- a/db/repositories/run_repository.py
+++ b/db/repositories/run_repository.py
@@ -13,7 +13,7 @@ from simulation.core.exceptions import (
 )
 from simulation.core.models.runs import Run, RunConfig, RunStatus
 from simulation.core.models.turns import TurnMetadata
-from simulation.core.ports import RunRepository
+from db.repositories.interfaces import RunRepository
 from simulation.core.validators import (
     validate_run_exists,
     validate_run_id,

--- a/simulation/core/command_service.py
+++ b/simulation/core/command_service.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 from simulation.core.exceptions import DuplicateTurnMetadataError, RunStatusUpdateError
 from lib.decorators import record_runtime
-from simulation.core.ports import (
+from db.repositories.interfaces import (
     FeedPostRepository,
     GeneratedBioRepository,
     GeneratedFeedRepository,

--- a/simulation/core/dependencies.py
+++ b/simulation/core/dependencies.py
@@ -25,7 +25,7 @@ from simulation.core.agent_action_rules_validator import AgentActionRulesValidat
 from simulation.core.command_service import SimulationCommandService
 from simulation.core.engine import SimulationEngine
 from simulation.core.models.agents import SocialMediaAgent
-from simulation.core.ports import (
+from db.repositories.interfaces import (
     FeedPostRepository,
     GeneratedBioRepository,
     GeneratedFeedRepository,

--- a/simulation/core/engine.py
+++ b/simulation/core/engine.py
@@ -9,7 +9,7 @@ from simulation.core.command_service import SimulationCommandService
 from simulation.core.models.agents import SocialMediaAgent
 from simulation.core.models.runs import Run, RunConfig, RunStatus
 from simulation.core.models.turns import TurnData, TurnMetadata
-from simulation.core.ports import (
+from db.repositories.interfaces import (
     FeedPostRepository,
     GeneratedBioRepository,
     GeneratedFeedRepository,

--- a/simulation/core/query_service.py
+++ b/simulation/core/query_service.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from simulation.core.exceptions import RunNotFoundError
 from simulation.core.models.runs import Run
-from simulation.core.ports import (
+from db.repositories.interfaces import (
     FeedPostRepository,
     GeneratedFeedRepository,
     RunRepository,


### PR DESCRIPTION
# PR Description

For each repository in `db/repositories/`, we have both an abstractclass describing the interface as well as the actual implementation. This splits those up so that all the interfaces live in their own location, removing them from the specific implementation details in `db/repositories/`.

We decided that persistence abstractions live under db/” is a hard rule and that app -> db for interface types is acceptable. It might not be 100% perfect architecture, but (1) it keeps the interfaces close to implementation and (2) everything stays under db/ for “database-facing” abstractions.