### PR TITLE
test: consolidate fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Shared pytest fixtures for the full test suite."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Generator
+
+import pytest
+
+
+@pytest.fixture
+def temp_db(monkeypatch: pytest.MonkeyPatch) -> Generator[str, None, None]:
+    """Create a temporary SQLite database, initialize schema, then clean up.
+
+    This fixture:
+    - Creates a temp .sqlite file path
+    - Ensures all SQLite consumers point at it (DB_PATH + SIM_DB_PATH)
+    - Applies Alembic migrations via initialize_database()
+    - Deletes the file on teardown
+    """
+    fd, temp_path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+
+    import db.adapters.sqlite.sqlite as sqlite_module
+    from db.adapters.sqlite.sqlite import initialize_database
+
+    monkeypatch.setattr(sqlite_module, "DB_PATH", temp_path)
+    monkeypatch.setenv(sqlite_module.SIM_DB_PATH_ENV, temp_path)
+
+    initialize_database()
+
+    try:
+        yield temp_path
+    finally:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)

--- a/tests/db/adapters/sqlite/test_feed_post_adapter.py
+++ b/tests/db/adapters/sqlite/test_feed_post_adapter.py
@@ -7,27 +7,13 @@ import pytest
 
 from db.adapters.sqlite.feed_post_adapter import SQLiteFeedPostAdapter
 from simulation.core.models.posts import BlueskyFeedPost
-from tests.db.adapters.sqlite.conftest import create_mock_db_connection, create_mock_row
+from tests.db.adapters.sqlite.conftest import create_mock_row
 
 
 @pytest.fixture
 def adapter():
     """Create a SQLiteFeedPostAdapter instance."""
     return SQLiteFeedPostAdapter()
-
-
-@pytest.fixture
-def mock_db_connection():
-    """Fixture that provides a context manager for mocking database connections.
-
-    Usage:
-        with mock_db_connection() as (mock_get_conn, mock_conn, mock_cursor):
-            mock_cursor.fetchall = Mock(return_value=[row1, row2])
-            # test code here
-    """
-    return create_mock_db_connection(
-        "db.adapters.sqlite.feed_post_adapter.get_connection"
-    )
 
 
 class TestSQLiteFeedPostAdapterReadFeedPostsByUris:

--- a/tests/db/adapters/sqlite/test_generated_bio_adapter.py
+++ b/tests/db/adapters/sqlite/test_generated_bio_adapter.py
@@ -7,27 +7,13 @@ import pytest
 from db.adapters.sqlite.generated_bio_adapter import SQLiteGeneratedBioAdapter
 from simulation.core.models.generated.base import GenerationMetadata
 from simulation.core.models.generated.bio import GeneratedBio
-from tests.db.adapters.sqlite.conftest import create_mock_db_connection, create_mock_row
+from tests.db.adapters.sqlite.conftest import create_mock_row
 
 
 @pytest.fixture
 def adapter():
     """Create a SQLiteGeneratedBioAdapter instance."""
     return SQLiteGeneratedBioAdapter()
-
-
-@pytest.fixture
-def mock_db_connection():
-    """Fixture that provides a context manager for mocking database connections.
-
-    Usage:
-        with mock_db_connection() as (mock_get_conn, mock_conn, mock_cursor):
-            mock_cursor.fetchone.return_value = some_row
-            # test code here
-    """
-    return create_mock_db_connection(
-        "db.adapters.sqlite.generated_bio_adapter.get_connection"
-    )
 
 
 class TestSQLiteGeneratedBioAdapterWriteGeneratedBio:

--- a/tests/db/adapters/sqlite/test_generated_feed_adapter.py
+++ b/tests/db/adapters/sqlite/test_generated_feed_adapter.py
@@ -8,7 +8,7 @@ import pytest
 
 from db.adapters.sqlite.generated_feed_adapter import SQLiteGeneratedFeedAdapter
 from simulation.core.models.feeds import GeneratedFeed
