### PR TITLE
[2026-03-08] Codex repo automation - conventions

### DIFF
--- a/tests/api/test_simulation_agents.py
+++ b/tests/api/test_simulation_agents.py
@@ -493,7 +493,7 @@ def test_delete_simulations_agents_success_removes_agent(simulation_client, temp
 
     post_resp = client.post("/v1/simulations/agents", json=body)
     assert post_resp.status_code == 201
-    created = post_resp.json()
+    created: dict[str, str] = post_resp.json()
 
     delete_resp = client.delete(f"/v1/simulations/agents/{created['handle']}")
     assert delete_resp.status_code == 204
@@ -501,7 +501,8 @@ def test_delete_simulations_agents_success_removes_agent(simulation_client, temp
     get_resp = client.get("/v1/simulations/agents?limit=100&offset=0")
     assert get_resp.status_code == 200
     handles = [agent["handle"] for agent in get_resp.json()]
-    assert created["handle"] not in handles
+    expected_result = created["handle"]
+    assert expected_result not in handles
 
 
 def test_delete_simulations_agents_missing_returns_404(simulation_client, temp_db):
@@ -512,4 +513,5 @@ def test_delete_simulations_agents_missing_returns_404(simulation_client, temp_d
     resp = client.delete(f"/v1/simulations/agents/{missing_handle}")
     assert resp.status_code == 404
     err = resp.json()
-    assert err["error"]["code"] == "AGENT_NOT_FOUND"
+    expected_result = "AGENT_NOT_FOUND"
+    assert err["error"]["code"] == expected_result

--- a/ui/components/agents/AgentsView.tsx
+++ b/ui/components/agents/AgentsView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import AgentDetail from '@/components/details/AgentDetail';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import { Agent } from '@/types';
@@ -24,8 +24,12 @@ export default function AgentsView({
 }: AgentsViewProps) {
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
+  const deleteRequestIdRef = useRef(0);
+
   useEffect(() => {
+    deleteRequestIdRef.current += 1;
     setDeleteError(null);
+    setIsDeleting(false);
   }, [selectedAgentHandle]);
   if (agentsLoading && agents.length === 0) {
     return (
@@ -77,13 +81,20 @@ export default function AgentsView({
     if (!confirmed) {
       return;
     }
-    setDeleteError(null);
+    const requestId = deleteRequestIdRef.current + 1;
+    deleteRequestIdRef.current = requestId;
     setIsDeleting(true);
     try {
       await onDeleteAgent(agent.handle);
     } catch (err) {
+      if (deleteRequestIdRef.current !== requestId) {
+        return;
+      }
       setDeleteError(err instanceof Error ? err.message : String(err));
     } finally {
+      if (deleteRequestIdRef.current !== requestId) {
+        return;
+      }
       setIsDeleting(false);
     }
   };

--- a/ui/components/details/RunSummary.tsx
+++ b/ui/components/details/RunSummary.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { Agent, Run } from '@/types';
 
+const COPY_RESET_DELAY_MS: number = 1_000;
+
 interface RunSummaryProps {
   run: Run;
   agents: Agent[];
@@ -26,7 +28,7 @@ export default function RunSummary({ run, agents, completedTurns }: RunSummaryPr
         await navigator.clipboard.writeText(run.runId)
         setCopied(true)
         if (copyResetTimerRef.current) clearTimeout(copyResetTimerRef.current);
-        copyResetTimerRef.current = setTimeout(() => setCopied(false), 1000);
+        copyResetTimerRef.current = setTimeout(() => setCopied(false), COPY_RESET_DELAY_MS);
       } catch (error) {
         console.log(error instanceof Error ? error.message : 'Copy failed');
         setCopied(false)


### PR DESCRIPTION
- Hoist the run ID copy timer into COPY_RESET_DELAY_MS per the repo rule about avoiding inline magic constants.\n- Guard the agent delete button’s async path with a request-id so the component stays consistent with frontend state lifecycle invariants.\n- Add explicit expected_result variables to the delete-agent API tests to satisfy the testing conventions.\n\nTests:\n- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/api/test_simulation_agents.py -k delete_simulations_agents -q` (fails: `uv` panicked in this environment with a system-configuration NULL object).\n- `cd ui && npm run lint -- --file components/details/RunSummary.tsx --file components/agents/AgentsView.tsx` (fails: `eslint` is not installed in this environment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved race conditions in delete operations that could occur when rapidly deleting multiple items, ensuring correct error messages and states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->