### PR TITLE
Codify persistence scope contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,9 @@ jobs:
       - name: Add project directory to PYTHONPATH
         run: echo "PYTHONPATH=${{ github.workspace }}" >> $GITHUB_ENV
 
+      - name: Check DB schema conventions (persistence scopes)
+        run: uv run python scripts/lint_schema_conventions.py
+
       - name: Check DB schema docs are up to date
         run: uv run python scripts/generate_db_schema_docs.py --check
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,11 @@ repos:
         entry: bash -lc "uv run python scripts/check_db_schema_drift.py"
         language: system
         pass_filenames: false
+      - id: db-schema-conventions
+        name: db schema conventions (persistence scopes)
+        entry: bash -lc "uv run python scripts/lint_schema_conventions.py"
+        language: system
+        pass_filenames: false
       - id: complexipy
         name: complexipy
         entry: bash -lc "uv run --extra test complexipy . --max-complexity-allowed 999"

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,4 +24,5 @@ Quick lookup table of contents for project documentation.
 |----------|-------------|
 | [RULES.md](RULES.md) | Project rules and conventions |
 | [api-contract.md](api-contract.md) | Backend ↔ frontend schema contract and generated types |
+| [architecture/seed-state-run-snapshot-turn-events.md](architecture/seed-state-run-snapshot-turn-events.md) | Persistence scopes: seed state vs run snapshot vs turn events |
 | [plans/](plans/) | Implementation plans and verification assets |

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -172,6 +172,23 @@ Persistence and model boundaries
 
 - When adding computed or derived data (e.g. metrics), persist it in dedicated storage (e.g. turn_metrics / run_metrics tables and a dedicated repository) rather than overloading existing models or repositories. Keeps core models stable and avoids bloating a single repo with unrelated concerns.
 
+Persistence scopes
+
+- The persistence layer has three distinct lifecycles. Model them explicitly and do not mix them in one table:
+  - __Seed state (current, editable)__: the current “what exists before the next run starts” state. Use `agent_*` for new seed-state tables.
+  - __Run snapshot (immutable after run creation)__: the frozen “what existed when this run started” snapshot. Use `run_*` for new snapshot tables.
+  - __Turn events (append-only history)__: immutable per-turn outputs produced during a run. Use `turn_*` for new per-turn tables.
+- Legacy exceptions already in the repo:
+  - `agent`, `agent_persona_bios`, `user_agent_profile_metadata` are seed-state tables even though they predate the `agent_*` naming convention.
+  - `likes`, `comments`, `follows`, and `generated_feeds` are legacy-named __turn-event__ tables; they must keep their current semantics (they are not seed state).
+- Historical-run reads must not derive behaviorally relevant state from live seed-state tables. If a run needs a “starting state”, it must be snapshotted into `run_*` at run creation time.
+- Ban mixed-lifecycle modeling patterns:
+  - Do not create a single table that holds both seed state and run/turn state via nullable `run_id` / nullable `turn_number`.
+  - Do not add a lifecycle-collapsing `source = manual | simulation` field to reuse an event-log table as editable seed state.
+- Migration contract (lossy vs non-lossy):
+  - __Counts are lossy__ and may be preserved as summaries/caches (e.g. `*_count` fields) but do not imply row identities.
+  - __Row-level facts__ (edges, posts, likes, comments) may only be migrated/backfilled when there is row-level source data to infer them from. Never synthesize rows from aggregate counts.
+
 Frontend — Shared components
 
 - Extract shared UI patterns (e.g. LoadingSpinner) into common components when the same JSX/styling appears in multiple places. Reuse rather than duplicate.