-from tests.db.adapters.sqlite.conftest import create_mock_db_connection, create_mock_row
+from tests.db.adapters.sqlite.conftest import create_mock_row
 
 
 @pytest.fixture
@@ -21,20 +21,6 @@ def adapter():
 def default_test_data():
     """Common test data used across multiple tests."""
     return {"run_id": "run_123", "turn_number": 0, "agent_handle": "agent.bsky.social"}
-
-
-@pytest.fixture
-def mock_db_connection():
-    """Fixture that provides a context manager for mocking database connections.
-
-    Usage:
-        with mock_db_connection() as (mock_get_conn, mock_conn, mock_cursor):
-            mock_cursor.fetchall = Mock(return_value=[row1, row2])
-            # test code here
-    """
-    return create_mock_db_connection(
-        "db.adapters.sqlite.generated_feed_adapter.get_connection"
-    )
 
 
 class TestSQLiteGeneratedFeedAdapterReadFeedsForTurn:

--- a/tests/db/adapters/sqlite/test_profile_adapter.py
+++ b/tests/db/adapters/sqlite/test_profile_adapter.py
@@ -6,27 +6,13 @@ import pytest
 
 from db.adapters.sqlite.profile_adapter import SQLiteProfileAdapter
 from simulation.core.models.profiles import BlueskyProfile
-from tests.db.adapters.sqlite.conftest import create_mock_db_connection, create_mock_row
+from tests.db.adapters.sqlite.conftest import create_mock_row
 
 
 @pytest.fixture
 def adapter():
     """Create a SQLiteProfileAdapter instance."""
     return SQLiteProfileAdapter()
-
-
-@pytest.fixture
-def mock_db_connection():
-    """Fixture that provides a context manager for mocking database connections.
-
-    Usage:
-        with mock_db_connection() as (mock_get_conn, mock_conn, mock_cursor):
-            mock_cursor.fetchone.return_value = some_row
-            # test code here
-    """
-    return create_mock_db_connection(
-        "db.adapters.sqlite.profile_adapter.get_connection"
-    )
 
 
 class TestSQLiteProfileAdapterWriteProfile:

--- a/tests/db/adapters/sqlite/test_run_adapter.py
+++ b/tests/db/adapters/sqlite/test_run_adapter.py
@@ -9,7 +9,7 @@ import pytest
 from db.adapters.sqlite.run_adapter import SQLiteRunAdapter
 from simulation.core.models.actions import TurnAction
 from simulation.core.models.turns import TurnMetadata
-from tests.db.adapters.sqlite.conftest import create_mock_db_connection, create_mock_row
+from tests.db.adapters.sqlite.conftest import create_mock_row
 
 
 @pytest.fixture
@@ -22,18 +22,6 @@ def adapter():
 def default_test_data():
     """Common test data used across multiple tests."""
     return {"run_id": "run_123", "turn_number": 0}
-
-
-@pytest.fixture
-def mock_db_connection():
-    """Fixture that provides a context manager for mocking database connections.
-
-    Usage:
-        with mock_db_connection() as (mock_get_conn, mock_conn, mock_cursor):
-            mock_cursor.fetchone.return_value = some_row
-            # test code here
-    """
-    return create_mock_db_connection("db.adapters.sqlite.run_adapter.get_connection")
 
 
 class TestSQLiteRunAdapterReadTurnMetadata:

