### PR TITLE
Update validate_non_empty_string usage

### DIFF
--- a/db/adapters/sqlite/agent_adapter.py
+++ b/db/adapters/sqlite/agent_adapter.py
@@ -59,7 +59,7 @@ class SQLiteAgentAdapter(AgentDatabaseAdapter):
 
     def read_agent(self, agent_id: str, *, conn: sqlite3.Connection) -> Agent | None:
         """Read an agent by ID."""
-        validate_non_empty_string(agent_id, "agent_id")
+        validate_non_empty_string(agent_id)
         row = conn.execute(
             "SELECT * FROM agent WHERE agent_id = ?", (agent_id,)
         ).fetchone()
@@ -72,7 +72,7 @@ class SQLiteAgentAdapter(AgentDatabaseAdapter):
         self, handle: str, *, conn: sqlite3.Connection
     ) -> Agent | None:
         """Read an agent by handle."""
-        validate_non_empty_string(handle, "handle")
+        validate_non_empty_string(handle)
         row = conn.execute("SELECT * FROM agent WHERE handle = ?", (handle,)).fetchone()
         if row is None:
             return None

--- a/db/adapters/sqlite/agent_bio_adapter.py
+++ b/db/adapters/sqlite/agent_bio_adapter.py
@@ -59,7 +59,7 @@ class SQLiteAgentBioAdapter(AgentBioDatabaseAdapter):
         self, agent_id: str, *, conn: sqlite3.Connection
     ) -> AgentBio | None:
         """Read the latest bio for an agent by created_at DESC."""
-        validate_non_empty_string(agent_id, "agent_id")
+        validate_non_empty_string(agent_id)
         row = conn.execute(
             "SELECT * FROM agent_persona_bios WHERE agent_id = ? "
             "ORDER BY created_at DESC LIMIT 1",
@@ -74,7 +74,7 @@ class SQLiteAgentBioAdapter(AgentBioDatabaseAdapter):
         self, agent_id: str, *, conn: sqlite3.Connection
     ) -> list[AgentBio]:
         """Read all bios for an agent, ordered by created_at DESC."""