--- a/docs/architecture/seed-state-run-snapshot-turn-events.md
+++ b/docs/architecture/seed-state-run-snapshot-turn-events.md
@@ -1,0 +1,78 @@
+# Seed state vs run snapshots vs turn events
+
+This document defines the **persistence scopes** used by the simulation platform. It exists to prevent a recurring failure mode: mixing editable “current state” data with immutable run history in one table family.
+
+## Canonical scopes
+
+### Seed state (current, editable)
+
+Seed state is the mutable data that should still exist even when **no run exists**. It represents “what exists before the next run starts.”
+
+- **Naming**: new seed-state tables use the `agent_*` prefix.
+- **Lifecycle**: editable; changes affect only future runs.
+- **Examples (current schema)**:
+  - `agent`
+  - `agent_persona_bios`
+  - `user_agent_profile_metadata` (summary/cache; not the source of truth for edges/posts)
+
+### Run snapshot (immutable after run creation)
+
+A run snapshot is the frozen copy of the relevant seed state captured **at run creation**. It exists so historical reads and historical behavior are stable even if seed state changes later.
+
+- **Naming**: new snapshot tables use the `run_*` prefix.
+- **Lifecycle**: created atomically with run creation; immutable afterward.
+- **Purpose**: historical runs must not be reinterpreted based on later edits.
+
+### Turn events (append-only history)
+
+Turn events are immutable per-turn outputs produced during a run. They represent “what happened during this run” and should never be edited to represent baseline state.
+
+- **Naming**: new per-turn tables use the `turn_*` prefix.
+- **Lifecycle**: append-only; writes are run-scoped; rows include non-null `run_id` and non-null `turn_number`.
+- **Legacy-named turn-event tables (current schema)**:
+  - `generated_feeds`
+  - `likes`
+  - `comments`
+  - `follows`
+  - `turn_metadata`
+  - `turn_metrics`
+
+## How the current schema maps to scopes
+
+This document describes intended semantics, not table renames. The current table set in `db/schema.py` already spans multiple scopes:
+
+- **Run identity and run-level summaries**:
+  - `runs` (run identity/config/status)
+  - `run_metrics` (run-level derived outputs)
+- **Turn events**:
+  - `turn_metadata`, `turn_metrics`
+  - `generated_feeds`, `likes`, `comments`, `follows`
+- **Seed state**:
+  - `agent`, `agent_persona_bios`, `user_agent_profile_metadata`
+- **Out-of-scope / supporting tables** (not governed by the `agent_*`/`run_*`/`turn_*` convention):
+  - `app_users` (app/auth)
+  - `bluesky_profiles`, `feed_posts`, `agent_bios` (ingest/enrichment/legacy seed substrate)
+
+## Core contract rules
+
+1. **Do not mix lifecycles inside one table.** If it should exist with no run, it is seed state. If it has `turn_number`, it is a turn event. If it must remain stable for history after edits, it must be snapshotted into `run_*` at run creation time.
+2. **Historical reads must not consult live seed state for behaviorally relevant values.** History pages and run replays should be backed by `run_*` and turn-event tables.
+3. **Do not overload event tables to store seed state.** The existing `likes/comments/follows` are turn events; they are not a place to store initialized “baseline” relationships.
+
+## Explicit bans (reviewer-fast-fail)
+
+The following patterns are incorrect by design and should be rejected in review:
+
+- A mixed-lifecycle table that stores seed state and events together by making `run_id` or `turn_number` nullable.
+- A single table re-used for baseline and events by adding a lifecycle-collapsing discriminator such as `source = manual | simulation`.
+
+## Migration/backfill semantics (counts vs rows)
+
+- **Counts are lossy**. Summary fields like `followers_count`, `follows_count`, `posts_count` are allowed as caches, but they do not imply the underlying row-level facts.
+- **Row-level facts must come from row-level source data**. Follow edges, posts, likes, and comments may only be migrated/backfilled when there is row-level source data to infer them from. Do not synthesize interaction rows from aggregate counters.
+
+## Non-goals for PR 1
+
+- No schema changes or Alembic migrations.
+- No new `agent_*` or `run_*` tables yet.
+- No runtime behavior changes, simulation startup cutovers, or history endpoint changes.

