### PR TITLE
Add markdownlint to CI + pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,20 @@ on:
     branches: [ main, master, develop ]
 
 jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run markdownlint-cli2
+        run: npx -y markdownlint-cli2 "**/*.md" "#node_modules" "#ui/node_modules" "#.venv" "#docs/plans"
+
   hadolint:
     runs-on: ubuntu-latest
     steps:

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,10 @@
+default: true
+
+# Reasonable defaults for mixed prose/code repositories:
+# - don't enforce line length (links and tables often exceed)
+# - allow HTML (often used for badges/callouts)
+# - don't require H1 as the first line (READMEs often start with badges)
+MD013: false
+MD060: false
+MD033: false
+MD041: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,14 @@ repos:
         args: [--check]
   - repo: local
     hooks:
+      - id: markdownlint
+        name: markdownlint (markdownlint-cli2)
+        entry: markdownlint-cli2
+        language: node
+        additional_dependencies: [markdownlint-cli2@0.21.0]
+        args: ["--config", ".markdownlint.yml"]
+        types: [markdown]
+        exclude: ^docs/plans/
       - id: complexipy
         name: complexipy
         entry: bash -lc "uv run complexipy . --max-complexity-allowed 999"

--- a/docs/runbooks/HOW_TO_CREATE_NEW_FEED_RANKING_ALGORITHM.md
+++ b/docs/runbooks/HOW_TO_CREATE_NEW_FEED_RANKING_ALGORITHM.md
@@ -104,7 +104,7 @@ The framework persists the feed, hydrates posts, and returns hydrated feeds to c
 from feeds.algorithms.implementations.my_algorithm import MyFeedAlgorithm
 ```
 
-2. Add an entry to `_ALGORITHM_LOOKUP`:
+1. Add an entry to `_ALGORITHM_LOOKUP`:
 
 ```python
 _ALGORITHM_LOOKUP: dict[str, FeedAlgorithm] = {

--- a/docs/runbooks/LOCAL_DEV_AUTH.md
+++ b/docs/runbooks/LOCAL_DEV_AUTH.md
@@ -18,7 +18,7 @@ DISABLE_AUTH=1 PYTHONPATH=. uv run uvicorn simulation.api.main:app --reload --po
 
 Or add to `.env` in the project root (if your runner loads it):
 
-```
+```dotenv
 DISABLE_AUTH=1
 ```
 
@@ -26,7 +26,7 @@ DISABLE_AUTH=1
 
 Add to `ui/.env.local`:
 
-```
+```dotenv
 NEXT_PUBLIC_DISABLE_AUTH=true
 ```
 

--- a/docs/runbooks/RAILWAY_DEPLOYMENT.md
+++ b/docs/runbooks/RAILWAY_DEPLOYMENT.md
@@ -40,6 +40,7 @@ railway variables --set "FORWARDED_ALLOW_IPS=*"
 ```
 
 Notes:
+
 - `SIM_DB_PATH` is read by the app at runtime and is the recommended SQLite path override for Railway.
 - If you use a different mount path, set `SIM_DB_PATH` accordingly.
 - The Docker build uses `uv sync --frozen` only when `uv.lock` exists; otherwise it falls back to `uv sync --no-dev`.
@@ -85,6 +86,7 @@ curl -sS -X POST "<APP_URL>/v1/simulations/run" \
 ```
 
 Expected behavior:
+
 - `GET /health` returns `{"status":"ok"}` with HTTP 200.
 - `POST /v1/simulations/run` returns HTTP 200 with `run_id`, `status`, `likes_per_turn`, and `total_likes` (status may be `failed` if no agent fixture data is loaded).
 

--- a/docs/runbooks/UI_DEPLOYMENT.md
+++ b/docs/runbooks/UI_DEPLOYMENT.md
@@ -22,6 +22,7 @@ vercel link
 ```
 
 Notes:
+
 - This creates `ui/.vercel/` (already gitignored).
 - Node version is controlled by `ui/package.json` via `engines.node` (we pin to `20.x` for parity with CI).
 
@@ -73,4 +74,3 @@ vercel logs <deployment-url>
 
 - `ui/package-lock.json` is committed and CI uses `npm ci` to ensure deterministic installs.
 - Keep `next` on a patched version (Vercel blocks deployments of vulnerable Next.js releases).
-

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -7,6 +7,7 @@ This directory contains the core simulation logic for the agent simulation platf
 ### `main.py`
 
 Runs the social media agent simulation:
+
 - Creates initial agents from the database
 - Runs 10 turns of simulation
 - Each turn, agents:

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,7 +66,7 @@ uv run pytest --tb=no
 
 Tests follow the structure of the source code:
 
-```
+```text
 tests/
 ├── db/
 │   └── repositories/


### PR DESCRIPTION
Adds markdownlint-cli2 with a repo-level config, runs it in GitHub Actions, and wires it into pre-commit (excluding docs/plans).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added markdown linting to the continuous integration pipeline and pre-commit hooks to maintain documentation quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->