### PR TITLE
Fix changelog markdownlint warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,60 +2,59 @@
 
 ## 2026-03-02 to 2026-03-08
 
-### Backend/API
+### Backend/API (2026-03-02 to 2026-03-08)
 
 - High-level summary: Backend simulation APIs added agent deletion support and tightened validation usage across adapters and domain models. These changes primarily touched API routes, repositories, adapters, and model validators.
 - PRs:
-- [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/173](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/173): Add delete-agent endpoint and UI control. Adds a delete-agent API path and related repository/adapter support for deleting agent records and linked metadata.
-- [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/193](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/193): Refine validate_non_empty_string usage. Normalizes validation utility usage across database adapters, schemas, and simulation core model types.
+  - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/173](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/173): Add delete-agent endpoint and UI control. Adds a delete-agent API path and related repository/adapter support for deleting agent records and linked metadata.
+  - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/193](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/193): Refine validate_non_empty_string usage. Normalizes validation utility usage across database adapters, schemas, and simulation core model types.
 
-### UI/frontend
+### UI/frontend (2026-03-02 to 2026-03-08)
 
 - High-level summary: Frontend updates added direct controls for agent deletion and run ID copying, with follow-up convention cleanup in core components. The week included both feature work and UI consistency adjustments.
 - PRs:
-- [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/173](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/173): Add delete-agent endpoint and UI control. Introduces the delete action in the agents UI and updates generated API types to support the new endpoint.
-- [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/182](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/182): add copying button for runId. Adds a copy-to-clipboard control in the run summary view for faster run ID reuse.
-- [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/197](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/197): Apply convention fixes from repo review automation. Applies targeted UI component convention fixes in `AgentsView` and `RunSummary`.
+  - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/173](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/173): Add delete-agent endpoint and UI control. Introduces the delete action in the agents UI and updates generated API types to support the new endpoint.
+  - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/182](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/182): add copying button for runId. Adds a copy-to-clipboard control in the run summary view for faster run ID reuse.
+  - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/197](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/197): Apply convention fixes from repo review automation. Applies targeted UI component convention fixes in `AgentsView` and `RunSummary`.
 
-### ML
+### ML (2026-03-02 to 2026-03-08)
 
 - High-level summary: No model, training, evaluation, or inference-specific pull requests were merged this week. ML behavior remained unchanged in this window.
 - PRs:
- - _None this week._
+  - _None this week._
 
-### Platform
+### Platform (2026-03-02 to 2026-03-08)
 
 - High-level summary: No infrastructure or deployment-platform specific pull requests were identified in first-parent merge history this week. Runtime platform behavior did not have dedicated platform PRs in this window.
 - PRs:
- - _None this week._
+  - _None this week._
 
-### Docs/Quality
+### Docs/Quality (2026-03-02 to 2026-03-08)
 
 - High-level summary: Quality work expanded validation tests and enforced Python test syntax conventions in CI and pre-commit. Validation cleanup work also updated test coverage and supporting runbook/plan artifacts.
 - PRs:
-- [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/181](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/181): Add unit tests for `validate_non_empty_iterable` and `validate_non_empty_string`. Adds focused unit tests for validation helpers in `tests/lib/test_validation_utils.py`.
-- [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/193](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/193): Refine validate_non_empty_string usage. Updates validators and related tests to align string validation call patterns across the codebase.
-- [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/196](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/196): Enforce python testing syntax conventions. Adds a lint script and CI/pre-commit enforcement while migrating affected test files to the required syntax pattern.
-- [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/197](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/197): Apply convention fixes from repo review automation. Applies review-driven fixes in tests and UI components to align with repository conventions.
+  - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/181](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/181): Add unit tests for `validate_non_empty_iterable` and `validate_non_empty_string`. Adds focused unit tests for validation helpers in `tests/lib/test_validation_utils.py`.
+  - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/193](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/193): Refine validate_non_empty_string usage. Updates validators and related tests to align string validation call patterns across the codebase.
+  - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/196](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/196): Enforce python testing syntax conventions. Adds a lint script and CI/pre-commit enforcement while migrating affected test files to the required syntax pattern.
+  - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/197](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/197): Apply convention fixes from repo review automation. Applies review-driven fixes in tests and UI components to align with repository conventions.
 
-### Automation/CI
+### Automation/CI (2026-03-02 to 2026-03-08)
 
 - High-level summary: Automation runs produced a weekly report at the start of the window, a feature-ideas report, and a refreshed weekly update at the end of the window. Reporting automation activity was concentrated in docs artifacts.
 - PRs:
-- [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/175](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/175): [2026-03-02] Codex repo automation - Weekly work update. Adds the weekly update artifact for the prior Monday-to-Sunday period in `docs/weekly_updates/`.
-- [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/188](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/188): Add 2026-03-07 feature ideas automation report. Adds the dated feature-ideas automation output under `docs/feature_ideas/`.
-- [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/192](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/192): [2026-03-08] Codex repo automation - Weekly work update. Adds the weekly update artifact for `2026-03-02` through `2026-03-08`.
+  - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/175](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/175): [2026-03-02] Codex repo automation - Weekly work update. Adds the weekly update artifact for the prior Monday-to-Sunday period in `docs/weekly_updates/`.
+  - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/188](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/188): Add 2026-03-07 feature ideas automation report. Adds the dated feature-ideas automation output under `docs/feature_ideas/`.
+  - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/192](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/192): [2026-03-08] Codex repo automation - Weekly work update. Adds the weekly update artifact for `2026-03-02` through `2026-03-08`.
 