-        validate_non_empty_string(agent_id, "agent_id")
+        validate_non_empty_string(agent_id)
         rows = conn.execute(
             "SELECT * FROM agent_persona_bios WHERE agent_id = ? "
             "ORDER BY created_at DESC",

--- a/db/adapters/sqlite/user_agent_profile_metadata_adapter.py
+++ b/db/adapters/sqlite/user_agent_profile_metadata_adapter.py
@@ -57,7 +57,7 @@ class SQLiteUserAgentProfileMetadataAdapter(UserAgentProfileMetadataDatabaseAdap
         self, agent_id: str, *, conn: sqlite3.Connection
     ) -> UserAgentProfileMetadata | None:
         """Read metadata by agent_id."""
-        validate_non_empty_string(agent_id, "agent_id")
+        validate_non_empty_string(agent_id)
         row = conn.execute(
             "SELECT * FROM user_agent_profile_metadata WHERE agent_id = ?",
             (agent_id,),

--- a/docs/plans/2026-03-08_validate_non_empty_string_single_arg_482193/plan.md
+++ b/docs/plans/2026-03-08_validate_non_empty_string_single_arg_482193/plan.md
@@ -1,0 +1,47 @@
+---
+description: >-
+  Update the shared string validation helper so callers only pass the value and
+  keep existing contextual errors via wrapper utilities.
+tags:
+  - planning
+  - validation
+---
+
+## Remember
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+
+## Title
+Remove `field_name` from `validate_non_empty_string` and update all callers/tests
+
+## Overview
+Streamline `validate_non_empty_string` in `lib/validation_utils.py` so it only needs the value and delivers consistent `"value ..."` errors; ripple that change through every domain model, generated model, SQLite adapter, API schema, and validator wrapper while keeping regression coverage intact and preserving the contextual labeled messages where external code depends on them.
+
+## Happy Flow
+1. **Helper contract** – `lib/validation_utils.py:146` accepts a single `value`, validates `None`, non-`str`, and emptiness, and returns the trimmed string with `"value ..."` errors.
+2. **Domain/generator consumers** – Pydantic validators across `simulation/core/models/*.py` and `simulation/core/models/generated/*.py` call the helper with only the incoming field to keep type coercion consistent.
+3. **API/schema guards** – `simulation/api/schemas/simulation.py` strips request values and hands them to the helper without redundant field labels.
+4. **Adapters** – SQLite builders (`db/adapters/sqlite/*.py`) call the helper directly before running SQL, ensuring their inputs are trimmed.
+5. **Wrapper translation** – `simulation/core/utils/validators.py` keeps the existing labeled errors for consumers like repositories by catching `ValueError`s, rephrasing them, and re-raising so external assertions still see `run_id cannot be empty`.
+
+## Data Flow
+1. **Input normalization** – API validators and domain models trim inputs (e.g., handles, URIs) and call `validate_non_empty_string(value)` to ensure non-empty strings flow inward.
+2. **Domain enforcement** – Models built by Pydantic propagate trimmed, validated strings into attributes returned to repositories and adapters.
+3. **Persistence checks** – Repository wrappers call `_validate_non_empty_string_labeled(...)` when exposed to external callers, translating helper errors into field-specific messages before hitting SQLite adapters.
+4. **Storage** – Validated IDs/handles proceed to SQLite adapters (`agent_adapter`, `agent_bio_adapter`, `user_agent_profile_metadata_adapter`) without redundant labeling, preventing malformed rows.
+
+## Manual Verification
+- `uv sync --extra test` — installs dependencies needed for the expanded pytest run.
+- `uv run pytest tests/lib/test_validation_utils.py -q` — helper tests pass with the new error strings.
+- `uv run pytest tests/db/repositories/test_profile_repository.py tests/db/repositories/test_generated_feed_repository.py tests/db/repositories/test_feed_post_repository.py -q` — verifies affected repositories still raise the expected labeled errors.
+- `uv run pytest` — full suite passes (623 tests, 2 skipped) with no collection errors after installing test dependencies.
+- `uv run ruff check .` — linting passes.
+- `uv run pyright .` — type checking passes.
+
+## Alternative approaches
+Keeping `field_name` optional and defaulting to `"value"` would have avoided API churn, but the goal was to drop the extra argument entirely so callers no longer need repetitive labels; wrapping helpers in `_validate_non_empty_string_labeled` still preserves the contextual messages for high-level APIs.
+
+## Assumptions
+- Labeled error messages (`"<field> cannot be empty"`) live in the repo wrappers, not the helper.
+- `_field_name(info)` helpers remain for potential future needs and are not removed in this change.

--- a/lib/validation_utils.py
+++ b/lib/validation_utils.py
@@ -143,29 +143,28 @@ def validate_turn_number(turn_number: int | None) -> None:
     validate_nonnegative_value(turn_number, "turn_number")
 
 
-def validate_non_empty_string(v: Any, field_name: str) -> str:
-    """Validate that a string field is non-empty after stripping.
+def validate_non_empty_string(value: str) -> str:
+    """Validate that a value is a non-empty string after stripping.
 
-    This function is intended to be called from Pydantic field_validators
-    after type coercion has occurred, so v should already be a str.
+    This function is intended to be called from Pydantic field validators after
+    type coercion has occurred, so value should typically already be a str.
     However, we include defensive None and type checking for robustness.
 
     Args:
-        v: The value to validate (expected to be str after Pydantic coercion,
-           but defensively handles None and non-str types)
-        field_name: The name of the field being validated (for error messages)
+        value: The value to validate (expected to be str after coercion, but
+            defensively handles None and non-str types at runtime).
 
     Returns:
-        The stripped string value
+        The stripped string value.
 
     Raises:
-        ValueError: If the value is None, not a string, or empty after stripping
+        ValueError: If the value is None, not a string, or empty after stripping.
     """
-    if v is None:
-        raise ValueError(f"{field_name} cannot be None")
-    if not isinstance(v, str):
-        raise ValueError(f"{field_name} must be a string")
-    v = v.strip()
-    if not v:
-        raise ValueError(f"{field_name} cannot be empty")
-    return v
+    if value is None:  # type: ignore[reportUnnecessaryComparison]
+        raise ValueError("value cannot be None")
+    if not isinstance(value, str):
+        raise ValueError("value must be a string")
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("value cannot be empty")
+    return cleaned

--- a/simulation/api/schemas/simulation.py
+++ b/simulation/api/schemas/simulation.py
@@ -155,14 +155,14 @@ class CreateAgentRequest(BaseModel):
     def _validate_handle(cls, v: str) -> str:
         from lib.validation_utils import validate_non_empty_string
 
-        return validate_non_empty_string(v.strip(), "handle")
+        return validate_non_empty_string(v.strip())
 
     @field_validator("display_name")
     @classmethod
     def _validate_display_name(cls, v: str) -> str:
         from lib.validation_utils import validate_non_empty_string
 
-        return validate_non_empty_string(v.strip(), "display_name")
+        return validate_non_empty_string(v.strip())
 
 
 class AgentSchema(BaseModel):

--- a/simulation/core/metrics/interfaces.py
+++ b/simulation/core/metrics/interfaces.py
@@ -126,24 +126,37 @@ class Metric(ABC):
                 f"{cls.__module__}.{cls.__name__} DEFAULT_ENABLED must be a bool"
             )
 
+        description = getattr(cls, "DESCRIPTION", None)
+        if not isinstance(description, str):
+            raise TypeError(
+                f"{cls.__module__}.{cls.__name__} must define class var DESCRIPTION as str"
+            )
         try:
-            validate_non_empty_string(getattr(cls, "DESCRIPTION", None), "DESCRIPTION")
+            validate_non_empty_string(description)
         except ValueError:
             raise TypeError(
                 f"{cls.__module__}.{cls.__name__} must define non-empty class var DESCRIPTION"
             ) from None
 
+        author = getattr(cls, "AUTHOR", None)
+        if not isinstance(author, str):
+            raise TypeError(
+                f"{cls.__module__}.{cls.__name__} must define class var AUTHOR as str"
+            )
         try:
-            validate_non_empty_string(getattr(cls, "AUTHOR", None), "AUTHOR")
+            validate_non_empty_string(author)
         except ValueError:
             raise TypeError(
                 f"{cls.__module__}.{cls.__name__} must define non-empty class var AUTHOR"
             ) from None
 
-        try:
-            validate_non_empty_string(
-                getattr(cls, "DISPLAY_NAME", None), "DISPLAY_NAME"
+        display_name = getattr(cls, "DISPLAY_NAME", None)
+        if not isinstance(display_name, str):
+            raise TypeError(
+                f"{cls.__module__}.{cls.__name__} must define class var DISPLAY_NAME as str"
             )
+        try:
+            validate_non_empty_string(display_name)
         except ValueError:
             raise TypeError(
                 f"{cls.__module__}.{cls.__name__} must define non-empty class var DISPLAY_NAME"

--- a/simulation/core/models/actions.py
+++ b/simulation/core/models/actions.py
@@ -19,7 +19,7 @@ class Like(BaseModel):
     @classmethod
     def validate_identifier_fields(cls, v: str, info: ValidationInfo) -> str:
         """Validate that identifier fields are non-empty strings."""
-        return validate_non_empty_string(v, _field_name(info))
+        return validate_non_empty_string(v)
 
 
 class Comment(BaseModel):
@@ -33,7 +33,7 @@ class Comment(BaseModel):
     @classmethod
     def validate_identifier_fields(cls, v: str, info: ValidationInfo) -> str:
         """Validate that identifier fields are non-empty strings."""
-        return validate_non_empty_string(v, _field_name(info))
+        return validate_non_empty_string(v)
 
 
 class Follow(BaseModel):
@@ -46,7 +46,7 @@ class Follow(BaseModel):
     @classmethod
     def validate_identifier_fields(cls, v: str, info: ValidationInfo) -> str:
         """Validate that identifier fields are non-empty strings."""
-        return validate_non_empty_string(v, _field_name(info))
+        return validate_non_empty_string(v)
 
 
 class TurnAction(str, Enum):

--- a/simulation/core/models/agent.py
+++ b/simulation/core/models/agent.py
@@ -27,12 +27,12 @@ class Agent(BaseModel):
     @field_validator("agent_id")
     @classmethod
     def validate_agent_id(cls, v: str) -> str:
-        return validate_non_empty_string(v, "agent_id")
+        return validate_non_empty_string(v)
 
     @field_validator("handle")
     @classmethod
     def validate_handle(cls, v: str) -> str:
-        return validate_non_empty_string(v, "handle")
+        return validate_non_empty_string(v)
 
     @field_validator("persona_source", mode="before")
     @classmethod

--- a/simulation/core/models/agent_bio.py
+++ b/simulation/core/models/agent_bio.py
@@ -27,17 +27,17 @@ class AgentBio(BaseModel):
     @field_validator("id")
     @classmethod
     def validate_id(cls, v: str) -> str:
-        return validate_non_empty_string(v, "id")
+        return validate_non_empty_string(v)
 
     @field_validator("agent_id")
     @classmethod
     def validate_agent_id(cls, v: str) -> str:
-        return validate_non_empty_string(v, "agent_id")
+        return validate_non_empty_string(v)
 
     @field_validator("persona_bio")
     @classmethod
     def validate_persona_bio(cls, v: str) -> str:
-        return validate_non_empty_string(v, "persona_bio")
+        return validate_non_empty_string(v)
 
     @field_validator("persona_bio_source", mode="before")
     @classmethod

--- a/simulation/core/models/app_user.py
+++ b/simulation/core/models/app_user.py
@@ -23,13 +23,13 @@ class AppUser(BaseModel):
     @classmethod
     def validate_auth_provider_id(cls, v: str) -> str:
         """Validate that auth_provider_id is non-empty."""
-        return validate_non_empty_string(v, "auth_provider_id")
+        return validate_non_empty_string(v)
 
     @field_validator("id")
     @classmethod
     def validate_id(cls, v: str) -> str:
         """Ensure the id is non-empty and a valid UUID."""
-        validated = validate_non_empty_string(v, "id")
+        validated = validate_non_empty_string(v)
 
         try:
             uuid.UUID(validated)
@@ -42,10 +42,10 @@ class AppUser(BaseModel):
     @classmethod
     def validate_email(cls, v: str) -> str:
         """Validate that the email is non-empty."""
-        return validate_non_empty_string(v, "email")
+        return validate_non_empty_string(v)
 
     @field_validator("display_name")
     @classmethod
     def validate_display_name(cls, v: str) -> str:
         """Validate that the display name is non-empty."""
-        return validate_non_empty_string(v, "display_name")
+        return validate_non_empty_string(v)

--- a/simulation/core/models/feeds.py
+++ b/simulation/core/models/feeds.py
@@ -24,19 +24,19 @@ class GeneratedFeed(BaseModel):
     @classmethod
     def validate_agent_handle(cls, v: str) -> str:
         """Validate that agent_handle is a non-empty string."""
-        return validate_non_empty_string(v, "agent_handle")
+        return validate_non_empty_string(v)
 
     @field_validator("run_id")
     @classmethod
     def validate_run_id(cls, v: str) -> str:
         """Validate that run_id is a non-empty string."""
-        return validate_non_empty_string(v, "run_id")
+        return validate_non_empty_string(v)
 
     @field_validator("feed_id")
     @classmethod
     def validate_feed_id(cls, v: str) -> str:
         """Validate that feed_id is a non-empty string."""
-        return validate_non_empty_string(v, "feed_id")
+        return validate_non_empty_string(v)
 
     @field_validator("turn_number")
     @classmethod

--- a/simulation/core/models/generated/bio.py
+++ b/simulation/core/models/generated/bio.py
@@ -14,12 +14,12 @@ class GeneratedBio(BaseModel):
     @field_validator("handle")
     @classmethod
     def validate_handle(cls, v: str) -> str:
-        return validate_non_empty_string(v, "handle")
+        return validate_non_empty_string(v)
 
     @field_validator("generated_bio")
     @classmethod
     def validate_generated_bio(cls, v: str) -> str:
-        return validate_non_empty_string(v, "generated_bio")
+        return validate_non_empty_string(v)
 
     @field_validator("metadata")
     @classmethod

--- a/simulation/core/models/generated/comment.py
+++ b/simulation/core/models/generated/comment.py
@@ -18,7 +18,7 @@ class GeneratedComment(BaseModel):
     @field_validator("explanation")
     @classmethod
     def validate_explanation(cls, v: str) -> str:
-        return validate_non_empty_string(v, "explanation")
+        return validate_non_empty_string(v)
 
     @field_validator("metadata")
     @classmethod

--- a/simulation/core/models/generated/follow.py
+++ b/simulation/core/models/generated/follow.py
@@ -18,7 +18,7 @@ class GeneratedFollow(BaseModel):
     @field_validator("explanation")
     @classmethod
     def validate_explanation(cls, v: str) -> str:
-        return validate_non_empty_string(v, "explanation")
+        return validate_non_empty_string(v)
 
     @field_validator("metadata")
     @classmethod

--- a/simulation/core/models/generated/like.py
+++ b/simulation/core/models/generated/like.py
@@ -18,7 +18,7 @@ class GeneratedLike(BaseModel):
     @field_validator("explanation")
     @classmethod
     def validate_explanation(cls, v: str) -> str:
-        return validate_non_empty_string(v, "explanation")
+        return validate_non_empty_string(v)
 
     @field_validator("metadata")
     @classmethod

--- a/simulation/core/models/metrics.py
+++ b/simulation/core/models/metrics.py
@@ -27,7 +27,7 @@ class TurnMetrics(BaseModel):
     @field_validator("run_id", "created_at", mode="before")
     @classmethod
     def _validate_non_empty(cls, v: str, info: ValidationInfo) -> str:
-        return validate_non_empty_string(v, _field_name(info))
+        return validate_non_empty_string(v)
 
     @field_validator("turn_number")
     @classmethod
@@ -45,6 +45,6 @@ class RunMetrics(BaseModel):
     @field_validator("run_id", "created_at", mode="before")
     @classmethod
     def _validate_non_empty(cls, v: str, info: ValidationInfo) -> str:
-        return validate_non_empty_string(v, _field_name(info))
+        return validate_non_empty_string(v)
 
     model_config = {"frozen": True}

--- a/simulation/core/models/posts.py
+++ b/simulation/core/models/posts.py
@@ -20,12 +20,12 @@ class Post(BaseModel):
     @field_validator("id")
     @classmethod
     def validate_id(cls, v: str) -> str:
-        return validate_non_empty_string(v, "id")
+        return validate_non_empty_string(v)
 
     @field_validator("author_handle")
     @classmethod
     def validate_author_handle(cls, v: str) -> str:
-        return validate_non_empty_string(v, "author_handle")
+        return validate_non_empty_string(v)
 
 
 class BlueskyFeedPost(Post):
@@ -40,7 +40,7 @@ class BlueskyFeedPost(Post):
     @field_validator("uri")
     @classmethod
     def validate_uri(cls, v: str) -> str:
-        return validate_non_empty_string(v, "uri")
+        return validate_non_empty_string(v)
 
     @field_validator("bookmark_count")
     @classmethod

--- a/simulation/core/models/profiles.py
+++ b/simulation/core/models/profiles.py
@@ -20,7 +20,7 @@ class Profile(BaseModel):
     @field_validator("handle")
     @classmethod
     def validate_handle(cls, v: str) -> str:
-        return validate_non_empty_string(v, "handle")
+        return validate_non_empty_string(v)
 
     @field_validator("followers_count")
     @classmethod
@@ -49,4 +49,4 @@ class BlueskyProfile(Profile):
     @field_validator("did")
     @classmethod
     def validate_did(cls, v: str) -> str:
-        return validate_non_empty_string(v, "did")
+        return validate_non_empty_string(v)

--- a/simulation/core/models/runs.py
+++ b/simulation/core/models/runs.py
@@ -30,7 +30,7 @@ class RunConfig(BaseModel):
         if v is None:
             return None
         validate_non_empty_iterable(v, "metric_keys")
-        return [validate_non_empty_string(item, "metric_keys") for item in v]
+        return [validate_non_empty_string(item) for item in v]
 
     @field_validator("num_agents")
     @classmethod
@@ -45,7 +45,7 @@ class RunConfig(BaseModel):
     @field_validator("feed_algorithm")
     @classmethod
     def validate_feed_algorithm(cls, v: str) -> str:
-        return validate_non_empty_string(v, "feed_algorithm")
+        return validate_non_empty_string(v)
 
 
 class RunStatus(str, Enum):
@@ -86,13 +86,13 @@ class Run(BaseModel):
     def validate_metric_keys_run(cls, v: list[str]) -> list[str]:
         """Validate that metric_keys is non-empty and contains non-empty strings."""
         validate_non_empty_iterable(v, "metric_keys")
-        return [validate_non_empty_string(item, "metric_keys") for item in v]
+        return [validate_non_empty_string(item) for item in v]
 
     @field_validator("run_id")
     @classmethod
     def validate_run_id(cls, v: str) -> str:
         """Validate that run_id is a non-empty string."""
-        return validate_non_empty_string(v, "run_id")
+        return validate_non_empty_string(v)
 
     @field_validator("total_turns")
     @classmethod
@@ -109,7 +109,7 @@ class Run(BaseModel):
     @field_validator("feed_algorithm")
     @classmethod
     def validate_feed_algorithm(cls, v: str) -> str:
-        return validate_non_empty_string(v, "feed_algorithm")
+        return validate_non_empty_string(v)
 
     @field_validator("app_user_id")
     @classmethod

--- a/simulation/core/models/turns.py
+++ b/simulation/core/models/turns.py
@@ -47,7 +47,7 @@ class TurnMetadata(BaseModel):
     @classmethod
     def validate_run_id(cls, v: str) -> str:
         """Validate that run_id is a non-empty string."""
-        return validate_non_empty_string(v, "run_id")
+        return validate_non_empty_string(v)
 
     @field_validator("turn_number")
     @classmethod

--- a/simulation/core/models/user_agent_profile_metadata.py
+++ b/simulation/core/models/user_agent_profile_metadata.py
@@ -19,12 +19,12 @@ class UserAgentProfileMetadata(BaseModel):
     @field_validator("id")
     @classmethod
     def validate_id(cls, v: str) -> str:
-        return validate_non_empty_string(v, "id")
+        return validate_non_empty_string(v)
 
     @field_validator("agent_id")
     @classmethod
     def validate_agent_id(cls, v: str) -> str:
-        return validate_non_empty_string(v, "agent_id")
+        return validate_non_empty_string(v)
 
     @field_validator("followers_count")
     @classmethod

--- a/simulation/core/utils/validators.py
+++ b/simulation/core/utils/validators.py
@@ -19,14 +19,25 @@ from simulation.core.utils.exceptions import (
 MAX_RATIO_OF_EMPTY_FEEDS = 0.25
 
 
+def _validate_non_empty_string_labeled(value: object, *, label: str) -> str:
+    if value is None:
+        raise ValueError(f"{label} cannot be None")
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string")
+    try:
+        return validate_non_empty_string(value)
+    except ValueError as exc:
+        raise ValueError(f"{label} cannot be empty") from exc
+
+
 def validate_run_id(run_id: str) -> str:
     """Validate that run_id is a non-empty string. Returns stripped value."""
-    return validate_non_empty_string(run_id, "run_id")
+    return _validate_non_empty_string_labeled(run_id, label="run_id")
 
 
 def validate_agent_id(agent_id: str) -> str:
     """Validate that agent_id is a non-empty string. Returns stripped value."""
-    return validate_non_empty_string(agent_id, "agent_id")
+    return _validate_non_empty_string_labeled(agent_id, label="agent_id")
 
 
 def validate_num_agents(num_agents: int) -> int:
@@ -108,7 +119,7 @@ def validate_insufficient_agents(agents: list[SocialMediaAgent], requested_agent
 
 def validate_handle_exists(handle: str) -> str:
     """Validate that handle is a non-empty string. Returns stripped value."""
-    return validate_non_empty_string(handle, "handle")
+    return _validate_non_empty_string_labeled(handle, label="handle")
 
 
 def validate_duplicate_agent_handles(agents: list[SocialMediaAgent]):
@@ -168,7 +179,7 @@ def validate_run_status_transition(
 
 def validate_uri_exists(uri: str) -> str:
     """Validate that uri is a non-empty string. Returns stripped value."""
-    return validate_non_empty_string(uri, "uri")
+    return _validate_non_empty_string_labeled(uri, label="uri")
 
 
 def validate_uris_exist(uris: Iterable[str]) -> Iterable[str]:

--- a/tests/db/repositories/test_feed_post_repository.py
+++ b/tests/db/repositories/test_feed_post_repository.py
@@ -133,7 +133,7 @@ class TestSQLiteFeedPostRepositoryCreateOrUpdateFeedPost:
                 created_at="2024-01-01T00:00:00Z",
             )
 
-        assert "uri cannot be empty" in str(exc_info.value)
+        assert "value cannot be empty" in str(exc_info.value)
 
     def test_raises_validation_error_when_uri_is_whitespace(self):
         """Test that creating BlueskyFeedPost with whitespace uri raises ValidationError from Pydantic."""
@@ -154,7 +154,7 @@ class TestSQLiteFeedPostRepositoryCreateOrUpdateFeedPost:
                 created_at="2024-01-01T00:00:00Z",
             )
 
-        assert "uri cannot be empty" in str(exc_info.value)
+        assert "value cannot be empty" in str(exc_info.value)
 
     def test_propagates_adapter_exception_when_write_fails(self):
         """Test that create_or_update_feed_post propagates adapter exceptions when database write fails."""
@@ -283,7 +283,7 @@ class TestSQLiteFeedPostRepositoryCreateOrUpdateFeedPosts:
                 created_at="2024-01-02T00:00:00Z",
             )
 
-        assert "uri cannot be empty" in str(exc_info.value)
+        assert "value cannot be empty" in str(exc_info.value)
 
     def test_propagates_adapter_exception_when_batch_write_fails(self):
         """Test that create_or_update_feed_posts propagates adapter exceptions when batch write fails."""

--- a/tests/db/repositories/test_feed_post_repository_integration.py
+++ b/tests/db/repositories/test_feed_post_repository_integration.py
@@ -287,7 +287,7 @@ class TestSQLiteFeedPostRepositoryIntegration:
                 created_at="2024-01-01T00:00:00Z",
             )
 
-        assert "uri cannot be empty" in str(exc_info.value)
+        assert "value cannot be empty" in str(exc_info.value)
 
     def test_get_feed_post_with_empty_uri_raises_error(self, feed_post_repo):
         """Test that get_feed_post raises ValueError when uri is empty."""

--- a/tests/db/repositories/test_generated_feed_repository.py
+++ b/tests/db/repositories/test_generated_feed_repository.py
@@ -116,7 +116,7 @@ class TestSQLiteGeneratedFeedRepositoryCreateOrUpdateGeneratedFeed:
                 created_at="2024-01-01T00:00:00Z",
             )
 
-        assert "agent_handle cannot be empty" in str(exc_info.value)
+        assert "value cannot be empty" in str(exc_info.value)
 
     def test_raises_validation_error_when_run_id_is_empty(self):
         """Test that creating GeneratedFeed with empty run_id raises ValidationError from Pydantic."""
@@ -132,7 +132,7 @@ class TestSQLiteGeneratedFeedRepositoryCreateOrUpdateGeneratedFeed:
                 created_at="2024-01-01T00:00:00Z",
             )
 
-        assert "run_id cannot be empty" in str(exc_info.value)
+        assert "value cannot be empty" in str(exc_info.value)
 
     def test_propagates_adapter_exception_when_write_fails(self):
         """Test that write_generated_feed propagates adapter exceptions when database write fails."""

--- a/tests/db/repositories/test_generated_feed_repository_integration.py
+++ b/tests/db/repositories/test_generated_feed_repository_integration.py
@@ -212,7 +212,7 @@ class TestSQLiteGeneratedFeedRepositoryIntegration:
                 created_at="2024-01-01T00:00:00Z",
             )
 
-        assert "agent_handle cannot be empty" in str(exc_info.value)
+        assert "value cannot be empty" in str(exc_info.value)
 
     def test_get_generated_feed_with_empty_agent_handle_raises_error(
         self, generated_feed_repo

--- a/tests/db/repositories/test_profile_repository.py
+++ b/tests/db/repositories/test_profile_repository.py
@@ -116,7 +116,7 @@ class TestSQLiteProfileRepositoryCreateOrUpdateProfile:
                 posts_count=25,
             )
 
-        assert "handle cannot be empty" in str(exc_info.value)
+        assert "value cannot be empty" in str(exc_info.value)
 
     def test_raises_validation_error_when_handle_is_whitespace(self):
         """Test that creating BlueskyProfile with whitespace handle raises ValidationError from Pydantic."""
@@ -133,7 +133,7 @@ class TestSQLiteProfileRepositoryCreateOrUpdateProfile:
                 posts_count=25,
             )
 
-        assert "handle cannot be empty" in str(exc_info.value)
+        assert "value cannot be empty" in str(exc_info.value)
 
     def test_propagates_adapter_exception_when_write_fails(self):
         """Test that create_or_update_profile propagates adapter exceptions when database write fails."""

--- a/tests/db/repositories/test_profile_repository_integration.py
+++ b/tests/db/repositories/test_profile_repository_integration.py
@@ -166,7 +166,7 @@ class TestSQLiteProfileRepositoryIntegration:
                 posts_count=25,
             )
 
-        assert "handle cannot be empty" in str(exc_info.value)
+        assert "value cannot be empty" in str(exc_info.value)
 
     def test_get_profile_with_empty_handle_raises_error(self, profile_repo):
         """Test that get_profile raises ValueError when handle is empty."""

--- a/tests/lib/test_validation_utils.py
+++ b/tests/lib/test_validation_utils.py
@@ -34,15 +34,15 @@ class TestValidateNonEmptyString:
     @pytest.mark.parametrize(
         "string, expected_error",
         [
-            (None, "field_name cannot be None"),
-            (5, "field_name must be a string"),
-            ("", "field_name cannot be empty"),
-            ("   ", "field_name cannot be empty"),
+            (None, "value cannot be None"),
+            (5, "value must be a string"),
+            ("", "value cannot be empty"),
+            ("   ", "value cannot be empty"),
         ],
     )
     def test_validation_errors(self, string, expected_error):
         with pytest.raises(ValueError, match=expected_error):
-            validate_non_empty_string(string, "field_name")
+            validate_non_empty_string(string)  # type: ignore[arg-type]
 
     @pytest.mark.parametrize(
         "string, expected",
@@ -52,5 +52,5 @@ class TestValidateNonEmptyString:
         ],
     )
     def test_if_v_strip_works(self, string, expected):
-        result = validate_non_empty_string(string, "field_name")
+        result = validate_non_empty_string(string)
         assert expected == result


### PR DESCRIPTION
Overview
> Streamline `validate_non_empty_string` in `lib/validation_utils.py` so it only needs the value and delivers consistent `value ...` errors; ripple that change through every domain model, generated model, SQLite adapter, API schema, and validator wrapper while keeping regression coverage intact and preserving the contextual labeled messages where external code depends on them.

Problem / motivation
> The helper currently requires a `field_name` argument, so every validator and adapter passes the same string multiple times just to get a contextual error message. That pattern is noisy and makes it hard to keep the helper’s behavior consistent.

Solution
> Make the helper single-argument with `"value …"` errors, update every caller to drop the label, and keep labeled messaging alive by translating the helper errors only in the wrapper functions that external callers use.

Happy Flow
1. **Helper contract** – `lib/validation_utils.py:146` accepts a single `value`, validates `None`, non-`str`, and emptiness, and returns the trimmed string with `"value ..."` errors.
2. **Domain/generator consumers** – Pydantic validators across `simulation/core/models/*.py` and `simulation/core/models/generated/*.py` call the helper with only the incoming field to keep type coercion consistent.
3. **API/schema guards** – `simulation/api/schemas/simulation.py` strips request values and hands them to the helper without redundant field labels.
4. **Adapters** – SQLite builders (`db/adapters/sqlite/*.py`) call the helper directly before running SQL, ensuring their inputs are trimmed.
5. **Wrapper translation** – `simulation/core/utils/validators.py` keeps the existing labeled errors for consumers like repositories by catching `ValueError`s, rephrasing them, and re-raising so external assertions still see `run_id cannot be empty`.

Data Flow
1. **Input normalization** – API validators and domain models trim inputs (e.g., handles, URIs) and call `validate_non_empty_string(value)` to ensure non-empty strings flow inward.
2. **Domain enforcement** – Models built by Pydantic propagate trimmed, validated strings into attributes returned to repositories and adapters.
3. **Persistence checks** – Repository wrappers call `_validate_non_empty_string_labeled(...)` when exposed to external callers, translating helper errors into field-specific messages before hitting SQLite adapters.
4. **Storage** – Validated IDs/handles proceed to SQLite adapters (`agent_adapter`, `agent_bio_adapter`, `user_agent_profile_metadata_adapter`) without redundant labeling, preventing malformed rows.

Changes
- `lib/validation_utils.py`: convert `validate_non_empty_string` to one argument and force `"value …"` errors.
- `simulation/core/utils/validators.py`: introduce `_validate_non_empty_string_labeled` and route `run_id/agent_id/handle/uri` validations through it.
- `simulation/core/models/*`, `simulation/core/models/generated/*`, `simulation/api/schemas/simulation.py`, and `db/adapters/sqlite/*.py`: drop `field_name` arguments when calling the helper.
- `simulation/core/metrics/interfaces.py`: verify metric metadata strings before calling the helper.
- Repository tests (`tests/db/repositories/*`) and `tests/lib/test_validation_utils.py`: expect the new `"value …"` errors.
- Planning doc `docs/plans/2026-03-08_validate_non_empty_string_single_arg_482193/plan.md` captures the plan, happy flow, and verification steps.

Manual Verification
- `uv sync --extra test` — install dependencies needed for the expanded pytest run.
- `uv run pytest tests/lib/test_validation_utils.py -q` — helper tests pass with the new error strings.
- `uv run pytest tests/db/repositories/test_profile_repository.py tests/db/repositories/test_generated_feed_repository.py tests/db/repositories/test_feed_post_repository.py -q` — verifies affected repositories still surface labeled errors.
- `uv run pytest` — full suite passes (623 tests, 2 skipped) with the newly installed dependencies.
- `uv run ruff check .` — linting passes.
- `uv run pyright .` — type checking passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified and standardized validation error messaging throughout the application for consistency. All input validation errors now display uniform, generic messages (for example, "value cannot be empty") instead of field-specific error messages, providing consistent and predictable feedback across the entire system whenever user input validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->