### PR TITLE
[2026-02-24] Codex repo automation - conventions

### DIFF
--- a/tests/api/test_feed_algorithms.py
+++ b/tests/api/test_feed_algorithms.py
@@ -20,14 +20,15 @@ def test_get_feed_algorithms_includes_chronological(simulation_client):
     assert response.status_code == 200
     data = response.json()
     chronological = next((a for a in data if a["id"] == "chronological"), None)
+    expected_display_name = "Chronological"
+    expected_description_snippet = "sorted by creation time"
+    expected_schema_type = "object"
+    expected_order_enum = ["newest_first", "oldest_first"]
     assert chronological is not None
-    assert chronological["display_name"] == "Chronological"
-    assert "sorted by creation time" in chronological["description"]
+    assert chronological["display_name"] == expected_display_name
+    assert expected_description_snippet in chronological["description"]
     assert isinstance(chronological.get("config_schema"), dict)
     config_schema = chronological["config_schema"]
-    assert config_schema["type"] == "object"
+    assert config_schema["type"] == expected_schema_type
     assert "order" in config_schema["properties"]
-    assert config_schema["properties"]["order"]["enum"] == [
-        "newest_first",
-        "oldest_first",
-    ]
+    assert config_schema["properties"]["order"]["enum"] == expected_order_enum

--- a/tests/api/test_metrics.py
+++ b/tests/api/test_metrics.py
@@ -36,10 +36,14 @@ def test_get_metrics_returns_list(simulation_client):
     client, _ = simulation_client
     response = client.get("/v1/simulations/metrics")
 
-    assert response.status_code == 200
+    expected_result = {
+        "status_code": 200,
+        "min_items": 4,
+    }
+    assert response.status_code == expected_result["status_code"]
     data = response.json()
     assert isinstance(data, list)
-    assert len(data) >= 4
+    assert len(data) >= expected_result["min_items"]
 
 
 def test_get_metrics_includes_builtins(simulation_client):
@@ -47,17 +51,18 @@ def test_get_metrics_includes_builtins(simulation_client):
     client, _ = simulation_client
     response = client.get("/v1/simulations/metrics")
 
-    assert response.status_code == 200
+    expected_result = {"status_code": 200}
+    assert response.status_code == expected_result["status_code"]
     data = response.json()
     by_key = {m["key"]: m for m in data}
 
     for key in BUILTIN_METRIC_KEYS:
         assert key in by_key, f"Missing metric: {key}"
         metric = by_key[key]
-        expected = EXPECTED_METRICS[key]
-        assert metric["description"] == expected["description"]
-        assert metric["scope"] == expected["scope"]
-        assert metric["author"] == expected["author"]
+        expected_result = EXPECTED_METRICS[key]
+        assert metric["description"] == expected_result["description"]
+        assert metric["scope"] == expected_result["scope"]
+        assert metric["author"] == expected_result["author"]
 
 
 def test_get_metrics_ordering_deterministic(simulation_client):
@@ -65,10 +70,12 @@ def test_get_metrics_ordering_deterministic(simulation_client):
     client, _ = simulation_client
     response = client.get("/v1/simulations/metrics")
 
-    assert response.status_code == 200
+    expected_result = {"status_code": 200}
+    assert response.status_code == expected_result["status_code"]
     data = response.json()
     keys = [m["key"] for m in data]
-    assert keys == sorted(keys)
+    expected_result = sorted(keys)
+    assert keys == expected_result
 
 
 def test_get_metrics_schema_shape(simulation_client):
@@ -76,17 +83,19 @@ def test_get_metrics_schema_shape(simulation_client):
     client, _ = simulation_client
     response = client.get("/v1/simulations/metrics")
 
-    assert response.status_code == 200
+    expected_result = {"status_code": 200}
+    assert response.status_code == expected_result["status_code"]
     data = response.json()
-    valid_scopes: set[str] = {"turn", "run"}
+    expected_result = {
+        "required_fields": {"key", "description", "scope", "author"},
+        "valid_scopes": {"turn", "run"},
+    }
 
     for item in data:
