### PR TITLE
Add FastAPI API gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=5 \
   CMD ["sh", "-c", "python -c \"import urllib.request, os; u = urllib.request.urlopen('http://127.0.0.1:' + os.environ.get('PORT', '8000') + '/health', timeout=5); exit(0 if u.getcode() == 200 else 1)\" || exit 1"]
 
-CMD ["sh", "-c", "uv run uvicorn simulation.api.main:app --host 0.0.0.0 --port ${PORT:-8000} --forwarded-allow-ips \"${FORWARDED_ALLOW_IPS:-*}\""]
+CMD ["sh", "-c", "uv run uvicorn \"${APP_MODULE:-simulation.api.main:app}\" --host 0.0.0.0 --port ${PORT:-8000} --forwarded-allow-ips \"${FORWARDED_ALLOW_IPS:-*}\""]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  api:
+    build: .
+    environment:
+      APP_MODULE: simulation.api.main:app
+      FORWARDED_ALLOW_IPS: "*"
+      LOCAL: "1"
+      PORT: "8000"
+    ports:
+      - "8000:8000"
+
+  gateway:
+    build: .
+    environment:
+      APP_MODULE: gateway.api.main:app
+      FORWARDED_ALLOW_IPS: "*"
+      GATEWAY_UPSTREAM_BASE_URL: http://api:8000
+      PORT: "8000"
+      ALLOWED_ORIGINS: http://localhost:3000,http://127.0.0.1:3000
+    ports:
+      - "8001:8000"
+    depends_on:
+      - api
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Quick lookup table of contents for project documentation.
 | [runbooks/UPDATE_SCHEMAS.md](runbooks/UPDATE_SCHEMAS.md) | Regenerate OpenAPI + UI types after contract changes |
 | [runbooks/PRODUCTION_DEPLOYMENT.md](runbooks/PRODUCTION_DEPLOYMENT.md) | General production and deployment guidance |
 | [runbooks/RAILWAY_DEPLOYMENT.md](runbooks/RAILWAY_DEPLOYMENT.md) | Deploy backend to Railway with Docker |
+| [runbooks/API_GATEWAY_FASTAPI.md](runbooks/API_GATEWAY_FASTAPI.md) | Run and deploy the FastAPI API gateway |
 | [runbooks/UI_DEPLOYMENT.md](runbooks/UI_DEPLOYMENT.md) | Deploy Next.js UI to Vercel |
 | [runbooks/SMOKE_TEST.md](runbooks/SMOKE_TEST.md) | Run smoke tests against a live API |
 | [runbooks/LOAD_TESTING.md](runbooks/LOAD_TESTING.md) | Run load tests with scripts |

--- a/docs/plans/2026-02-26_fastapi_api_gateway_482931/plan.md
+++ b/docs/plans/2026-02-26_fastapi_api_gateway_482931/plan.md
@@ -1,0 +1,36 @@
+## Overview
+
+Add a bare-bones FastAPI API gateway that proxies `/v1/*` requests to the existing FastAPI backend, and wire it for local development (Docker Compose) and Railway deployment (two services using the same Dockerfile selected by `APP_MODULE`).
+
+## Happy Flow
+
+1. **UI request via env** – `ui/lib/api/simulation.ts` points to `NEXT_PUBLIC_SIMULATION_API_URL` so the browser hits `https://<gateway-domain>/v1/...`.
+2. **Gateway entry** – `gateway/api/main.py` adds `X-Request-ID`, logs start, and routes through `gateway/api/proxy.py`.
+3. **Proxy forward** – `gateway/api/proxy.py` builds `${GATEWAY_UPSTREAM_BASE_URL}/v1/...`, filters hop-by-hop headers, and uses `httpx.AsyncClient`.
+4. **Backend handling** – `simulation/api/main.py` processes the request and returns the response.
+5. **Gateway response** – The proxy filters hop-by-hop headers, returns the payload, and `GatewayRequestLoggingMiddleware` logs completion + latency/status.
+6. **Structured logs** – Logs include `event`, `request_id`, `route`, `method`, `latency_ms`, `status` for future observability.
+7. **UI receives same payload** – Browser gets the proxied response with the `X-Request-ID`.
+
+## Data Flow
+
+- Browser request → `gateway/api/main.py` → `gateway/api/proxy.py` (formed URL using `GATEWAY_UPSTREAM_BASE_URL` + `/v1/{full_path}`).
+- Proxy → upstream backend (`simulation/api/main.py`) and receives response.
+- Gateway middleware filters headers, logs completion, and returns response → computer/UI.
+
+## Key changes
+
+- New gateway service code in `gateway/` (FastAPI app + httpx proxy).
+- Root `Dockerfile` supports `APP_MODULE` to select which ASGI app to run.
+- `docker-compose.yml` runs `api` + `gateway` locally.
+- Tests validate proxying behavior using `httpx.MockTransport`.
+- New runbook: `docs/runbooks/API_GATEWAY_FASTAPI.md`.
+
+## Manual verification
+
+- `uv sync --extra test`
+- Backend: `PYTHONPATH=. uv run uvicorn simulation.api.main:app --reload --port 8000`
+- Gateway: `PYTHONPATH=. GATEWAY_UPSTREAM_BASE_URL=http://127.0.0.1:8000 uv run uvicorn gateway.api.main:app --reload --port 8001`
+- `curl -sS http://127.0.0.1:8001/health`
+- `curl -sS http://127.0.0.1:8001/v1/simulations/metrics`
+- Tests: `uv run --extra test pytest`