--- a/tests/db/repositories/test_feed_post_repository_integration.py
+++ b/tests/db/repositories/test_feed_post_repository_integration.py
@@ -3,40 +3,10 @@
 These tests use a real SQLite database to test end-to-end functionality.
 """
 
-import os
-import tempfile
-
 import pytest
 
-from db.adapters.sqlite.sqlite import DB_PATH, initialize_database
 from db.repositories.feed_post_repository import create_sqlite_feed_post_repository
 from simulation.core.models.posts import BlueskyFeedPost
-
-
-@pytest.fixture
-def temp_db():
-    """Create a temporary database for testing."""
-    # Save original DB path
-    original_path = DB_PATH
-
-    # Create temporary database
-    fd, temp_path = tempfile.mkstemp(suffix=".sqlite")
-    os.close(fd)
-
-    # Monkey-patch DB_PATH
-    import db.adapters.sqlite.sqlite as sqlite_module
-
-    sqlite_module.DB_PATH = temp_path
-
-    # Initialize the database
-    initialize_database()
-
-    yield temp_path
-
-    # Cleanup
-    sqlite_module.DB_PATH = original_path
-    if os.path.exists(temp_path):
-        os.unlink(temp_path)
 
 
 class TestSQLiteFeedPostRepositoryIntegration:

--- a/tests/db/repositories/test_generated_bio_repository_integration.py
+++ b/tests/db/repositories/test_generated_bio_repository_integration.py
@@ -3,43 +3,14 @@
 These tests use a real SQLite database to test end-to-end functionality.
 """
 
-import os
-import tempfile
-
 import pytest
 
-from db.adapters.sqlite.sqlite import DB_PATH, initialize_database
 from db.repositories.generated_bio_repository import (
     create_sqlite_generated_bio_repository,
 )
 from lib.timestamp_utils import get_current_timestamp
 from simulation.core.models.generated.base import GenerationMetadata
 from simulation.core.models.generated.bio import GeneratedBio
-
-
-@pytest.fixture
-def temp_db():
-    """Create a temporary database for testing."""
-    # Save original DB path
-    original_path = DB_PATH
-
-    # Create temporary database
-    fd, temp_path = tempfile.mkstemp(suffix=".sqlite")
-    os.close(fd)
-
-    import db.adapters.sqlite.sqlite as sqlite_module
-
-    sqlite_module.DB_PATH = temp_path
-
-    # Initialize the database
-    initialize_database()
-
-    yield temp_path
-
-    # Cleanup
-    sqlite_module.DB_PATH = original_path
-    if os.path.exists(temp_path):
-        os.unlink(temp_path)
 
 
 class TestSQLiteGeneratedBioRepositoryIntegration:

--- a/tests/db/repositories/test_generated_feed_repository_integration.py
+++ b/tests/db/repositories/test_generated_feed_repository_integration.py
@@ -3,43 +3,14 @@
 These tests use a real SQLite database to test end-to-end functionality.
 """
 
-import os
-import tempfile
-
 import pytest
 from pydantic import ValidationError
 
-from db.adapters.sqlite.sqlite import DB_PATH, get_connection, initialize_database
+from db.adapters.sqlite.sqlite import get_connection
 from db.repositories.generated_feed_repository import (
     create_sqlite_generated_feed_repository,
 )
 from simulation.core.models.feeds import GeneratedFeed
-
-
-@pytest.fixture
-def temp_db():
-    """Create a temporary database for testing."""
-    # Save original DB path
-    original_path = DB_PATH
-
-    # Create temporary database
-    fd, temp_path = tempfile.mkstemp(suffix=".sqlite")
-    os.close(fd)
-
-    # Monkey-patch DB_PATH
-    import db.adapters.sqlite.sqlite as sqlite_module
-
-    sqlite_module.DB_PATH = temp_path
-
-    # Initialize the database
-    initialize_database()
-
-    yield temp_path
-
-    # Cleanup
-    sqlite_module.DB_PATH = original_path
-    if os.path.exists(temp_path):
-        os.unlink(temp_path)
 
 
 def _ensure_run_exists(run_id: str) -> None:

--- a/tests/db/repositories/test_metrics_repository_integration.py
+++ b/tests/db/repositories/test_metrics_repository_integration.py
@@ -1,36 +1,10 @@
 """Integration tests for db.repositories.metrics_repository module."""
 
-import os
-import tempfile
-
-import pytest
-
-from db.adapters.sqlite.sqlite import DB_PATH, initialize_database
 from db.repositories.metrics_repository import create_sqlite_metrics_repository
 from db.repositories.run_repository import create_sqlite_repository
 from lib.timestamp_utils import get_current_timestamp
 from simulation.core.models.metrics import RunMetrics, TurnMetrics
 from simulation.core.models.runs import RunConfig
-
-
-@pytest.fixture
-def temp_db():
-    """Create a temporary database for integration tests."""
-    original_path = DB_PATH
-
-    fd, temp_path = tempfile.mkstemp(suffix=".sqlite")
-    os.close(fd)
-
-    import db.adapters.sqlite.sqlite as sqlite_module
-
-    sqlite_module.DB_PATH = temp_path
-    initialize_database()
-
-    yield temp_path
-
-    sqlite_module.DB_PATH = original_path
-    if os.path.exists(temp_path):
-        os.unlink(temp_path)
 
 
 class TestSQLiteMetricsRepositoryIntegration:

--- a/tests/db/repositories/test_profile_repository_integration.py
+++ b/tests/db/repositories/test_profile_repository_integration.py
@@ -3,41 +3,11 @@
 These tests use a real SQLite database to test end-to-end functionality.
 """
 