-        assert "key" in item
-        assert "description" in item
-        assert "scope" in item
-        assert "author" in item
+        for field in expected_result["required_fields"]:
+            assert field in item
         assert isinstance(item["key"], str)
         assert isinstance(item["description"], str)
         assert isinstance(item["scope"], str)
         assert isinstance(item["author"], str)
-        assert item["scope"] in valid_scopes
+        assert item["scope"] in expected_result["valid_scopes"]

--- a/tests/api/test_simulation_agents.py
+++ b/tests/api/test_simulation_agents.py
@@ -10,7 +10,8 @@ def test_get_simulations_agents_returns_list(simulation_client, temp_db):
     client, _ = simulation_client
     response = client.get("/v1/simulations/agents")
 
-    assert response.status_code == 200
+    expected_result = {"status_code": 200}
+    assert response.status_code == expected_result["status_code"]
     data = response.json()
     assert isinstance(data, list)
 
@@ -20,10 +21,12 @@ def test_get_simulations_agents_ordering_deterministic(simulation_client, temp_d
     client, _ = simulation_client
     response = client.get("/v1/simulations/agents")
 
-    assert response.status_code == 200
+    expected_result = {"status_code": 200}
+    assert response.status_code == expected_result["status_code"]
     data = response.json()
     handles = [a["handle"] for a in data]
-    assert handles == sorted(handles)
+    expected_result = sorted(handles)
+    assert handles == expected_result
 
 
 def test_get_simulations_agents_fields_present(simulation_client, temp_db):
@@ -31,9 +34,10 @@ def test_get_simulations_agents_fields_present(simulation_client, temp_db):
     client, _ = simulation_client
     response = client.get("/v1/simulations/agents")
 
-    assert response.status_code == 200
+    expected_result = {"status_code": 200}
+    assert response.status_code == expected_result["status_code"]
     data = response.json()
-    required_fields = {
+    expected_result = {
         "handle",
         "name",
         "bio",
@@ -43,7 +47,7 @@ def test_get_simulations_agents_fields_present(simulation_client, temp_db):
         "posts_count",
     }
     for agent in data:
-        for field in required_fields:
+        for field in expected_result:
             assert field in agent, f"Agent missing field {field}"
 
 
@@ -52,12 +56,14 @@ def test_get_simulations_agents_mock_returns_dummy(simulation_client):
     client, _ = simulation_client
     response = client.get("/v1/simulations/agents/mock")
 
-    assert response.status_code == 200
+    expected_result = {"status_code": 200, "count": len(DUMMY_AGENTS)}
+    assert response.status_code == expected_result["status_code"]
     data = response.json()
     assert isinstance(data, list)
-    assert len(data) == len(DUMMY_AGENTS)
+    assert len(data) == expected_result["count"]
     handles = [a["handle"] for a in data]
-    assert handles == sorted(handles)
+    expected_result = sorted(handles)
+    assert handles == expected_result
 
 
 def test_post_simulations_agents_success(simulation_client, temp_db):
@@ -72,16 +78,25 @@ def test_post_simulations_agents_success(simulation_client, temp_db):
 
     response = client.post("/v1/simulations/agents", json=body)
 
-    assert response.status_code == 201
+    expected_result = {
+        "status_code": 201,
+        "name": "Test Agent",
+        "bio": "A test bio",
+        "generated_bio": "",
+        "followers": 0,
+        "following": 0,
+        "posts_count": 0,
+    }
+    assert response.status_code == expected_result["status_code"]
     data = response.json()
-    expected_handle = f"@{handle.lstrip('@').lower()}"
-    assert data["handle"] == expected_handle
-    assert data["name"] == "Test Agent"
-    assert data["bio"] == "A test bio"
-    assert data["generated_bio"] == ""
-    assert data["followers"] == 0
-    assert data["following"] == 0
-    assert data["posts_count"] == 0
+    expected_result["handle"] = f"@{handle.lstrip('@').lower()}"
+    assert data["handle"] == expected_result["handle"]
+    assert data["name"] == expected_result["name"]
+    assert data["bio"] == expected_result["bio"]
+    assert data["generated_bio"] == expected_result["generated_bio"]
+    assert data["followers"] == expected_result["followers"]
+    assert data["following"] == expected_result["following"]
+    assert data["posts_count"] == expected_result["posts_count"]
 
 
 def test_post_simulations_agents_duplicate_handle_returns_409(
@@ -93,13 +108,15 @@ def test_post_simulations_agents_duplicate_handle_returns_409(
     body = {"handle": handle, "display_name": "First", "bio": ""}
 
     r1 = client.post("/v1/simulations/agents", json=body)
-    assert r1.status_code == 201
+    expected_result = {"status_code": 201}
+    assert r1.status_code == expected_result["status_code"]
 
     r2 = client.post("/v1/simulations/agents", json=body)
-    assert r2.status_code == 409
+    expected_result = {"status_code": 409, "error_code": "HANDLE_ALREADY_EXISTS"}
+    assert r2.status_code == expected_result["status_code"]
     err = r2.json()
     assert "error" in err
-    assert err["error"]["code"] == "HANDLE_ALREADY_EXISTS"
+    assert err["error"]["code"] == expected_result["error_code"]
 
 
 def test_post_simulations_agents_validation_empty_handle_returns_422(
@@ -111,7 +128,8 @@ def test_post_simulations_agents_validation_empty_handle_returns_422(
         "/v1/simulations/agents",
         json={"handle": "", "display_name": "Name", "bio": ""},
     )
-    assert response.status_code == 422
+    expected_result = {"status_code": 422}
+    assert response.status_code == expected_result["status_code"]
 
 
 def test_post_simulations_agents_validation_empty_display_name_returns_422(
@@ -123,7 +141,8 @@ def test_post_simulations_agents_validation_empty_display_name_returns_422(
         "/v1/simulations/agents",
         json={"handle": "user.bsky.social", "display_name": "", "bio": ""},
     )
-    assert response.status_code == 422
+    expected_result = {"status_code": 422}
+    assert response.status_code == expected_result["status_code"]
 
 
 def test_post_simulations_agents_then_get_includes_new_agent(
@@ -139,11 +158,14 @@ def test_post_simulations_agents_then_get_includes_new_agent(
     }
 
     post_resp = client.post("/v1/simulations/agents", json=body)
-    assert post_resp.status_code == 201
+    expected_result = {"status_code": 201}
+    assert post_resp.status_code == expected_result["status_code"]
     created = post_resp.json()
 
     get_resp = client.get("/v1/simulations/agents")
-    assert get_resp.status_code == 200
+    expected_result = {"status_code": 200}
+    assert get_resp.status_code == expected_result["status_code"]
     agents = get_resp.json()
     handles = [a["handle"] for a in agents]
-    assert created["handle"] in handles
+    expected_result = created["handle"]
+    assert expected_result in handles

--- a/tests/feeds/test_feed_generator.py
+++ b/tests/feeds/test_feed_generator.py
@@ -206,7 +206,8 @@ class TestGenerateFeed:
             )
 
         _, kwargs = mock_algorithm.generate.call_args
-        assert kwargs["config"] == feed_algorithm_config
+        expected_result = feed_algorithm_config
+        assert kwargs["config"] == expected_result
 
     def test_chronological_respects_oldest_first_config(
         self, sample_agent, sample_posts
@@ -219,12 +220,12 @@ class TestGenerateFeed:
             limit=20,
             config={"order": "oldest_first"},
         )
-        expected_order = [
+        expected_result = [
             "at://did:plc:test1/app.bsky.feed.post/post1",
             "at://did:plc:test2/app.bsky.feed.post/post2",
             "at://did:plc:test3/app.bsky.feed.post/post3",
         ]
-        assert result.post_uris == expected_order
+        assert result.post_uris == expected_result
 
 
 class TestGenerateFeeds:


### PR DESCRIPTION
This PR was created by a Codex automation run.

Improvements:
- Update new/modified tests to follow testing conventions (use an expected_result variable before assertions).
- Refactor assertions in API/feed tests for readability and consistency.

Validation:
- uv run --extra test pytest -q tests/api/test_feed_algorithms.py tests/api/test_metrics.py tests/api/test_simulation_agents.py tests/api/test_simulation_run.py tests/feeds/test_feed_generator.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test assertions across multiple test suites to use centralized expected result structures instead of hard-coded literals.
  * Parameterized dynamic field expectations for clearer, more maintainable test validation.
  * Test coverage and functional behavior remain unchanged; improvements are internal to test implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->