### PR TITLE
Hotfix: Vercel build failing due to RunConfig type

### DIFF
--- a/ui/components/details/DetailsPanel.tsx
+++ b/ui/components/details/DetailsPanel.tsx
@@ -8,7 +8,7 @@ import { useRunDetail } from '@/components/run-detail/RunDetailContext';
 import { getPosts } from '@/lib/api/simulation';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import { getTurnsErrorMessage } from '@/lib/error-messages';
-import { Agent, Post, Turn } from '@/types';
+import { Agent, Post, RunConfig, Turn } from '@/types';
 
 export default function DetailsPanel() {
   const {
@@ -111,7 +111,7 @@ function getAllPostsForTurn(
 
 interface TurnDetailContentProps {
   currentTurn: Turn;
-  currentRunConfig: { numAgents: number; numTurns: number } | null;
+  currentRunConfig: RunConfig | null;
   runAgents: Agent[];
 }
 

--- a/ui/lib/run-selectors.ts
+++ b/ui/lib/run-selectors.ts
@@ -1,4 +1,5 @@
 import { Agent, Run, RunConfig, Turn } from '@/types';
+import { FALLBACK_DEFAULT_CONFIG } from '@/lib/default-config';
 
 const MAX_VISIBLE_RUN_AGENTS: number = 8;
 const EMPTY_TURNS: Record<string, Turn> = {};
@@ -85,6 +86,7 @@ export function getRunConfig(
   return {
     numAgents: run.totalAgents,
     numTurns: run.totalTurns,
+    feedAlgorithm: FALLBACK_DEFAULT_CONFIG.feedAlgorithm,
   };
 }
 


### PR DESCRIPTION
Fixes Next.js build failure on main caused by RunConfig now requiring feedAlgorithm.

- Updates DetailsPanel TurnDetailContent prop type to RunConfig.
- Ensures run config selector always returns a complete RunConfig by filling feedAlgorithm with FALLBACK_DEFAULT_CONFIG when backend config isn't available.

Verified locally: 
added 404 packages, and audited 405 packages in 8s

166 packages are looking for funding
  run `npm fund` for details

16 vulnerabilities (1 moderate, 15 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.

> ui@0.1.0 build
> next build

   ▲ Next.js 16.0.10 (Turbopack)

   Creating an optimized production build ...
 ✓ Compiled successfully in 1314.4ms
   Running TypeScript ...
   Collecting page data using 11 workers ...
   Generating static pages using 11 workers (0/5) ...
   Generating static pages using 11 workers (1/5) 
   Generating static pages using 11 workers (2/5) 
   Generating static pages using 11 workers (3/5) 
 ✓ Generating static pages using 11 workers (5/5) in 219.0ms
   Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
└ ○ /auth/callback


○  (Static)  prerendered as static content passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized run configuration handling to use centralized type definitions.
  * Run configurations now include a feedAlgorithm field with default fallback values for consistent behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->