### PR TITLE
add copying button for runId

### DIFF
--- a/ui/components/details/RunSummary.tsx
+++ b/ui/components/details/RunSummary.tsx
@@ -23,7 +23,6 @@ export default function RunSummary({ run, agents, completedTurns }: RunSummaryPr
 
   const handleCopyRunId = async (): Promise<void> => {
       try {
-   //     throw new Error('copy error');
         await navigator.clipboard.writeText(run.runId)
         setCopied(true)
         if (copyResetTimerRef.current) clearTimeout(copyResetTimerRef.current);


### PR DESCRIPTION
**Overview**
Adds a copy button to copy runId to clipboard. Fixes https://github.com/METResearchGroup/social_agent_simulation_platform/issues/180

**Problem**
- In the run details view, users often need the runId for debugging, sharing, or referencing logs.
- Today RunSummary displays the runId as plain text only, so copying requires manual text selection (error-prone and annoying).
- We want a small CTA that copies the run ID to the clipboard and gives immediate UI feedback (“Copied!”) without adding any new data fetching.

**Solution**
Add a copy button

**Happy Flow**
1. User hovers over copy button. 
2. Copy button turns darker, into hover state
3. User presses on copy button.
4. UserId is copied to user's clipboard.
5. Copy text changes from "Copy" to "Copied!" for 1000 milliseconds.
6. Copy text changes back to "Copy"

**Changes**
Added a button in the table.
Used useState to track if button was clicked or not
Used setTimeout to setClicked back to false after 1000 milliseconds.

**Manual Verification**
FOR LOCAL DEVELOPMENT: 
cd ui
LOCAL=true npm run dev

**State (before)**
<img width="3446" height="1918" alt="image" src="https://github.com/user-attachments/assets/389eba6c-fdd5-4eab-a878-3d8535855f54" />


**State (after)**


<img width="1176" height="807" alt="image" src="https://github.com/user-attachments/assets/5ecfd411-d26b-49e2-8a7f-a0657e50c3db" />


<img width="1199" height="816" alt="image" src="https://github.com/user-attachments/assets/8024cdf3-d5f4-4373-87f8-0c6592817ec9" />


**Testing of Error**

Add line to throw error in the "try" block and check console. 

<img width="1512" height="484" alt="image" src="https://github.com/user-attachments/assets/45b6a045-f983-4950-90b4-01c33a20b7ed" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run ID can be copied to the clipboard via a dedicated button; the label changes to "Copied!" briefly after success.
  * The copy feedback automatically resets after a short interval and is cleared if the copy fails, ensuring consistent UI state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->