--- a/docs/runbooks/API_GATEWAY_FASTAPI.md
+++ b/docs/runbooks/API_GATEWAY_FASTAPI.md
@@ -1,0 +1,116 @@
+---
+description: Add and operate the FastAPI API Gateway (proxy) locally and on Railway.
+tags: [gateway, fastapi, proxy, railway, docker]
+---
+
+# FastAPI API Gateway (Proxy)
+
+This runbook describes how to run and deploy the FastAPI-based API gateway service that proxies `/v1/*` requests to the existing backend API.
+
+## What it does (MVP)
+
+- Exposes `GET /health`.
+- Proxies `/{...}` under `/v1/{full_path:path}` to a single upstream `GATEWAY_UPSTREAM_BASE_URL`.
+- Adds/propagates `X-Request-ID` and emits structured JSON logs (request start + completion).
+
+## Local development (no Docker)
+
+### 1) Install deps
+
+From repo root:
+
+```bash
+uv sync --extra test
+```
+
+### 2) Start the backend API (upstream)
+
+```bash
+PYTHONPATH=. uv run uvicorn simulation.api.main:app --reload --port 8000
+```
+
+Expected: backend serves `http://127.0.0.1:8000/health`.
+
+### 3) Start the gateway
+
+```bash
+PYTHONPATH=. \
+GATEWAY_UPSTREAM_BASE_URL=http://127.0.0.1:8000 \
+uv run uvicorn gateway.api.main:app --reload --port 8001
+```
+
+Expected: gateway serves `http://127.0.0.1:8001/health`.
+
+### 4) Verify proxying
+
+```bash
+curl -sS http://127.0.0.1:8001/health
+curl -sS http://127.0.0.1:8001/v1/simulations/metrics
+```
+
+Expected:
+
+- Health returns `{"status":"ok"}`.
+- The `/v1/...` call returns the same payload as the backend upstream.
+
+## Local development (Docker Compose)
+
+From repo root:
+
+```bash
+docker compose up --build
+```
+
+Verify:
+
+```bash
+curl -sS http://127.0.0.1:8001/health
+curl -sS http://127.0.0.1:8001/v1/simulations/metrics
+```
+
+## Railway deployment (two services, one repo, one Dockerfile)
+
+This repo uses a single root `Dockerfile` and selects which FastAPI app to run via `APP_MODULE`.
+
+### Service 1: `api` (existing backend)
+
+Variables:
+
+- `APP_MODULE=simulation.api.main:app`
+- `FORWARDED_ALLOW_IPS=*`
+- If using persistent SQLite: `SIM_DB_PATH=/data/db.sqlite` (and mount a volume at `/data`)
+
+Networking:
+
+- Recommended after gateway is live: remove the public domain for `api` so it is only reachable on the private network.
+
+### Service 2: `gateway` (public entrypoint)
+
+Variables:
+
+- `APP_MODULE=gateway.api.main:app`
+- `FORWARDED_ALLOW_IPS=*`
+- `ALLOWED_ORIGINS=<comma-separated UI origin(s)>`
+- `GATEWAY_UPSTREAM_BASE_URL=http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}`
+- `GATEWAY_TIMEOUT_SECONDS=60`
+
+### UI (Vercel) configuration
+
+Set Vercel env var:
+
+- `NEXT_PUBLIC_SIMULATION_API_URL=https://<gateway-public-domain>/v1`
+
+Redeploy the UI.
+
+### Verify
+
+```bash
+curl -sS https://<gateway-public-domain>/health
+curl -sS https://<gateway-public-domain>/v1/simulations/metrics
+```
+
+Optional smoke test:
+
+```bash
+SIMULATION_API_URL=https://<gateway-public-domain> uv run pytest -m smoke tests/api/test_simulation_smoke.py
+```

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -1,0 +1,1 @@
+"""API gateway package (FastAPI proxy service)."""