--- a/docs/plans/2026-03-10_pr1_persistence_contract_55fdb4/plan.md
+++ b/docs/plans/2026-03-10_pr1_persistence_contract_55fdb4/plan.md
@@ -1,0 +1,161 @@
+---
+description: PR 1 plan for codifying persistence scopes (seed state vs run snapshot vs turn events) and adding schema-convention guardrails.
+tags: [plan, architecture, persistence, schema, linting]
+name: PR1 persistence contract
+overview: "Plan the first migration PR as a contract-setting change: document the persistence-scope model and add lightweight schema guardrails, without introducing new tables or runtime behavior changes."
+todos:
+  - id: write-persistence-contract-docs
+    content: Add the persistence-scope contract to docs/RULES.md and a new docs/architecture/seed-state-run-snapshot-turn-events.md doc, then surface it from docs/README.md.
+    status: completed
+  - id: add-schema-lint-tests
+    content: Write focused tests for a new schema-convention linter before implementing the linter itself.
+    status: completed
+  - id: implement-schema-lint
+    content: Add scripts/lint_schema_conventions.py to enforce the new scope rules against db.schema.metadata.
+    status: completed
+  - id: wire-guardrails
+    content: Hook the schema-convention linter into pre-commit and CI, keeping the PR limited to contract enforcement only.
+    status: completed
+  - id: verify-pr1-scope
+    content: Run markdown, lint, and focused test checks to prove PR 1 changes are docs/guardrail only and do not alter runtime behavior.
+    status: completed
+isProject: false
+---
+
+# PR 1 Persistence Scope Contract
+
+## Remember
+
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- UI changes: agent captures before/after screenshots itself (no README or instructions for the user)
+
+## Overview
+
+This PR should lock in the persistence-scope contract before any new `agent_*` or `run_*` tables land. The implementation should be intentionally narrow: document the canonical model, make it easy for reviewers to reject scope-mixing proposals, and add one lightweight schema guardrail so future schema PRs fail fast if they violate the contract. No Alembic revisions, API changes, runtime behavior changes, or simulation cutovers belong in PR 1.
+
+Plan assets should live under the generated plan folder for this work, following `docs/plans/2026-03-10_pr1_persistence_contract_<hash>/`.
+
+## Happy Flow
+
+1. A reviewer reads the new `Persistence scopes` rules in `[docs/RULES.md](docs/RULES.md)` and sees the canonical contract: editable current state lives in `agent_*`, immutable run-start state lives in `run_*`, and execution history lives in `turn_*` plus the legacy event tables `likes`, `comments`, `follows`, and `generated_feeds`.
+2. The deeper rationale and migration semantics live in a new architecture note at `[docs/architecture/seed-state-run-snapshot-turn-events.md](docs/architecture/seed-state-run-snapshot-turn-events.md)`. That doc explains the legacy exceptions already present in the repo, especially `[db/schema.py](db/schema.py)` tables like `agent`, `agent_persona_bios`, `user_agent_profile_metadata`, `runs`, `run_metrics`, `turn_metadata`, `turn_metrics`, `generated_feeds`, `likes`, `comments`, and `follows`.
+3. `[docs/README.md](docs/README.md)` links to the new architecture note so the contract becomes part of the discoverable documentation surface instead of living only in a temp memo.
+4. A new linter at `[scripts/lint_schema_conventions.py](scripts/lint_schema_conventions.py)` imports `db.schema.metadata`, classifies tables by persistence scope, and enforces only the rules that are mechanically checkable today.
+5. Focused tests in `[tests/lint/test_lint_schema_conventions.py](tests/lint/test_lint_schema_conventions.py)` prove the linter accepts the current schema baseline and rejects representative mixed-scope violations.
+6. Pre-commit and CI run the new guard automatically via `[.pre-commit-config.yaml](.pre-commit-config.yaml)` and `[.github/workflows/ci.yml](.github/workflows/ci.yml)`, so later PRs adding schema can be blocked before review if they blur seed state, run snapshots, and turn events.
+
+## Implementation Steps
+
+### 1. Codify the contract in repo docs
+
+Update `[docs/RULES.md](docs/RULES.md)` by adding a dedicated `Persistence scopes` subsection under or adjacent to the current `Persistence and model boundaries` guidance.
+
+That section should state, in repo-rule language:
+
+- New editable seed-state tables use the `agent_*` namespace.
+- New immutable run-start snapshot tables use the `run_*` namespace.
+- New per-turn execution tables use the `turn_*` namespace.
+- Existing `likes`, `comments`, `follows`, and `generated_feeds` are legacy-named turn-event tables and must keep their current semantics.
+- Existing `agent`, `agent_persona_bios`, and `user_agent_profile_metadata` remain current-state tables even though they predate the naming convention.
+- Historical run reads must not derive behaviorally relevant state from live current-state tables.
+- Do not mix seed state and run/turn history in one table via nullable `run_id`, nullable `turn_number`, or a lifecycle-collapsing `source = manual | simulation` pattern.
+- Counts are caches or summaries; row-level identities may only be migrated from row-level source data.
+
+Add a durable architecture note at `[docs/architecture/seed-state-run-snapshot-turn-events.md](docs/architecture/seed-state-run-snapshot-turn-events.md)`. Keep it narrow and contract-focused rather than turning it into a full migration plan. Recommended sections:
+
+- Problem statement
+- Canonical scopes: current state, run snapshot, turn event
+- Existing-table mapping from `[db/schema.py](db/schema.py)`
+- Naming rules for new tables vs legacy exceptions
+- Backfill contract: counts vs row-level facts
+- Non-goals for PR 1
+
+Update `[docs/README.md](docs/README.md)` to add an `Architecture` or `Data architecture` entry so this document is discoverable.
+
+Do not land updates to `[temp/2026-03-08_data_architecture_rules/](temp/2026-03-08_data_architecture_rules/)` as part of PR 1. Those files are planning inputs, not part of the permanent contract surface.
+
+### 2. Add TDD coverage for the new guardrail
+
+Before implementing the linter, create `[tests/lint/test_lint_schema_conventions.py](tests/lint/test_lint_schema_conventions.py)`.
+
+Model the test shape after the existing custom-linter test pattern in `[tests/lint/test_lint_python_testing_syntax_conventions.py](tests/lint/test_lint_python_testing_syntax_conventions.py)`:
+
+- unit-test the linter entrypoint directly
+- build small temporary schema fixtures or source strings that simulate valid and invalid table definitions
+- assert exit codes and exact rule IDs/messages for failures
+
+Start with a small rule set that is truly enforceable from schema metadata:
+
+- `SCHEMA-1`: `agent_*` tables must not declare `run_id` or `turn_number`.
+- `SCHEMA-2`: `run_*` tables must declare non-null `run_id`.
+- `SCHEMA-3`: `turn_*` tables and legacy turn-event tables (`generated_feeds`, `likes`, `comments`, `follows`, `turn_metadata`, `turn_metrics`) must declare non-null `run_id` and non-null `turn_number`.
+- `SCHEMA-4`: lifecycle rules are prefix-based for new tables, with explicit allowlists for legacy tables that predate the convention.
+
+Do not try to encode every conceptual rule in PR 1. Keep the linter limited to what can be checked deterministically from SQLAlchemy metadata.
+
+### 3. Implement the schema-convention linter
+
+Create `[scripts/lint_schema_conventions.py](scripts/lint_schema_conventions.py)`.
+
+Implementation shape:
+
+- Import `metadata` from `[db/schema.py](db/schema.py)` rather than regexing source text.
+- Iterate the SQLAlchemy `Table` objects and inspect names, columns, and nullability.
+- Use explicit classification helpers for:
+  - new `agent_*` tables
+  - new `run_*` tables
+  - new `turn_*` tables
+  - legacy allowlisted current-state tables
+  - legacy allowlisted run/turn tables
+  - out-of-scope/import/auth tables
+- Emit stable `path:line:col [SCHEMA-x] message`-style output where feasible, or a consistent `db/schema.py [SCHEMA-x] ...` format if precise source locations are not worth the complexity.
+- Print a single `OK (...)` success line on a clean run, matching the repo’s existing custom-linter ergonomics.
+
+Keep this linter scoped to schema conventions only. Do not fold service-boundary enforcement into PR 1. Python-layer historical-read rules can come later, once `agent_*` and `run_*` repositories actually exist.
+
+### 4. Wire the guard into the existing quality gates
+
+Add the new linter to `[.pre-commit-config.yaml](.pre-commit-config.yaml)` as a local hook with a clear name such as `db_schema_conventions`.
+
+Update `[.github/workflows/ci.yml](.github/workflows/ci.yml)` so the same command runs in CI. The cleanest placement is the existing `schema` job because this check is about `db/schema.py` conventions, not DI wiring.
+
+If the team wants a short local run command documented, make the smallest possible update to `[docs/runbooks/PRE_COMMIT_AND_LINTING.md](docs/runbooks/PRE_COMMIT_AND_LINTING.md)` so developers know to run:
+
+- `uv run python scripts/lint_schema_conventions.py`
+- `uv run pre-commit run --all-files`
+
+That runbook change is optional but reasonable; prefer one short addition over a brand-new runbook.
+
+### 5. Keep PR 1 intentionally narrow
+
+Explicitly exclude the following from this PR:
+
+- changes to `[db/schema.py](db/schema.py)` table definitions
+- Alembic revisions under `[db/migrations/versions/](db/migrations/versions/)`
+- repository or adapter additions under `[db/repositories/](db/repositories/)` or `[db/adapters/sqlite/](db/adapters/sqlite/)`
+- API changes under `[simulation/api/](simulation/api/)`
+- runtime/simulation behavior changes under `[simulation/core/](simulation/core/)`
+- DB schema docs regeneration under `[docs/db/](docs/db/)` unless a real schema change happens
+
+The only code changes in PR 1 should be guardrail code and its tests. Everything else is documentation.
+
+## Manual Verification
+
+- Read `[docs/RULES.md](docs/RULES.md)` and confirm the new `Persistence scopes` section clearly distinguishes current-state, run-snapshot, and turn-event storage, including the legacy exceptions already present in `[db/schema.py](db/schema.py)`.
+- Read `[docs/architecture/seed-state-run-snapshot-turn-events.md](docs/architecture/seed-state-run-snapshot-turn-events.md)` and confirm it documents the contract and non-goals for PR 1 without drifting into later PR implementation details.
+- Run `uv run pytest tests/lint/test_lint_schema_conventions.py -q` and confirm the focused linter tests pass.
+- Run `uv run python scripts/lint_schema_conventions.py` and confirm the output is a single success line such as `OK (...)` against the current schema.
+- Run `uv run pre-commit run markdownlint --files docs/RULES.md docs/README.md docs/architecture/seed-state-run-snapshot-turn-events.md` and confirm markdown checks pass.
+- If `[docs/runbooks/PRE_COMMIT_AND_LINTING.md](docs/runbooks/PRE_COMMIT_AND_LINTING.md)` is edited, run `uv run python scripts/check_docs_metadata.py docs/runbooks/PRE_COMMIT_AND_LINTING.md` and confirm metadata validation passes.
+- Run `uv run pre-commit run --all-files` and confirm the new schema-convention guard participates cleanly with the existing repo checks.
+- Confirm no Alembic revision, runtime service, API schema, or UI file changed in the PR diff.
+
+## Alternative Approaches
+
+- Docs-only PR with no enforcement: rejected because PR 1 is explicitly supposed to establish a contract reviewers can enforce mechanically, not just describe in prose.
+- Extend `[scripts/lint_architecture.py](scripts/lint_architecture.py)` instead of creating a schema-specific linter: possible, but less clear because the contract here is about persisted table shape rather than DI or Python service wiring. A dedicated schema linter fits the concern better.
+- Defer all enforcement to later migration PRs: rejected because that leaves PR 2 and PR 3 without a hard guardrail during the highest-risk modeling phase.
+- Add broader Python-layer service-boundary rules now: deferred because the future `agent_*` and `run_*` repositories/services do not exist yet, so the rule surface would mostly be speculative in PR 1.
+

