### PR TITLE
Update docker remove nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,14 @@ WORKDIR /app
 RUN useradd --create-home --shell /usr/sbin/nologin appuser \
     && pip install --no-cache-dir 'uv==0.10.3'
 
-COPY --chown=appuser:appuser . /app
+COPY . /app
 
 # Install runtime dependencies with uv lockfile fidelity.
-USER appuser
 RUN if [ -f uv.lock ]; then uv sync --frozen --no-dev; else uv sync --no-dev; fi
 
 EXPOSE 8000
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD ["sh", "-c", "python -c \"import urllib.request, os; u = urllib.request.urlopen('http://127.0.0.1:' + os.environ.get('PORT', '8000') + '/health', timeout=3); exit(0 if u.getcode() == 200 else 1)\" || exit 1"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=5 \
+  CMD ["sh", "-c", "python -c \"import urllib.request, os; u = urllib.request.urlopen('http://127.0.0.1:' + os.environ.get('PORT', '8000') + '/health', timeout=5); exit(0 if u.getcode() == 200 else 1)\" || exit 1"]
 
 CMD ["sh", "-c", "uv run uvicorn simulation.api.main:app --host 0.0.0.0 --port ${PORT:-8000} --forwarded-allow-ips \"${FORWARDED_ALLOW_IPS:-*}\""]


### PR DESCRIPTION
# PR Description

Our deploys in prod were failing. 

```bash
error: failed to create directory `/app/.venv`: Permission denied (os error 13)
```

appuser couldn’t create the virtualenv because /app wasn’t writable for that user.


Changes made

1. Removed the non-root user for the build/run – uv sync and the app now run as root so:

- .venv can be created during the image build
- The app can write to Railway’s /data volume for SQLite

2. Relaxed the healthcheck – Increased start-period from 5s to 30s and timeout from 3s to 5s so DB init and startup can finish before health checks start.

Verification

- Health: https://agent-simulation-platform-production.up.railway.app/health → {"status":"ok"}
- Runs: https://agent-simulation-platform-production.up.railway.app/v1/simulations/runs → returns run data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker health check intervals and timeout settings for improved monitoring reliability
  * Adjusted container user permission configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->