--- a/gateway/api/__init__.py
+++ b/gateway/api/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI gateway application package."""

--- a/gateway/api/main.py
+++ b/gateway/api/main.py
@@ -1,0 +1,139 @@
+"""FastAPI gateway entrypoint.
+
+Run locally (example):
+  PYTHONPATH=. GATEWAY_UPSTREAM_BASE_URL=http://127.0.0.1:8000 \\
+    uv run uvicorn gateway.api.main:app --reload --port 8001
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+import uuid
+from contextlib import asynccontextmanager
+
+import httpx
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from gateway.api.proxy import proxy_v1_request
+from gateway.api.settings import GatewaySettings
+from lib.request_logging import log_request_start, log_route_completion
+from lib.security_headers import SecurityHeadersMiddleware
+
+logger = logging.getLogger(__name__)
+
+
+class GatewayRequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Assigns request_id and emits request start/completion logs."""
+
+    async def dispatch(self, request: Request, call_next):
+        request_id = request.headers.get("X-Request-ID") or uuid.uuid4().hex
+        request.state.request_id = request_id
+
+        route = f"{request.method} {request.url.path}"
+        log_request_start(
+            request_id=request_id,
+            method=request.method,
+            path=request.url.path,
+            route=route,
+        )
+
+        start = time.perf_counter()
+        response = await call_next(request)
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        log_route_completion(
+            request_id=request_id,
+            route=route,
+            latency_ms=latency_ms,
+            status=str(getattr(response, "status_code", "")),
+        )
+        response.headers.setdefault("X-Request-ID", request_id)
+        return response
+
+
+def _allowed_origins_from_env() -> list[str]:
+    # Note: parse ALLOWED_ORIGINS without requiring GATEWAY_UPSTREAM_BASE_URL at import time.
+    raw = os.environ.get(
+        "ALLOWED_ORIGINS", "http://localhost:3000,http://127.0.0.1:3000"
+    )
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+
+def create_app(*, settings: GatewaySettings | None = None) -> FastAPI:
+    """Create a gateway app (exported for tests).
+
+    If settings are not provided, they are loaded during startup. This keeps
+    module import safe for tests while still failing fast on misconfiguration.
+    """
+    allowed_origins = (
+        settings.allowed_origins if settings else _allowed_origins_from_env()
+    )
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        # Allow injection of a transport for tests by setting app.state.http_transport.
+        transport = getattr(app.state, "http_transport", None)
+        app.state.http_client = httpx.AsyncClient(transport=transport)
+        app.state.settings = settings or GatewaySettings.from_env()
+        try:
+            yield
+        finally:
+            await app.state.http_client.aclose()
+
+    app = FastAPI(title="Agent Simulation Platform Gateway", lifespan=lifespan)
+    if settings is not None:
+        # Avoid surprises in tests/tools that call the app without lifespan startup.
+        app.state.settings = settings
+
+    app.add_middleware(SecurityHeadersMiddleware)
+    app.add_middleware(GatewayRequestLoggingMiddleware)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allowed_origins,
+        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+        allow_headers=["*"],
+    )
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    @app.api_route(
+        "/v1/{full_path:path}",
+        methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    )
+    async def proxy_v1(request: Request, full_path: str):  # noqa: ARG001
+        # CORSMiddleware handles preflight before reaching here.
+        settings_obj: GatewaySettings = app.state.settings
+        client: httpx.AsyncClient = app.state.http_client
+        return await proxy_v1_request(
+            request=request,
+            upstream_base_url=settings_obj.upstream_base_url,
+            timeout_seconds=settings_obj.timeout_seconds,
+            client=client,
+        )
+
+    @app.exception_handler(RuntimeError)
+    async def runtime_error_handler(
+        request: Request, exc: RuntimeError
+    ) -> JSONResponse:  # noqa: ARG001
+        # Useful for missing env vars during dev.
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": {
+                    "code": "GATEWAY_MISCONFIGURED",
+                    "message": str(exc),
+                    "detail": None,
+                }
+            },
+        )
+
+    return app
+
+
+app = create_app()

--- a/gateway/api/proxy.py
+++ b/gateway/api/proxy.py
@@ -1,0 +1,109 @@
+"""HTTP proxy utilities for the FastAPI gateway."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+import httpx
+from fastapi import Request
+from fastapi.responses import JSONResponse, Response
+
+logger = logging.getLogger(__name__)
+
+_HOP_BY_HOP_HEADERS: frozenset[str] = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "host",
+        "content-length",
+    }
+)
+
+
+def _filter_headers(headers: Iterable[tuple[str, str]]) -> dict[str, str]:
+    filtered: dict[str, str] = {}
+    for k, v in headers:
+        if k.lower() in _HOP_BY_HOP_HEADERS:
+            continue
+        filtered[k] = v
+    return filtered
+
+
+def _build_upstream_url(*, upstream_base_url: str, path: str, query: str) -> str:
+    base = upstream_base_url.rstrip("/")
+    url = f"{base}{path}"
+    if query:
+        url = f"{url}?{query}"
+    return url
+
+
+async def proxy_v1_request(
+    *,
+    request: Request,
+    upstream_base_url: str,
+    timeout_seconds: float,
+    client: httpx.AsyncClient,
+) -> Response:
+    """Proxy a request to the configured upstream.
+
+    MVP behavior:
+    - Buffers request and response bodies in memory.
+    - Forces identity encoding to avoid content-decoding mismatches.
+    """
+    upstream_url = _build_upstream_url(
+        upstream_base_url=upstream_base_url,
+        path=request.url.path,
+        query=request.url.query,
+    )
+
+    upstream_headers = _filter_headers(request.headers.items())
+    # Avoid automatic content decoding issues; we can remove this once we stream raw bytes.
+    upstream_headers["accept-encoding"] = "identity"
+
+    body = await request.body()
+
+    try:
+        upstream_response = await client.request(
+            request.method,
+            upstream_url,
+            content=body,
+            headers=upstream_headers,
+            timeout=httpx.Timeout(timeout_seconds),
+        )
+    except httpx.TimeoutException:
+        return JSONResponse(
+            status_code=504,
+            content={
+                "error": {
+                    "code": "UPSTREAM_TIMEOUT",
+                    "message": "Upstream request timed out",
+                    "detail": None,
+                }
+            },
+        )
+    except httpx.RequestError as exc:
+        logger.warning("Upstream request failed: %s", exc)
+        return JSONResponse(
+            status_code=502,
+            content={
+                "error": {
+                    "code": "UPSTREAM_UNAVAILABLE",
+                    "message": "Upstream request failed",
+                    "detail": None,
+                }
+            },
+        )
+
+    response_headers = _filter_headers(upstream_response.headers.items())
+    return Response(
+        content=upstream_response.content,
+        status_code=upstream_response.status_code,
+        headers=response_headers,
+    )