--- a/scripts/lint_schema_conventions.py
+++ b/scripts/lint_schema_conventions.py
@@ -1,0 +1,147 @@
+"""Schema convention linter for persistence-scope contracts.
+
+This linter enforces the mechanically-checkable subset of the persistence-scope
+contract documented in:
+- docs/RULES.md (Persistence scopes)
+- docs/architecture/seed-state-run-snapshot-turn-events.md
+
+It is intentionally narrow: it validates only table naming + the presence or
+absence of `run_id`/`turn_number` columns for new tables.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import sqlalchemy as sa
+
+LEGACY_SEED_STATE_TABLES: frozenset[str] = frozenset(
+    {
+        # Seed-state tables that predate the `agent_*` prefix.
+        "agent",
+        "agent_persona_bios",
+        "user_agent_profile_metadata",
+    }
+)
+
+LEGACY_TURN_EVENT_TABLES: frozenset[str] = frozenset(
+    {
+        # Legacy-named turn event tables (treated like `turn_*`).
+        "generated_feeds",
+        "likes",
+        "comments",
+        "follows",
+        # Already-prefixed turn-event tables.
+        "turn_metadata",
+        "turn_metrics",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    rule: str
+    table_name: str
+    message: str
+
+    def format(self) -> str:
+        return f"db/schema.py [{self.rule}] {self.table_name}: {self.message}"
+
+
+def _has_column(table: sa.Table, name: str) -> bool:
+    return name in table.c
+
+
+def _has_nonnull_column(table: sa.Table, name: str) -> bool:
+    col = table.c.get(name)
+    if col is None:
+        return False
+    return col.nullable is False
+
+
+def _lint_agent_table(table: sa.Table) -> Iterable[Violation]:
+    name = table.name
+    if _has_column(table, "run_id"):
+        yield Violation(
+            rule="SCHEMA-1",
+            table_name=name,
+            message="agent_* tables must not declare run_id (seed state must not mix run scope).",
+        )
+    if _has_column(table, "turn_number"):
+        yield Violation(
+            rule="SCHEMA-1",
+            table_name=name,
+            message=(
+                "agent_* tables must not declare turn_number "
+                "(seed state must not mix turn events)."
+            ),
+        )
+
+
+def _lint_run_table(table: sa.Table) -> Iterable[Violation]:
+    name = table.name
+    if not _has_nonnull_column(table, "run_id"):
+        yield Violation(
+            rule="SCHEMA-2",
+            table_name=name,
+            message="run_* tables must declare a non-null run_id column.",
+        )
+
+
+def _lint_turn_event_table(table: sa.Table) -> Iterable[Violation]:
+    name = table.name
+    if not _has_nonnull_column(table, "run_id"):
+        yield Violation(
+            rule="SCHEMA-3",
+            table_name=name,
+            message="turn-event tables must declare a non-null run_id column.",
+        )
+    if not _has_nonnull_column(table, "turn_number"):
+        yield Violation(
+            rule="SCHEMA-3",
+            table_name=name,
+            message="turn-event tables must declare a non-null turn_number column.",
+        )
+
+
+def lint_metadata(metadata: sa.MetaData) -> list[Violation]:
+    """Return violations for the provided SQLAlchemy MetaData."""
+
+    violations: list[Violation] = []
+    for table in metadata.tables.values():
+        name = table.name
+
+        if name.startswith("agent_"):
+            violations.extend(_lint_agent_table(table))
+            continue
+
+        if name.startswith("run_"):
+            violations.extend(_lint_run_table(table))
+            continue
+
+        if name.startswith("turn_") or name in LEGACY_TURN_EVENT_TABLES:
+            violations.extend(_lint_turn_event_table(table))
+            continue
+
+        # Current-state legacy tables and non-governed tables are not linted here.
+
+    return sorted(violations, key=lambda v: (v.rule, v.table_name, v.message))
+
+
+def main() -> int:
+    from db import schema as repo_schema
+
+    violations = lint_metadata(repo_schema.metadata)
+    if violations:
+        for v in violations:
+            print(v.format())
+        return 1
+
+    table_count = len(repo_schema.metadata.tables)
+    print(f"OK ({table_count} tables checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/lint/test_lint_schema_conventions.py
+++ b/tests/lint/test_lint_schema_conventions.py
@@ -1,0 +1,60 @@
+"""Unit tests for scripts/lint_schema_conventions.py."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+
+class TestLintSchemaConventions:
+    def test_accepts_repo_schema_metadata(self):
+        # The linter must accept the current repo schema baseline.
+        from db import schema as repo_schema
+        from scripts import lint_schema_conventions
+
+        violations = lint_schema_conventions.lint_metadata(repo_schema.metadata)
+
+        assert violations == []
+
+    def test_rejects_agent_tables_with_run_id(self):
+        from scripts import lint_schema_conventions
+
+        md = sa.MetaData()
+        sa.Table(
+            "agent_follow_edges",
+            md,
+            sa.Column("id", sa.Text(), primary_key=True),
+            sa.Column("run_id", sa.Text(), nullable=False),
+        )
+
+        violations = lint_schema_conventions.lint_metadata(md)
+
+        assert any(v.rule == "SCHEMA-1" for v in violations)
+
+    def test_rejects_run_tables_missing_run_id(self):
+        from scripts import lint_schema_conventions
+
+        md = sa.MetaData()
+        sa.Table(
+            "run_agents",
+            md,
+            sa.Column("agent_id", sa.Text(), nullable=False),
+        )
+
+        violations = lint_schema_conventions.lint_metadata(md)
+
+        assert any(v.rule == "SCHEMA-2" for v in violations)
+
+    def test_rejects_turn_tables_missing_turn_number(self):
+        from scripts import lint_schema_conventions
+
+        md = sa.MetaData()
+        sa.Table(
+            "turn_posts",
+            md,
+            sa.Column("run_id", sa.Text(), nullable=False),
+            sa.Column("post_id", sa.Text(), nullable=False),
+        )
+
+        violations = lint_schema_conventions.lint_metadata(md)
+
+        assert any(v.rule == "SCHEMA-3" for v in violations)


### PR DESCRIPTION
## Summary
- Document persistence scopes (seed state vs run snapshot vs turn events) and explicitly ban mixed-lifecycle schema patterns.
- Add an architecture note and link it from the docs index.
- Add a schema-convention linter (SCHEMA-1/2/3) with tests, and wire it into pre-commit + CI schema checks.

## Test plan
- [x] `uv run python scripts/lint_schema_conventions.py`
- [x] `uv run pytest tests/lint/test_lint_schema_conventions.py -q`
- [x] `uv run pre-commit run --all-files`

## Notes
- No runtime behavior changes.
- No Alembic migrations or `db/schema.py` changes.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated database schema convention validation to CI pipeline, executing before other schema checks.
  * Integrated new pre-commit hook to enforce schema conventions locally before commits.
  * New linting tool validates schema structure and naming patterns.

* **Tests**
  * Added test coverage for schema convention validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->