-import os
-import tempfile
-
 import pytest
 from pydantic import ValidationError
 
-from db.adapters.sqlite.sqlite import DB_PATH, initialize_database
 from db.repositories.profile_repository import create_sqlite_profile_repository
 from simulation.core.models.profiles import BlueskyProfile
-
-
-@pytest.fixture
-def temp_db():
-    """Create a temporary database for testing."""
-    # Save original DB path
-    original_path = DB_PATH
-
-    # Create temporary database
-    fd, temp_path = tempfile.mkstemp(suffix=".sqlite")
-    os.close(fd)
-
-    # Monkey-patch DB_PATH
-    import db.adapters.sqlite.sqlite as sqlite_module
-
-    sqlite_module.DB_PATH = temp_path
-
-    # Initialize the database
-    initialize_database()
-
-    yield temp_path
-
-    # Cleanup
-    sqlite_module.DB_PATH = original_path
-    if os.path.exists(temp_path):
-        os.unlink(temp_path)
 
 
 class TestSQLiteProfileRepositoryIntegration:

--- a/tests/db/repositories/test_run_repository_integration.py
+++ b/tests/db/repositories/test_run_repository_integration.py
@@ -3,13 +3,11 @@
 These tests use a real SQLite database to test end-to-end functionality.
 """
 
-import os
-import tempfile
 import time
 
 import pytest
 
-from db.adapters.sqlite.sqlite import DB_PATH, get_connection, initialize_database
+from db.adapters.sqlite.sqlite import get_connection
 from db.repositories.run_repository import create_sqlite_repository
 from simulation.core.exceptions import (
     DuplicateTurnMetadataError,
@@ -17,32 +15,6 @@ from simulation.core.exceptions import (
     RunNotFoundError,
 )
 from simulation.core.models.runs import Run, RunConfig, RunStatus
-
-
-@pytest.fixture
-def temp_db():
-    """Create a temporary database for testing."""
-    # Save original DB path
-    original_path = DB_PATH
-
-    # Create temporary database
-    fd, temp_path = tempfile.mkstemp(suffix=".sqlite")
-    os.close(fd)
-
-    # Monkey-patch DB_PATH
-    import db.adapters.sqlite.sqlite as sqlite_module
-
-    sqlite_module.DB_PATH = temp_path
-
-    # Initialize the database
-    initialize_database()
-
-    yield temp_path
-
-    # Cleanup
-    sqlite_module.DB_PATH = original_path
-    if os.path.exists(temp_path):
-        os.unlink(temp_path)
 
 
 class TestSQLiteRunRepositoryIntegration:

--- a/tests/simulation/core/conftest.py
+++ b/tests/simulation/core/conftest.py
@@ -1,0 +1,46 @@
+"""Shared pytest fixtures for simulation core tests."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from db.repositories.feed_post_repository import FeedPostRepository
+from db.repositories.generated_bio_repository import GeneratedBioRepository
+from db.repositories.generated_feed_repository import GeneratedFeedRepository
+from db.repositories.interfaces import MetricsRepository
+from db.repositories.profile_repository import ProfileRepository
+from db.repositories.run_repository import RunRepository
+from simulation.core.models.runs import Run, RunStatus
+
+
+@pytest.fixture
+def mock_repos():
+    return {
+        "run_repo": Mock(spec=RunRepository),
+        "metrics_repo": Mock(spec=MetricsRepository),
+        "profile_repo": Mock(spec=ProfileRepository),
+        "feed_post_repo": Mock(spec=FeedPostRepository),
+        "generated_bio_repo": Mock(spec=GeneratedBioRepository),
+        "generated_feed_repo": Mock(spec=GeneratedFeedRepository),
+    }
+
+
+@pytest.fixture
+def deps(mock_repos):
+    return mock_repos
+
+
+@pytest.fixture
+def sample_run(request):
+    overrides = getattr(request.module, "SAMPLE_RUN_OVERRIDES", {})
+    return Run(
+        run_id="run_123",
+        created_at="2024_01_01-12:00:00",
+        total_turns=overrides.get("total_turns", 2),
+        total_agents=overrides.get("total_agents", 2),
+        started_at="2024_01_01-12:00:00",
+        status=RunStatus.RUNNING,
+        completed_at=None,
+    )