-### Bug Fixes
+### Bug Fixes (2026-03-02 to 2026-03-08)
 
 - High-level summary: No standalone bug-fix-only PRs were identified outside the feature and quality categories above. Fix-oriented changes are captured in those sections.
 - PRs:
- - _None this week._
-
+  - _None this week._
 
 ## 2026-02-23 to 2026-02-28
 
-### Backend/API
+### Backend/API (2026-02-23 to 2026-02-28)
 
 - High-level summary: Stabilized backend data flows by extending schema docs, improving fault tolerance for run config fetches, and reshuffling connection management so auth and persistence layers stay reliable. Persisted run actions/metrics metadata, exposed feed config inputs, and added per-run metric selection so the UI can drive rich telemetry. Removed deprecated fields on agent creation submissions while keeping action guardrails and timeline attribution in sync with the new tables.
 - PRs:
@@ -70,7 +69,7 @@
   - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/122](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/122): Render feed algorithm config inputs. Delivers backend support for rendering feed ranking configuration so UI editors can adjust algorithm parameters.
   - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/120](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/120): Move conn manager from adapter to repository layer. Relocates connection management to the repository layer to simplify dependency wiring for storage access.
 
-### UI/frontend
+### UI/frontend (2026-02-23 to 2026-02-28)
 
 - High-level summary: Refined agent creation, pagination, and metric configuration experiences while tightly coupling the UI with backend APIs and typed contracts. Added validation for handwritten inputs, richer previews, and search filters so agent builders have immediate feedback, and generated OpenAPI-derived types to keep frontend/back-end contracts aligned.
 - PRs:
@@ -83,19 +82,19 @@
   - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/152](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/152): Add agent search/filtering via q param. Enables quick filtering of agents via a query parameter.
   - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/104](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/104): OpenAPI-generated UI API types + CI contract check. Adds generated API types and a CI check to keep UI contracts aligned with OpenAPI.
 
-### ML
+### ML (2026-02-23 to 2026-02-28)
 
 - High-level summary: No ML-focused PRs were merged this week, so the pipeline work remains scheduled for future sprints.
 - PRs:
   - _None this week._
 
-### Platform
+### Platform (2026-02-23 to 2026-02-28)
 
 - High-level summary: Improved the local development experience by allowing a deterministic dummy database and seed to be forced when DISABLE_AUTH is enabled. This keeps contributors productive while fuzzing auth gubs and preparing for future migrations.
 - PRs:
   - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/136](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/136): Add LOCAL dev mode forced dummy DB + seed. Adds logic to create and seed a dummy database when local dev mode is enabled so devs can run scenarios without needing a real backend.
 
-### Docs/Quality
+### Docs/Quality (2026-02-23 to 2026-02-28)
 
 - High-level summary: Bolstered documentation linting, TypeScript/ Python guardrails, deterministic factories, and utility organization to keep the repo consistent and easier to scale. These changes also added metadata checks so CI can enforce the repository’s documentation and architecture conventions.
 - PRs:
@@ -107,7 +106,7 @@
   - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/155](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/155): Migrate simulation core utilities into utils package. Moves shared utilities into `utils/` to reduce coupling.
   - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/148](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/148): Add deterministic test factories (Faker + Hypothesis). Adds deterministic Faker/Hypothesis factories so tests stay stable across runs.
 
-### Automation/CI
+### Automation/CI (2026-02-23 to 2026-02-28)
 
 - High-level summary: Continued the Codex feature ideas scan automation across multiple dates to keep a steady stream of discovery for the backlog. The automation runs were documented so the daily scans remain visible in release notes.
 - PRs:
@@ -115,7 +114,7 @@
   - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/131](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/131): [2026-02-24] Codex repo automation - Feature ideas scan. Captures the Feb 24 feature ideas scan automation results.
   - [https://github.com/METResearchGroup/social_agent_simulation_platform/pull/106](https://github.com/METResearchGroup/social_agent_simulation_platform/pull/106): [2026-02-21] Codex repo automation - Feature ideas scan. Captures the Feb 21 feature ideas scan automation results.
 
-### Bug Fixes
+### Bug Fixes (2026-02-23 to 2026-02-28)
 
 - High-level summary: Cleaned up failing tests by aligning the `expected_result` fixtures with the updated behavior so CI remains green. This also prevents regressions in suites that relied on those expectations.
 - PRs:


### PR DESCRIPTION
## Summary
- disambiguate the repeated section headings in the changelog by appending each week\'s date range
- indent the PR lists so markdownlint sees the nested items consistently and trim extra blank lines between sections
- rerun the markdownlint job to confirm the previous failure is resolved

## Testing
- npx -y markdownlint-cli2 "**/*.md" "#node_modules" "#ui/node_modules" "#.venv" "#docs/plans"