--- a/gateway/api/settings.py
+++ b/gateway/api/settings.py
@@ -1,0 +1,44 @@
+"""Gateway settings loaded from environment variables."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GatewaySettings:
+    upstream_base_url: str
+    timeout_seconds: float
+    allowed_origins_raw: str
+
+    @classmethod
+    def from_env(cls) -> "GatewaySettings":
+        upstream = os.environ.get("GATEWAY_UPSTREAM_BASE_URL", "").strip().rstrip("/")
+        if not upstream:
+            raise RuntimeError("GATEWAY_UPSTREAM_BASE_URL must be set")
+
+        timeout_raw = os.environ.get("GATEWAY_TIMEOUT_SECONDS", "60").strip()
+        try:
+            timeout = float(timeout_raw)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"GATEWAY_TIMEOUT_SECONDS must be a number, got: {timeout_raw!r}"
+            ) from exc
+
+        allowed_origins_raw = os.environ.get(
+            "ALLOWED_ORIGINS", "http://localhost:3000,http://127.0.0.1:3000"
+        )
+        return cls(
+            upstream_base_url=upstream,
+            timeout_seconds=timeout,
+            allowed_origins_raw=allowed_origins_raw,
+        )
+
+    @property
+    def allowed_origins(self) -> list[str]:
+        return [
+            origin.strip()
+            for origin in self.allowed_origins_raw.split(",")
+            if origin.strip()
+        ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "alembic>=1.17.2",
     "fastapi>=0.115.0",
+    "httpx>=0.27.0",
     "uvicorn>=0.32.0",
     "pyyaml>=6.0",
     "litellm>=1.59.10",
@@ -96,7 +97,7 @@ quote-style = "double"
 indent-style = "space"
 
 [tool.ruff.lint.isort]
-known-first-party = ["simulation", "db", "ai", "lib", "feeds", "jobs", "ml_tooling"]
+known-first-party = ["simulation", "db", "ai", "lib", "feeds", "jobs", "ml_tooling", "gateway"]
 
 [tool.pyright]
 include = ["."]
@@ -110,7 +111,7 @@ typeCheckingMode = "basic"
 reportMissingTypeStubs = false
 
 [tool.importlinter]
-root_packages = ["simulation", "db", "lib", "feeds", "ai", "jobs", "ml_tooling"]
+root_packages = ["simulation", "db", "lib", "feeds", "ai", "jobs", "ml_tooling", "gateway"]
 include_external_packages = false
 exclude_type_checking_imports = true
 

--- a/tests/gateway/test_proxy.py
+++ b/tests/gateway/test_proxy.py
@@ -1,0 +1,77 @@
+import json
+
+import httpx
+from fastapi.testclient import TestClient
+
+from gateway.api.main import create_app
+from gateway.api.settings import GatewaySettings
+
+
+def test_proxy_forwards_path_query_method_and_body_and_filters_hop_by_hop_headers():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/v1/simulations/run"
+        assert request.url.query == b"foo=bar"
+        assert request.headers.get("host") is not None  # httpx sets host internally
+        assert request.headers.get("content-length") is not None  # computed by httpx
+        # Our proxy removes hop-by-hop headers from inbound request; ensure caller-provided ones are gone.
+        assert request.headers.get("upgrade") is None
+        assert request.headers.get("proxy-authorization") is None
+        assert request.headers.get("accept-encoding") == "identity"
+        assert json.loads(request.content.decode()) == {"x": 1}
+        return httpx.Response(
+            status_code=201,
+            headers={
+                "Content-Type": "application/json",
+                "Connection": "close",
+                "X-Upstream": "1",
+            },
+            json={"ok": True},
+        )
+
+    transport = httpx.MockTransport(handler)
+    settings = GatewaySettings(
+        upstream_base_url="http://upstream",
+        timeout_seconds=1.0,
+        allowed_origins_raw="http://localhost:3000",
+    )
+    app = create_app(settings=settings)
+    app.state.http_transport = transport
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/simulations/run?foo=bar",
+            headers={
+                "Connection": "keep-alive",
+                "Upgrade": "websocket",
+                "Proxy-Authorization": "secret",
+                "X-Request-ID": "abc123",
+            },
+            json={"x": 1},
+        )
+
+    assert resp.status_code == 201
+    assert resp.json() == {"ok": True}
+    assert resp.headers.get("x-upstream") == "1"
+    assert resp.headers.get("connection") is None
+    assert resp.headers.get("x-request-id") == "abc123"
+
+
+def test_proxy_timeout_maps_to_504():
+    def handler(request: httpx.Request) -> httpx.Response:  # noqa: ARG001
+        raise httpx.ReadTimeout("boom")
+
+    transport = httpx.MockTransport(handler)
+    settings = GatewaySettings(
+        upstream_base_url="http://upstream",
+        timeout_seconds=0.01,
+        allowed_origins_raw="http://localhost:3000",
+    )
+    app = create_app(settings=settings)
+    app.state.http_transport = transport
+
+    with TestClient(app) as client:
+        resp = client.get("/v1/simulations/metrics")
+
+    assert resp.status_code == 504
+    assert resp.json()["error"]["code"] == "UPSTREAM_TIMEOUT"


### PR DESCRIPTION
Overview
Add a bare-bones FastAPI API gateway that proxies `/v1/*` requests to the existing FastAPI backend, and wire it for local development (Docker Compose) and Railway deployment (two services using the same Dockerfile selected by `APP_MODULE`).

Problem / motivation
The frontend and backend currently share a single public backend, so we still expose the API directly. A lightweight gateway gives us a real routing layer, keeps the backend private on Railway, and lets us learn request-shaping/middleware patterns before adding rate limiting or auth enforcement in a follow-up.

Solution
Introduce a dedicated `gateway` FastAPI app that proxies `/v1/*` through `GATEWAY_UPSTREAM_BASE_URL`, exposes `/health`, filters hop-by-hop headers, logs structured `X-Request-ID` traffic, and shares the existing Dockerfile via an `APP_MODULE` env switch. Local Docker Compose wiring and docs describe how to run the pair, and tests cover the proxy behavior.

Happy Flow
1. **UI request via env** – `ui/lib/api/simulation.ts` points to `NEXT_PUBLIC_SIMULATION_API_URL`, so the browser hits `https://<gateway-domain>/v1/...`.
2. **Gateway entry** – `gateway/api/main.py` adds `X-Request-ID`, logs start, and routes through `gateway/api/proxy.py`.
3. **Proxy forward** – `gateway/api/proxy.py` builds `${GATEWAY_UPSTREAM_BASE_URL}/v1/...`, filters hop-by-hop headers, and uses `httpx.AsyncClient`.
4. **Backend handling** – `simulation/api/main.py` processes the request and returns the response.
5. **Gateway response** – The proxy filters hop-by-hop headers, returns the payload, and `GatewayRequestLoggingMiddleware` logs completion + latency/status.
6. **Structured logs** – Logs include `event`, `request_id`, `route`, `method`, `latency_ms`, `status` for future observability.
7. **UI receives same payload** – Browser gets the proxied response with the `X-Request-ID`.

Data Flow
- Browser request → `gateway/api/main.py` → `gateway/api/proxy.py` (formed URL using `GATEWAY_UPSTREAM_BASE_URL` + `/v1/{full_path}`).
- Proxy → upstream backend (`simulation/api/main.py`) and receives response.
- Gateway middleware filters headers, logs completion, and returns response → browser/UI.

Changes
- `gateway/`: new FastAPI gateway package, settings, proxy helper, and entrypoint middleware.
- `pyproject.toml`: add `httpx` and treat `gateway` as a first-party package for import linter/ruff.
- `Dockerfile` and `docker-compose.yml`: support selecting `APP_MODULE` and running `api`+`gateway` locally.
- `tests/gateway/test_proxy.py`: verify request forwarding, header filtering, and timeout handling.
- Docs: add `docs/runbooks/API_GATEWAY_FASTAPI.md`, link it from `docs/README.md`, and record the plan in `docs/plans/2026-02-26_fastapi_api_gateway_482931/plan.md`.

Manual Verification
- `uv sync --extra test`
- Backend: `PYTHONPATH=. uv run uvicorn simulation.api.main:app --reload --port 8000`
- Gateway: `PYTHONPATH=. GATEWAY_UPSTREAM_BASE_URL=http://127.0.0.1:8000 uv run uvicorn gateway.api.main:app --reload --port 8001`
- `curl -sS http://127.0.0.1:8001/health`
- `curl -sS http://127.0.0.1:8001/v1/simulations/metrics`
- `uv run --extra test pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run --extra test pyright .`
- `uv run --extra test lint-imports --config pyproject.toml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced API gateway service with request tracing, unique request IDs, and security headers.
  * Added health check endpoint for gateway availability.
  * Implemented HTTP proxy routing with timeout and error handling.

* **Chores**
  * Added Docker Compose configuration for easy multi-service deployment.
  * Added httpx dependency for HTTP client functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->