### PR TITLE
turn off daily Cursor QA job

### DIFF
--- a/.github/workflows/cursor-daily-quality-check.yml
+++ b/.github/workflows/cursor-daily-quality-check.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   cursor-quality-check:
+    if: false  # Disabled
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:


### PR DESCRIPTION
# PR Description

We previously enabled daily Cursor QA jobs. There are better ways to do this in the future, but this current way costs too much. Costs $5/run and it isn't very worth it.

<img width="1060" height="150" alt="Screenshot 2026-02-18 at 4 32 19 PM" src="https://github.com/user-attachments/assets/6e1498ac-589f-4036-82c6-0ed79999cc5e" />

We want to keep the .yml file there, but we just disable it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflow configuration to disable a quality check job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->