### PR TITLE
Show post previews for comment actions in AgentDetail

### DIFF
--- a/ui/components/details/DetailsPanel.tsx
+++ b/ui/components/details/DetailsPanel.tsx
@@ -94,19 +94,16 @@ function getPostUrisFromTurn(turn: Turn): string[] {
       }
     }
   }
+  for (const actions of Object.values(turn.agentActions)) {
+    for (const action of actions) {
+      if (!action.postUri) continue;
+      if (!seen.has(action.postUri)) {
+        seen.add(action.postUri);
+        uris.push(action.postUri);
+      }
+    }
+  }
   return uris;
-}
-
-function getAllPostsForTurn(
-  turn: Turn,
-  postsByUri: Record<string, Post>,
-): Post[] {
-  return Object.values(turn.agentFeeds)
-    .flatMap((feed) =>
-      feed.postUris
-        .map((uri) => postsByUri[uri])
-        .filter((post): post is Post => post !== undefined),
-    );
 }
 
 interface TurnDetailContentProps {
@@ -187,7 +184,7 @@ function TurnDetailContent({
     );
   }
 
-  const allPosts: Post[] = getAllPostsForTurn(currentTurn, postsByUri);
+  const allPosts: Post[] = Object.values(postsByUri);
   const participatingAgents: Agent[] = getParticipatingAgents(
     currentTurn,
     runAgents,


### PR DESCRIPTION
### What
- In AgentDetail > Comments, render a PostCard preview for each comment action (fallback when missing).
- Fetch posts for the union of feed postUris + action postUri targets so previews work even when actions reference non-feed posts.

### Why
Comment actions previously only showed postUri; showing post content makes behavior easier to interpret.

### Testing
- Pre-commit hooks ran on commit (pyright, oxlint, react-doctor, etc.)
- UI build: `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced comments section with improved spacing and layout.
  * Added post preview display in comments with fallback messaging.

* **Bug Fixes**
  * Improved handling of missing or unknown post references with informative placeholders.

* **Refactor**
  * Optimized post lookup performance.
  * Expanded post data retrieval to include additional post information sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->