--- a/tests/simulation/core/test_command_service.py
+++ b/tests/simulation/core/test_command_service.py
@@ -4,12 +4,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from db.repositories.feed_post_repository import FeedPostRepository
-from db.repositories.generated_bio_repository import GeneratedBioRepository
-from db.repositories.generated_feed_repository import GeneratedFeedRepository
-from db.repositories.interfaces import MetricsRepository
-from db.repositories.profile_repository import ProfileRepository
-from db.repositories.run_repository import RunRepository
 from db.services.simulation_persistence_service import SimulationPersistenceService
 from feeds.interfaces import FeedGenerator
 from simulation.core.action_history import InMemoryActionHistoryStore
@@ -29,20 +23,8 @@ from simulation.core.models.generated.comment import GeneratedComment
 from simulation.core.models.generated.follow import GeneratedFollow
 from simulation.core.models.generated.like import GeneratedLike
 from simulation.core.models.posts import BlueskyFeedPost
-from simulation.core.models.runs import Run, RunStatus
+from simulation.core.models.runs import RunStatus
 from simulation.core.models.turns import TurnResult
-
-
-@pytest.fixture
-def mock_repos():
-    return {
-        "run_repo": Mock(spec=RunRepository),
-        "metrics_repo": Mock(spec=MetricsRepository),
-        "profile_repo": Mock(spec=ProfileRepository),
-        "feed_post_repo": Mock(spec=FeedPostRepository),
-        "generated_bio_repo": Mock(spec=GeneratedBioRepository),
-        "generated_feed_repo": Mock(spec=GeneratedFeedRepository),
-    }
 
 
 @pytest.fixture
@@ -103,19 +85,6 @@ def command_service(mock_repos, mock_agent_factory, mock_feed_generator):
         agent_action_rules_validator=agent_action_rules_validator,
         agent_action_history_recorder=agent_action_history_recorder,
         agent_action_feed_filter=agent_action_feed_filter,
-    )
-
-
-@pytest.fixture
-def sample_run():
-    return Run(
-        run_id="run_123",
-        created_at="2024_01_01-12:00:00",
-        total_turns=2,
-        total_agents=2,
-        started_at="2024_01_01-12:00:00",
-        status=RunStatus.RUNNING,
-        completed_at=None,
     )
 
 

