### PR TITLE
Update failure propagation model for partial-result API

### DIFF
--- a/simulation/core/exceptions.py
+++ b/simulation/core/exceptions.py
@@ -153,6 +153,20 @@ class RunStatusUpdateError(Exception):
         super().__init__(message)
 
 
+class SimulationRunFailure(Exception):
+    """Raised when simulation run execution fails."""
+
+    def __init__(
+        self,
+        message: str,
+        run_id: str | None = None,
+        cause: BaseException | None = None,
+    ):
+        self.run_id = run_id
+        self.cause = cause
+        super().__init__(message)
+
+
 class DuplicateTurnMetadataError(Exception):
     """Raised when turn metadata already exists."""
 

--- a/simulation/main.py
+++ b/simulation/main.py
@@ -6,6 +6,7 @@ from simulation.core.exceptions import (
     RunCreationError,
     RunNotFoundError,
     RunStatusUpdateError,
+    SimulationRunFailure,
 )
 from simulation.core.factories import create_engine
 from simulation.core.models.runs import RunConfig
@@ -23,14 +24,8 @@ def do_simulation_run(config: RunConfig) -> None:
 
     print(f"Starting simulation: {config.num_agents} agents, {config.num_turns} turns")
 
-    try:
-        run = engine.execute_run(config)
-        print(f"Simulation run {run.run_id} completed in {run.total_turns} turns.")
-    except Exception as e:
-        # Error handling matches previous implementation
-        # Engine handles status updates internally, but we still catch and print
-        print(f"Error: Failed to complete simulation: {e}")
-        raise
+    run = engine.execute_run(config)
+    print(f"Simulation run {run.run_id} completed in {run.total_turns} turns.")
 
 
 def main():
@@ -45,6 +40,10 @@ def main():
 
     try:
         do_simulation_run(config)
+    except SimulationRunFailure as e:
+        run_context = e.run_id or "unknown"
+        print(f"Error: simulation run failed (run_id={run_context}): {e}")
+        sys.exit(1)
     except (
         RunNotFoundError,
         InvalidTransitionError,


### PR DESCRIPTION
# PR Description

Previously, we had a bug in execute_run() where run may be referenced before assignment in the except block. We resolve this. We also introduce a new `SimulationRunFailure` exception class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and reporting during simulation execution with enhanced error messages that include run context information.
  * Simulation run failures now provide clearer diagnostics and detailed context, making it easier to identify which runs encountered issues and troubleshoot problems more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->