--- a/tests/simulation/core/test_engine.py
+++ b/tests/simulation/core/test_engine.py
@@ -4,29 +4,11 @@ from unittest.mock import ANY, Mock
 
 import pytest
 
-from db.repositories.feed_post_repository import FeedPostRepository
-from db.repositories.generated_bio_repository import GeneratedBioRepository
-from db.repositories.generated_feed_repository import GeneratedFeedRepository
-from db.repositories.interfaces import MetricsRepository
-from db.repositories.profile_repository import ProfileRepository
-from db.repositories.run_repository import RunRepository
 from simulation.core.command_service import SimulationCommandService
 from simulation.core.engine import SimulationEngine
 from simulation.core.models.agents import SocialMediaAgent
 from simulation.core.models.runs import Run, RunStatus
 from simulation.core.query_service import SimulationQueryService
-
-
-@pytest.fixture
-def deps():
-    return {
-        "run_repo": Mock(spec=RunRepository),
-        "metrics_repo": Mock(spec=MetricsRepository),
-        "profile_repo": Mock(spec=ProfileRepository),
-        "feed_post_repo": Mock(spec=FeedPostRepository),
-        "generated_bio_repo": Mock(spec=GeneratedBioRepository),
-        "generated_feed_repo": Mock(spec=GeneratedFeedRepository),
-    }
 
 
 @pytest.fixture

--- a/tests/simulation/core/test_query_service.py
+++ b/tests/simulation/core/test_query_service.py
@@ -1,29 +1,14 @@
 """Tests for simulation.core.query_service module."""
 
-from unittest.mock import Mock
-
 import pytest
 
-from db.repositories.feed_post_repository import FeedPostRepository
-from db.repositories.generated_feed_repository import GeneratedFeedRepository
-from db.repositories.interfaces import MetricsRepository
-from db.repositories.run_repository import RunRepository
 from simulation.core.exceptions import RunNotFoundError
 from simulation.core.models.feeds import GeneratedFeed
 from simulation.core.models.posts import BlueskyFeedPost
-from simulation.core.models.runs import Run, RunStatus
 from simulation.core.models.turns import TurnData, TurnMetadata
 from simulation.core.query_service import SimulationQueryService
 
-
-@pytest.fixture
-def mock_repos():
-    return {
-        "run_repo": Mock(spec=RunRepository),
-        "metrics_repo": Mock(spec=MetricsRepository),
-        "feed_post_repo": Mock(spec=FeedPostRepository),
-        "generated_feed_repo": Mock(spec=GeneratedFeedRepository),
-    }
+SAMPLE_RUN_OVERRIDES = {"total_turns": 10, "total_agents": 5}
 
 
 @pytest.fixture
@@ -33,19 +18,6 @@ def query_service(mock_repos):
         metrics_repo=mock_repos["metrics_repo"],
         feed_post_repo=mock_repos["feed_post_repo"],
         generated_feed_repo=mock_repos["generated_feed_repo"],
-    )
-
-
-@pytest.fixture
-def sample_run():
-    return Run(
-        run_id="run_123",
-        created_at="2024_01_01-12:00:00",
-        total_turns=10,
-        total_agents=5,
-        started_at="2024_01_01-12:00:00",
-        status=RunStatus.RUNNING,
-        completed_at=None,
     )
 
 


### PR DESCRIPTION
Consolidates duplicated pytest fixtures to reduce boilerplate and standardize test setup.

- Adds shared `temp_db` in `tests/conftest.py` (patches `DB_PATH` + `SIM_DB_PATH`, runs `initialize_database()`).
- Adds shared simulation-core fixtures in `tests/simulation/core/conftest.py` (`mock_repos`/`deps`/`sample_run` w/ module overrides).
- Adds shared sqlite adapter `mock_db_connection` in `tests/db/adapters/sqlite/conftest.py` (infers patch target from test filename).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test fixtures and database setup into centralized configuration modules.
  * Consolidated duplicate fixture definitions across adapter and repository test modules.
  * Improved test infrastructure organization for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->