### PR TITLE
Agent follow edges table

### DIFF
--- a/db/adapters/base.py
+++ b/db/adapters/base.py
@@ -8,6 +8,7 @@ from typing import Iterable
 
 from simulation.core.models.agent import Agent
 from simulation.core.models.agent_bio import AgentBio
+from simulation.core.models.agent_follow_edge import AgentFollowEdge
 from simulation.core.models.app_user import AppUser
 from simulation.core.models.feeds import GeneratedFeed
 from simulation.core.models.generated.bio import GeneratedBio
@@ -730,6 +731,13 @@ class AgentDatabaseAdapter(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def read_agents_by_ids(
+        self, agent_ids: Iterable[str], *, conn: object
+    ) -> dict[str, Agent | None]:
+        """Read agents for the given agent IDs, keyed by input ID."""
+        raise NotImplementedError
+
+    @abstractmethod
     def read_all_agents(self, *, conn: object) -> list[Agent]:
         """Read all agents. Returns empty list if none exist."""
         raise NotImplementedError
@@ -844,6 +852,63 @@ class UserAgentProfileMetadataDatabaseAdapter(ABC):
     @abstractmethod
     def delete_by_agent_id(self, agent_id: str, *, conn: object) -> None:
         """Delete metadata rows by agent_id."""
+        raise NotImplementedError
+
+
+class AgentFollowEdgeDatabaseAdapter(ABC):
+    """Abstract interface for seed follow-edge database operations."""
+
+    @abstractmethod
+    def write_agent_follow_edge(self, edge: AgentFollowEdge, *, conn: object) -> None:
+        """Insert one seed-state follow edge."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def read_agent_follow_edge(
+        self,
+        follower_agent_id: str,
+        target_agent_id: str,
+        *,
+        conn: object,
+    ) -> AgentFollowEdge | None:
+        """Read one seed-state follow edge by its natural key."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def read_agent_follow_edges_by_follower_agent_id(
+        self,
+        follower_agent_id: str,
+        *,
+        limit: int,
+        offset: int,
+        conn: object,
+    ) -> list[AgentFollowEdge]:
+        """Read follow edges for one follower in deterministic order."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def count_agent_follow_edges_by_follower_agent_id(
+        self, follower_agent_id: str, *, conn: object
+    ) -> int:
+        """Count follow edges where the given agent is the follower."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def count_agent_follow_edges_by_target_agent_id(
+        self, target_agent_id: str, *, conn: object
+    ) -> int:
+        """Count follow edges where the given agent is the target."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete_agent_follow_edge(
+        self,
+        follower_agent_id: str,
+        target_agent_id: str,
+        *,
+        conn: object,
+    ) -> bool:
+        """Delete a seed-state follow edge by its natural key."""
         raise NotImplementedError
 
 

--- a/db/adapters/sqlite/__init__.py
+++ b/db/adapters/sqlite/__init__.py
@@ -2,6 +2,7 @@
 
 from db.adapters.sqlite.agent_adapter import SQLiteAgentAdapter
 from db.adapters.sqlite.agent_bio_adapter import SQLiteAgentBioAdapter
+from db.adapters.sqlite.agent_follow_edge_adapter import SQLiteAgentFollowEdgeAdapter
 from db.adapters.sqlite.app_user_adapter import SQLiteAppUserAdapter
 from db.adapters.sqlite.comment_adapter import SQLiteCommentAdapter
 from db.adapters.sqlite.feed_post_adapter import SQLiteFeedPostAdapter
@@ -20,6 +21,7 @@ __all__ = [
     "SQLiteAppUserAdapter",
     "SQLiteAgentAdapter",
     "SQLiteAgentBioAdapter",
+    "SQLiteAgentFollowEdgeAdapter",
     "SQLiteCommentAdapter",
     "SQLiteFeedPostAdapter",
     "SQLiteFollowAdapter",

--- a/db/adapters/sqlite/agent_adapter.py
+++ b/db/adapters/sqlite/agent_adapter.py
@@ -1,6 +1,7 @@
 """SQLite implementation of agent database adapter."""
 
 import sqlite3
+from collections.abc import Iterable
 
 from db.adapters.base import AgentDatabaseAdapter
 from db.adapters.sqlite.schema_utils import ordered_column_names, required_column_names
@@ -79,6 +80,32 @@ class SQLiteAgentAdapter(AgentDatabaseAdapter):
             return None
         self._validate_agent_row(row)
         return self._row_to_agent(row)
+
+    def read_agents_by_ids(
+        self, agent_ids: Iterable[str], *, conn: sqlite3.Connection
+    ) -> dict[str, Agent | None]:
+        """Read agents keyed by agent_id for the given IDs."""
+        agent_ids_list = list(agent_ids)
+        if not agent_ids_list:
+            return {}
+
+        for agent_id in agent_ids_list:
+            validate_agent_id(agent_id)
+
+        q_marks = ",".join("?" for _ in agent_ids_list)
+        rows = conn.execute(
+            f"SELECT * FROM agent WHERE agent_id IN ({q_marks})",
+            tuple(agent_ids_list),
+        ).fetchall()
+
+        result: dict[str, Agent | None] = {
+            agent_id: None for agent_id in agent_ids_list
+        }
+        for row in rows:
+            self._validate_agent_row(row)
+            agent = self._row_to_agent(row)
+            result[agent.agent_id] = agent
+        return result
 
     def read_all_agents(self, *, conn: sqlite3.Connection) -> list[Agent]:
         """Read all agents, ordered by updated_at DESC, handle ASC for determinism."""

--- a/db/adapters/sqlite/agent_follow_edge_adapter.py
+++ b/db/adapters/sqlite/agent_follow_edge_adapter.py
@@ -1,0 +1,150 @@
+"""SQLite implementation of seed follow-edge database adapter."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from db.adapters.base import AgentFollowEdgeDatabaseAdapter
+from db.adapters.sqlite.schema_utils import ordered_column_names, required_column_names
+from db.adapters.sqlite.sqlite import validate_required_fields
+from db.schema import agent_follow_edges
+from lib.validation_decorators import validate_inputs
+from simulation.core.models.agent_follow_edge import AgentFollowEdge
+from simulation.core.utils.validators import validate_agent_id
+
+from ._validation import _require_sqlite_connection
+
+AGENT_FOLLOW_EDGE_COLUMNS = ordered_column_names(agent_follow_edges)
+AGENT_FOLLOW_EDGE_REQUIRED_FIELDS = required_column_names(agent_follow_edges)
+_INSERT_AGENT_FOLLOW_EDGE_SQL = (
+    f"INSERT INTO agent_follow_edges ({', '.join(AGENT_FOLLOW_EDGE_COLUMNS)}) "
+    f"VALUES ({', '.join('?' for _ in AGENT_FOLLOW_EDGE_COLUMNS)})"
+)
+
+
+class SQLiteAgentFollowEdgeAdapter(AgentFollowEdgeDatabaseAdapter):
+    """SQLite implementation of AgentFollowEdgeDatabaseAdapter."""
+
+    def _validate_agent_follow_edge_row(self, row: sqlite3.Row) -> None:
+        validate_required_fields(row, AGENT_FOLLOW_EDGE_REQUIRED_FIELDS)
+
+    def _row_to_agent_follow_edge(self, row: sqlite3.Row) -> AgentFollowEdge:
+        return AgentFollowEdge(
+            agent_follow_edge_id=row["agent_follow_edge_id"],
+            follower_agent_id=row["follower_agent_id"],
+            target_agent_id=row["target_agent_id"],
+            created_at=row["created_at"],
+        )
+
+    def write_agent_follow_edge(self, edge: AgentFollowEdge, *, conn: object) -> None:
+        """Insert one follow edge row."""
+        sqlite_conn = _require_sqlite_connection(conn)
+        row_values = tuple(getattr(edge, col) for col in AGENT_FOLLOW_EDGE_COLUMNS)
+        sqlite_conn.execute(_INSERT_AGENT_FOLLOW_EDGE_SQL, row_values)
+
+    @validate_inputs(
+        (validate_agent_id, "follower_agent_id"),
+        (validate_agent_id, "target_agent_id"),
+    )
+    def read_agent_follow_edge(
+        self,
+        follower_agent_id: str,
+        target_agent_id: str,
+        *,
+        conn: object,
+    ) -> AgentFollowEdge | None:
+        """Read one follow edge by its natural key."""
+        sqlite_conn = _require_sqlite_connection(conn)
+        row = sqlite_conn.execute(
+            """
+            SELECT *
+            FROM agent_follow_edges
+            WHERE follower_agent_id = ? AND target_agent_id = ?
+            """,
+            (follower_agent_id, target_agent_id),
+        ).fetchone()
+        if row is None:
+            return None
+        self._validate_agent_follow_edge_row(row)
+        return self._row_to_agent_follow_edge(row)
+
+    @validate_inputs((validate_agent_id, "follower_agent_id"))
+    def read_agent_follow_edges_by_follower_agent_id(
+        self,
+        follower_agent_id: str,
+        *,
+        limit: int,
+        offset: int,
+        conn: object,
+    ) -> list[AgentFollowEdge]:
+        """Read follow edges for one follower in deterministic order."""
+        sqlite_conn = _require_sqlite_connection(conn)
+        rows = sqlite_conn.execute(
+            """
+            SELECT *
+            FROM agent_follow_edges
+            WHERE follower_agent_id = ?
+            ORDER BY target_agent_id ASC, agent_follow_edge_id ASC
+            LIMIT ? OFFSET ?
+            """,
+            (follower_agent_id, limit, offset),
+        ).fetchall()
+        result: list[AgentFollowEdge] = []
+        for row in rows:
+            self._validate_agent_follow_edge_row(row)
+            result.append(self._row_to_agent_follow_edge(row))
+        return result
+
+    @validate_inputs((validate_agent_id, "follower_agent_id"))
+    def count_agent_follow_edges_by_follower_agent_id(
+        self, follower_agent_id: str, *, conn: object
+    ) -> int:
+        """Count follow edges where the given agent is the follower."""
+        sqlite_conn = _require_sqlite_connection(conn)
+        row = sqlite_conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM agent_follow_edges
+            WHERE follower_agent_id = ?
+            """,
+            (follower_agent_id,),
+        ).fetchone()
+        return int(row[0])
+
+    @validate_inputs((validate_agent_id, "target_agent_id"))
+    def count_agent_follow_edges_by_target_agent_id(
+        self, target_agent_id: str, *, conn: object
+    ) -> int:
+        """Count follow edges where the given agent is the target."""
+        sqlite_conn = _require_sqlite_connection(conn)
+        row = sqlite_conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM agent_follow_edges
+            WHERE target_agent_id = ?
+            """,
+            (target_agent_id,),
+        ).fetchone()
+        return int(row[0])
+
+    @validate_inputs(
+        (validate_agent_id, "follower_agent_id"),
+        (validate_agent_id, "target_agent_id"),
+    )
+    def delete_agent_follow_edge(
+        self,
+        follower_agent_id: str,
+        target_agent_id: str,
+        *,
+        conn: object,
+    ) -> bool:
+        """Delete one follow edge row by its natural key."""
+        sqlite_conn = _require_sqlite_connection(conn)
+        cursor = sqlite_conn.execute(
+            """
+            DELETE FROM agent_follow_edges
+            WHERE follower_agent_id = ? AND target_agent_id = ?
+            """,
+            (follower_agent_id, target_agent_id),
+        )
+        return cursor.rowcount > 0

--- a/db/migrations/versions/6f2b7c8d9e1a_add_agent_follow_edges.py
+++ b/db/migrations/versions/6f2b7c8d9e1a_add_agent_follow_edges.py
@@ -1,0 +1,78 @@
+"""Add seed-state agent_follow_edges table.
+
+Revision ID: 6f2b7c8d9e1a
+Revises: e1f0d1c2b3a4
+Create Date: 2026-03-13 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "6f2b7c8d9e1a"
+down_revision: Union[str, Sequence[str], None] = "e1f0d1c2b3a4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the agent_follow_edges seed-state table and indexes."""
+    op.create_table(
+        "agent_follow_edges",
+        sa.Column("agent_follow_edge_id", sa.Text(), nullable=False),
+        sa.Column("follower_agent_id", sa.Text(), nullable=False),
+        sa.Column("target_agent_id", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["follower_agent_id"],
+            ["agent.agent_id"],
+            name="fk_agent_follow_edges_follower_agent_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["target_agent_id"],
+            ["agent.agent_id"],
+            name="fk_agent_follow_edges_target_agent_id",
+        ),
+        sa.PrimaryKeyConstraint(
+            "agent_follow_edge_id",
+            name="pk_agent_follow_edges",
+        ),
+        sa.UniqueConstraint(
+            "follower_agent_id",
+            "target_agent_id",
+            name="uq_agent_follow_edges_follower_target",
+        ),
+        sa.CheckConstraint(
+            "follower_agent_id != target_agent_id",
+            name="ck_agent_follow_edges_no_self_follow",
+        ),
+    )
+    op.create_index(
+        "idx_agent_follow_edges_follower_agent_id",
+        "agent_follow_edges",
+        ["follower_agent_id"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_agent_follow_edges_target_agent_id",
+        "agent_follow_edges",
+        ["target_agent_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the agent_follow_edges seed-state table and indexes."""
+    op.drop_index(
+        "idx_agent_follow_edges_target_agent_id",
+        table_name="agent_follow_edges",
+    )
+    op.drop_index(
+        "idx_agent_follow_edges_follower_agent_id",
+        table_name="agent_follow_edges",
+    )
+    op.drop_table("agent_follow_edges")

--- a/db/repositories/agent_follow_edge_repository.py
+++ b/db/repositories/agent_follow_edge_repository.py
@@ -1,0 +1,179 @@
+"""SQLite implementation of seed follow-edge repository."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from db.adapters.base import AgentFollowEdgeDatabaseAdapter, TransactionProvider
+from db.repositories.interfaces import AgentFollowEdgeRepository
+from lib.validation_decorators import validate_inputs
+from simulation.core.models.agent_follow_edge import AgentFollowEdge
+from simulation.core.utils.validators import validate_agent_id
+
+
+class DuplicateAgentFollowEdgeError(Exception):
+    """Raised when a seed follow edge already exists for the same natural key."""
+
+
+class SQLiteAgentFollowEdgeRepository(AgentFollowEdgeRepository):
+    """SQLite implementation of AgentFollowEdgeRepository."""
+
+    def __init__(
+        self,
+        *,
+        db_adapter: AgentFollowEdgeDatabaseAdapter,
+        transaction_provider: TransactionProvider,
+    ):
+        self._db_adapter = db_adapter
+        self._transaction_provider = transaction_provider
+
+    def create_agent_follow_edge(
+        self,
+        edge: AgentFollowEdge,
+        conn: object | None = None,
+    ) -> AgentFollowEdge:
+        """Create one follow edge row."""
+        try:
+            if conn is not None:
+                self._db_adapter.write_agent_follow_edge(edge, conn=conn)
+            else:
+                with self._transaction_provider.run_transaction() as c:
+                    self._db_adapter.write_agent_follow_edge(edge, conn=c)
+        except sqlite3.IntegrityError as exc:
+            if _is_duplicate_agent_follow_edge_integrity_error(exc):
+                raise DuplicateAgentFollowEdgeError(edge.follower_agent_id) from exc
+            raise
+        return edge
+
+    @validate_inputs(
+        (validate_agent_id, "follower_agent_id"),
+        (validate_agent_id, "target_agent_id"),
+    )
+    def get_agent_follow_edge(
+        self,
+        follower_agent_id: str,
+        target_agent_id: str,
+        conn: object | None = None,
+    ) -> AgentFollowEdge | None:
+        """Get one follow edge by natural key."""
+        if conn is not None:
+            return self._db_adapter.read_agent_follow_edge(
+                follower_agent_id,
+                target_agent_id,
+                conn=conn,
+            )
+        with self._transaction_provider.run_transaction() as c:
+            return self._db_adapter.read_agent_follow_edge(
+                follower_agent_id,
+                target_agent_id,
+                conn=c,
+            )
+
+    @validate_inputs((validate_agent_id, "follower_agent_id"))
+    def list_agent_follow_edges_by_follower_agent_id(
+        self,
+        follower_agent_id: str,
+        *,
+        limit: int,
+        offset: int,
+        conn: object | None = None,
+    ) -> list[AgentFollowEdge]:
+        """List follow edges for one follower in deterministic order."""
+        if conn is not None:
+            return self._db_adapter.read_agent_follow_edges_by_follower_agent_id(
+                follower_agent_id,
+                limit=limit,
+                offset=offset,
+                conn=conn,
+            )
+        with self._transaction_provider.run_transaction() as c:
+            return self._db_adapter.read_agent_follow_edges_by_follower_agent_id(
+                follower_agent_id,
+                limit=limit,
+                offset=offset,
+                conn=c,
+            )
+
+    @validate_inputs((validate_agent_id, "follower_agent_id"))
+    def count_agent_follow_edges_by_follower_agent_id(
+        self, follower_agent_id: str, conn: object | None = None
+    ) -> int:
+        """Count follow edges where the given agent is the follower."""
+        if conn is not None:
+            return self._db_adapter.count_agent_follow_edges_by_follower_agent_id(
+                follower_agent_id,
+                conn=conn,
+            )
+        with self._transaction_provider.run_transaction() as c:
+            return self._db_adapter.count_agent_follow_edges_by_follower_agent_id(
+                follower_agent_id,
+                conn=c,
+            )
+
+    @validate_inputs((validate_agent_id, "target_agent_id"))
+    def count_agent_follow_edges_by_target_agent_id(
+        self, target_agent_id: str, conn: object | None = None
+    ) -> int:
+        """Count follow edges where the given agent is the target."""
+        if conn is not None:
+            return self._db_adapter.count_agent_follow_edges_by_target_agent_id(
+                target_agent_id,
+                conn=conn,
+            )
+        with self._transaction_provider.run_transaction() as c:
+            return self._db_adapter.count_agent_follow_edges_by_target_agent_id(
+                target_agent_id,
+                conn=c,
+            )
+
+    @validate_inputs(
+        (validate_agent_id, "follower_agent_id"),
+        (validate_agent_id, "target_agent_id"),
+    )
+    def delete_agent_follow_edge(
+        self,
+        follower_agent_id: str,
+        target_agent_id: str,
+        conn: object | None = None,
+    ) -> bool:
+        """Delete a follow edge by its natural key."""
+        if conn is not None:
+            return self._db_adapter.delete_agent_follow_edge(
+                follower_agent_id,
+                target_agent_id,
+                conn=conn,
+            )
+        with self._transaction_provider.run_transaction() as c:
+            return self._db_adapter.delete_agent_follow_edge(
+                follower_agent_id,
+                target_agent_id,
+                conn=c,
+            )
+
+
+def create_sqlite_agent_follow_edge_repository(
+    *,
+    transaction_provider: TransactionProvider,
+) -> SQLiteAgentFollowEdgeRepository:
+    """Factory to create SQLiteAgentFollowEdgeRepository with default dependencies."""
+    from db.adapters.sqlite import SQLiteAgentFollowEdgeAdapter
+
+    return SQLiteAgentFollowEdgeRepository(
+        db_adapter=SQLiteAgentFollowEdgeAdapter(),
+        transaction_provider=transaction_provider,
+    )
+
+
+def _is_duplicate_agent_follow_edge_integrity_error(
+    exc: sqlite3.IntegrityError,
+) -> bool:
+    """Return True when SQLite surfaced the natural-key uniqueness constraint."""
+    message = str(exc)
+    return (
+        "uq_agent_follow_edges_follower_target" in message
+        or (
+            "UNIQUE constraint failed: agent_follow_edges.follower_agent_id,"
+            " agent_follow_edges.target_agent_id"
+        )
+        in message
+    )

--- a/db/repositories/agent_repository.py
+++ b/db/repositories/agent_repository.py
@@ -1,5 +1,7 @@
 """SQLite implementation of agent repositories."""
 
+from collections.abc import Iterable
+
 from db.adapters.base import AgentDatabaseAdapter, TransactionProvider
 from db.repositories.interfaces import AgentRepository
 from lib.validation_decorators import validate_inputs
@@ -30,16 +32,31 @@ class SQLiteAgentRepository(AgentRepository):
         return agent
 
     @validate_inputs((validate_agent_id, "agent_id"))
-    def get_agent(self, agent_id: str) -> Agent | None:
+    def get_agent(self, agent_id: str, conn: object | None = None) -> Agent | None:
         """Get an agent by ID."""
+        if conn is not None:
+            return self._db_adapter.read_agent(agent_id, conn=conn)
         with self._transaction_provider.run_transaction() as c:
             return self._db_adapter.read_agent(agent_id, conn=c)
 
     @validate_inputs((validate_handle_exists, "handle"))
-    def get_agent_by_handle(self, handle: str) -> Agent | None:
+    def get_agent_by_handle(
+        self, handle: str, conn: object | None = None
+    ) -> Agent | None:
         """Get an agent by handle."""
+        if conn is not None:
+            return self._db_adapter.read_agent_by_handle(handle, conn=conn)
         with self._transaction_provider.run_transaction() as c:
             return self._db_adapter.read_agent_by_handle(handle, conn=c)
+
+    def get_agents_by_ids(
+        self, agent_ids: Iterable[str], conn: object | None = None
+    ) -> dict[str, Agent | None]:
+        """Return agents keyed by agent_id for the given IDs."""
+        if conn is not None:
+            return self._db_adapter.read_agents_by_ids(agent_ids, conn=conn)
+        with self._transaction_provider.run_transaction() as c:
+            return self._db_adapter.read_agents_by_ids(agent_ids, conn=c)
 
     def list_all_agents(self) -> list[Agent]:
         """List all agents, ordered by updated_at DESC and handle ASC."""

--- a/db/repositories/interfaces.py
+++ b/db/repositories/interfaces.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 
 from simulation.core.models.agent import Agent
 from simulation.core.models.agent_bio import AgentBio
+from simulation.core.models.agent_follow_edge import AgentFollowEdge
 from simulation.core.models.app_user import AppUser
 from simulation.core.models.feeds import GeneratedFeed
 from simulation.core.models.generated.bio import GeneratedBio
@@ -38,13 +39,22 @@ class AgentRepository(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_agent(self, agent_id: str) -> Agent | None:
+    def get_agent(self, agent_id: str, conn: object | None = None) -> Agent | None:
         """Get an agent by ID."""
         raise NotImplementedError
 
     @abstractmethod
-    def get_agent_by_handle(self, handle: str) -> Agent | None:
+    def get_agent_by_handle(
+        self, handle: str, conn: object | None = None
+    ) -> Agent | None:
         """Get an agent by handle."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_agents_by_ids(
+        self, agent_ids: Iterable[str], conn: object | None = None
+    ) -> dict[str, Agent | None]:
+        """Return agents keyed by agent_id for the given IDs."""
         raise NotImplementedError
 
     @abstractmethod
@@ -116,13 +126,15 @@ class UserAgentProfileMetadataRepository(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_by_agent_id(self, agent_id: str) -> UserAgentProfileMetadata | None:
+    def get_by_agent_id(
+        self, agent_id: str, conn: object | None = None
+    ) -> UserAgentProfileMetadata | None:
         """Get metadata by agent_id."""
         raise NotImplementedError
 
     @abstractmethod
     def get_metadata_by_agent_ids(
-        self, agent_ids: Iterable[str]
+        self, agent_ids: Iterable[str], conn: object | None = None
     ) -> dict[str, UserAgentProfileMetadata | None]:
         """Return metadata per agent_id for the given agent IDs.
 
@@ -133,6 +145,65 @@ class UserAgentProfileMetadataRepository(ABC):
     @abstractmethod
     def delete_by_agent_id(self, agent_id: str, conn: object | None = None) -> None:
         """Delete metadata by agent_id."""
+        raise NotImplementedError
+
+
+class AgentFollowEdgeRepository(ABC):
+    """Abstract base class defining the interface for seed follow-edge repositories."""
+
+    @abstractmethod
+    def create_agent_follow_edge(
+        self,
+        edge: AgentFollowEdge,
+        conn: object | None = None,
+    ) -> AgentFollowEdge:
+        """Create one seed-state follow edge."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_agent_follow_edge(
+        self,
+        follower_agent_id: str,
+        target_agent_id: str,
+        conn: object | None = None,
+    ) -> AgentFollowEdge | None:
+        """Get a seed-state follow edge by its natural key."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_agent_follow_edges_by_follower_agent_id(
+        self,
+        follower_agent_id: str,
+        *,
+        limit: int,
+        offset: int,
+        conn: object | None = None,
+    ) -> list[AgentFollowEdge]:
+        """List follow edges for one follower in deterministic order."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def count_agent_follow_edges_by_follower_agent_id(
+        self, follower_agent_id: str, conn: object | None = None
+    ) -> int:
+        """Count follow edges where the given agent is the follower."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def count_agent_follow_edges_by_target_agent_id(
+        self, target_agent_id: str, conn: object | None = None
+    ) -> int:
+        """Count follow edges where the given agent is the target."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete_agent_follow_edge(
+        self,
+        follower_agent_id: str,
+        target_agent_id: str,
+        conn: object | None = None,
+    ) -> bool:
+        """Delete a seed-state follow edge by its natural key."""
         raise NotImplementedError
 
 

--- a/db/repositories/user_agent_profile_metadata_repository.py
+++ b/db/repositories/user_agent_profile_metadata_repository.py
@@ -37,15 +37,21 @@ class SQLiteUserAgentProfileMetadataRepository(UserAgentProfileMetadataRepositor
         return metadata
 
     @validate_inputs((validate_agent_id, "agent_id"))
-    def get_by_agent_id(self, agent_id: str) -> UserAgentProfileMetadata | None:
+    def get_by_agent_id(
+        self, agent_id: str, conn: object | None = None
+    ) -> UserAgentProfileMetadata | None:
         """Get metadata by agent_id."""
+        if conn is not None:
+            return self._db_adapter.read_by_agent_id(agent_id, conn=conn)
         with self._transaction_provider.run_transaction() as c:
             return self._db_adapter.read_by_agent_id(agent_id, conn=c)
 
     def get_metadata_by_agent_ids(
-        self, agent_ids: Iterable[str]
+        self, agent_ids: Iterable[str], conn: object | None = None
     ) -> dict[str, UserAgentProfileMetadata | None]:
         """Return metadata per agent_id for the given agent IDs."""
+        if conn is not None:
+            return self._db_adapter.read_metadata_by_agent_ids(agent_ids, conn=conn)
         with self._transaction_provider.run_transaction() as c:
             return self._db_adapter.read_metadata_by_agent_ids(agent_ids, conn=c)
 

--- a/db/schema.py
+++ b/db/schema.py
@@ -204,6 +204,34 @@ user_agent_profile_metadata = sa.Table(
     sa.UniqueConstraint("agent_id", name="uq_user_agent_profile_metadata_agent_id"),
 )
 
+agent_follow_edges = sa.Table(
+    "agent_follow_edges",
+    metadata,
+    sa.Column("agent_follow_edge_id", sa.Text(), primary_key=True),
+    sa.Column("follower_agent_id", sa.Text(), nullable=False),
+    sa.Column("target_agent_id", sa.Text(), nullable=False),
+    sa.Column("created_at", sa.Text(), nullable=False),
+    sa.ForeignKeyConstraint(
+        ["follower_agent_id"],
+        ["agent.agent_id"],
+        name="fk_agent_follow_edges_follower_agent_id",
+    ),
+    sa.ForeignKeyConstraint(
+        ["target_agent_id"],
+        ["agent.agent_id"],
+        name="fk_agent_follow_edges_target_agent_id",
+    ),
+    sa.UniqueConstraint(
+        "follower_agent_id",
+        "target_agent_id",
+        name="uq_agent_follow_edges_follower_target",
+    ),
+    sa.CheckConstraint(
+        "follower_agent_id != target_agent_id",
+        name="ck_agent_follow_edges_no_self_follow",
+    ),
+)
+
 
 # --- Run-scoped action tables (likes, comments, follows) ---
 
@@ -302,6 +330,14 @@ sa.Index(
     "idx_agent_persona_bios_agent_id_created_at",
     agent_persona_bios.c.agent_id,
     agent_persona_bios.c.created_at.desc(),
+)
+sa.Index(
+    "idx_agent_follow_edges_follower_agent_id",
+    agent_follow_edges.c.follower_agent_id,
+)
+sa.Index(
+    "idx_agent_follow_edges_target_agent_id",
+    agent_follow_edges.c.target_agent_id,
 )
 sa.Index(
     "idx_likes_run_turn_agent",

--- a/docs/db/2026_03_13-231045-cursor__agent-follow-edges-table-6ec4/schema.md
+++ b/docs/db/2026_03_13-231045-cursor__agent-follow-edges-table-6ec4/schema.md
@@ -1,0 +1,618 @@
+# Database schema (Alembic migrations @ head)
+
+## Mermaid Diagram
+
+```mermaid
+erDiagram
+  agent {
+    TEXT agent_id PK
+    TEXT handle
+    TEXT persona_source
+    TEXT display_name
+    TEXT created_at
+    TEXT updated_at
+  }
+  agent_bios {
+    TEXT handle PK
+    TEXT generated_bio
+    TEXT created_at
+  }
+  agent_follow_edges {
+    TEXT agent_follow_edge_id PK
+    TEXT follower_agent_id FK
+    TEXT target_agent_id FK
+    TEXT created_at
+  }
+  agent_persona_bios {
+    TEXT id PK
+    TEXT agent_id FK
+    TEXT persona_bio
+    TEXT persona_bio_source
+    TEXT created_at
+    TEXT updated_at
+  }
+  app_users {
+    TEXT id PK
+    TEXT auth_provider_id
+    TEXT email
+    TEXT display_name
+    TEXT created_at
+    TEXT last_seen_at
+  }
+  bluesky_profiles {
+    TEXT handle PK
+    TEXT did
+    TEXT display_name
+    TEXT bio
+    INTEGER followers_count
+    INTEGER follows_count
+    INTEGER posts_count
+  }
+  comments {
+    TEXT comment_id PK
+    TEXT run_id FK
+    INTEGER turn_number
+    TEXT agent_handle
+    TEXT post_id
+    TEXT text
+    TEXT created_at
+    TEXT explanation
+    TEXT model_used
+    TEXT generation_metadata_json
+    TEXT generation_created_at
+  }
+  feed_posts {
+    TEXT post_id PK
+    TEXT source
+    TEXT uri
+    TEXT author_display_name
+    TEXT author_handle
+    TEXT text
+    INTEGER bookmark_count
+    INTEGER like_count
+    INTEGER quote_count
+    INTEGER reply_count
+    INTEGER repost_count
+    TEXT created_at
+  }
+  follows {
+    TEXT follow_id PK
+    TEXT run_id FK
+    INTEGER turn_number
+    TEXT agent_handle
+    TEXT user_id
+    TEXT created_at
+    TEXT explanation
+    TEXT model_used
+    TEXT generation_metadata_json
+    TEXT generation_created_at
+  }
+  generated_feeds {
+    TEXT feed_id
+    TEXT run_id PK FK
+    INTEGER turn_number PK
+    TEXT agent_handle PK
+    TEXT post_ids
+    TEXT created_at
+  }
+  likes {
+    TEXT like_id PK
+    TEXT run_id FK
+    INTEGER turn_number
+    TEXT agent_handle
+    TEXT post_id
+    TEXT created_at
+    TEXT explanation
+    TEXT model_used
+    TEXT generation_metadata_json
+    TEXT generation_created_at
+  }
+  run_metrics {
+    TEXT run_id PK FK
+    TEXT metrics
+    TEXT created_at
+  }
+  runs {
+    TEXT run_id PK
+    TEXT created_at
+    INTEGER total_turns
+    INTEGER total_agents
+    TEXT started_at
+    TEXT status
+    TEXT completed_at
+    TEXT feed_algorithm
+    TEXT metric_keys
+    TEXT app_user_id
+  }
+  turn_metadata {
+    TEXT run_id PK FK
+    INTEGER turn_number PK
+    TEXT total_actions
+    TEXT created_at
+  }
+  turn_metrics {
+    TEXT run_id PK FK
+    INTEGER turn_number PK
+    TEXT metrics
+    TEXT created_at
+  }
+  user_agent_profile_metadata {
+    TEXT id PK
+    TEXT agent_id FK
+    INTEGER followers_count
+    INTEGER follows_count
+    INTEGER posts_count
+    TEXT created_at
+    TEXT updated_at
+  }
+  agent ||--o{ agent_follow_edges : "fk_agent_follow_edges_follower_agent_id (follower_agent_id)"
+  agent ||--o{ agent_follow_edges : "fk_agent_follow_edges_target_agent_id (target_agent_id)"
+  agent ||--o{ agent_persona_bios : "fk_agent_persona_bios_agent_id (agent_id)"
+  agent ||--o{ user_agent_profile_metadata : "fk_user_agent_profile_metadata_agent_id (agent_id)"
+  runs ||--o{ comments : "fk_comments_run_id (run_id)"
+  runs ||--o{ follows : "fk_follows_run_id (run_id)"
+  runs ||--o{ generated_feeds : "fk_generated_feeds_run_id (run_id)"
+  runs ||--o{ likes : "fk_likes_run_id (run_id)"
+  runs ||--o{ run_metrics : "fk_run_metrics_run_id (run_id)"
+  runs ||--o{ turn_metadata : "fk_turn_metadata_run_id (run_id)"
+  runs ||--o{ turn_metrics : "fk_turn_metrics_run_id (run_id)"
+```
+
+This documentation is generated from a fresh SQLite database after applying Alembic migrations to `head`.
+
+## `agent`
+
+### Columns (`agent`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `agent_id` | `TEXT` | no | `` | `1` |
+| `handle` | `TEXT` | no | `` | `` |
+| `persona_source` | `TEXT` | no | `` | `` |
+| `display_name` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+| `updated_at` | `TEXT` | no | `` | `` |
+
+### Primary key (`agent`)
+
+- Name: `pk_agent`
+- Columns: `agent_id`
+
+### Unique constraints (`agent`)
+
+- `uq_agent_handle`: `handle`
+
+### Referenced by (`agent`)
+
+- `agent_follow_edges` `fk_agent_follow_edges_follower_agent_id`: `follower_agent_id` → `agent_id`
+- `agent_follow_edges` `fk_agent_follow_edges_target_agent_id`: `target_agent_id` → `agent_id`
+- `agent_persona_bios` `fk_agent_persona_bios_agent_id`: `agent_id` → `agent_id`
+- `user_agent_profile_metadata` `fk_user_agent_profile_metadata_agent_id`: `agent_id` → `agent_id`
+
+## `agent_bios`
+
+### Columns (`agent_bios`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `handle` | `TEXT` | no | `` | `1` |
+| `generated_bio` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+
+### Primary key (`agent_bios`)
+
+- Name: (none)
+- Columns: `handle`
+
+## `agent_follow_edges`
+
+### Columns (`agent_follow_edges`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `agent_follow_edge_id` | `TEXT` | no | `` | `1` |
+| `follower_agent_id` | `TEXT` | no | `` | `` |
+| `target_agent_id` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+
+### Primary key (`agent_follow_edges`)
+
+- Name: `pk_agent_follow_edges`
+- Columns: `agent_follow_edge_id`
+
+### Foreign keys (`agent_follow_edges`)
+
+- `fk_agent_follow_edges_follower_agent_id`: `follower_agent_id` → `agent(agent_id)`
+- `fk_agent_follow_edges_target_agent_id`: `target_agent_id` → `agent(agent_id)`
+
+### Unique constraints (`agent_follow_edges`)
+
+- `uq_agent_follow_edges_follower_target`: `follower_agent_id`, `target_agent_id`
+
+### Indexes (`agent_follow_edges`)
+
+- `idx_agent_follow_edges_follower_agent_id`: `follower_agent_id`
+- `idx_agent_follow_edges_target_agent_id`: `target_agent_id`
+
+### Check constraints (`agent_follow_edges`)
+
+- `ck_agent_follow_edges_no_self_follow`: `follower_agent_id != target_agent_id`
+
+## `agent_persona_bios`
+
+### Columns (`agent_persona_bios`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `id` | `TEXT` | no | `` | `1` |
+| `agent_id` | `TEXT` | no | `` | `` |
+| `persona_bio` | `TEXT` | no | `` | `` |
+| `persona_bio_source` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+| `updated_at` | `TEXT` | no | `` | `` |
+
+### Primary key (`agent_persona_bios`)
+
+- Name: `pk_agent_persona_bios`
+- Columns: `id`
+
+### Foreign keys (`agent_persona_bios`)
+
+- `fk_agent_persona_bios_agent_id`: `agent_id` → `agent(agent_id)`
+
+### Indexes (`agent_persona_bios`)
+
+- `idx_agent_persona_bios_agent_id_created_at`: `agent_id`, `created_at`
+
+## `app_users`
+
+### Columns (`app_users`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `id` | `TEXT` | no | `` | `1` |
+| `auth_provider_id` | `TEXT` | no | `` | `` |
+| `email` | `TEXT` | no | `` | `` |
+| `display_name` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+| `last_seen_at` | `TEXT` | no | `` | `` |
+
+### Primary key (`app_users`)
+
+- Name: (none)
+- Columns: `id`
+
+### Indexes (`app_users`)
+
+- `idx_app_users_auth_provider_id`: unique `auth_provider_id`
+
+## `bluesky_profiles`
+
+### Columns (`bluesky_profiles`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `handle` | `TEXT` | no | `` | `1` |
+| `did` | `TEXT` | no | `` | `` |
+| `display_name` | `TEXT` | no | `` | `` |
+| `bio` | `TEXT` | no | `` | `` |
+| `followers_count` | `INTEGER` | no | `` | `` |
+| `follows_count` | `INTEGER` | no | `` | `` |
+| `posts_count` | `INTEGER` | no | `` | `` |
+
+### Primary key (`bluesky_profiles`)
+
+- Name: (none)
+- Columns: `handle`
+
+## `comments`
+
+### Columns (`comments`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `comment_id` | `TEXT` | no | `` | `1` |
+| `run_id` | `TEXT` | no | `` | `` |
+| `turn_number` | `INTEGER` | no | `` | `` |
+| `agent_handle` | `TEXT` | no | `` | `` |
+| `post_id` | `TEXT` | no | `` | `` |
+| `text` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+| `explanation` | `TEXT` | yes | `` | `` |
+| `model_used` | `TEXT` | yes | `` | `` |
+| `generation_metadata_json` | `TEXT` | yes | `` | `` |
+| `generation_created_at` | `TEXT` | yes | `` | `` |
+
+### Primary key (`comments`)
+
+- Name: `pk_comments`
+- Columns: `comment_id`
+
+### Foreign keys (`comments`)
+
+- `fk_comments_run_id`: `run_id` → `runs(run_id)`
+
+### Unique constraints (`comments`)
+
+- `uq_comments_run_turn_agent_post`: `run_id`, `turn_number`, `agent_handle`, `post_id`
+
+### Indexes (`comments`)
+
+- `idx_comments_run_turn_agent`: `run_id`, `turn_number`, `agent_handle`
+
+### Check constraints (`comments`)
+
+- `ck_comments_turn_number_gte_0`: `turn_number >= 0`
+
+## `feed_posts`
+
+### Columns (`feed_posts`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `post_id` | `TEXT` | no | `` | `1` |
+| `source` | `TEXT` | no | `` | `` |
+| `uri` | `TEXT` | no | `` | `` |
+| `author_display_name` | `TEXT` | no | `` | `` |
+| `author_handle` | `TEXT` | no | `` | `` |
+| `text` | `TEXT` | no | `` | `` |
+| `bookmark_count` | `INTEGER` | no | `` | `` |
+| `like_count` | `INTEGER` | no | `` | `` |
+| `quote_count` | `INTEGER` | no | `` | `` |
+| `reply_count` | `INTEGER` | no | `` | `` |
+| `repost_count` | `INTEGER` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+
+### Primary key (`feed_posts`)
+
+- Name: (none)
+- Columns: `post_id`
+
+### Indexes (`feed_posts`)
+
+- `idx_feed_posts_author_handle`: `author_handle`
+
+## `follows`
+
+### Columns (`follows`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `follow_id` | `TEXT` | no | `` | `1` |
+| `run_id` | `TEXT` | no | `` | `` |
+| `turn_number` | `INTEGER` | no | `` | `` |
+| `agent_handle` | `TEXT` | no | `` | `` |
+| `user_id` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+| `explanation` | `TEXT` | yes | `` | `` |
+| `model_used` | `TEXT` | yes | `` | `` |
+| `generation_metadata_json` | `TEXT` | yes | `` | `` |
+| `generation_created_at` | `TEXT` | yes | `` | `` |
+
+### Primary key (`follows`)
+
+- Name: `pk_follows`
+- Columns: `follow_id`
+
+### Foreign keys (`follows`)
+
+- `fk_follows_run_id`: `run_id` → `runs(run_id)`
+
+### Unique constraints (`follows`)
+
+- `uq_follows_run_turn_agent_user`: `run_id`, `turn_number`, `agent_handle`, `user_id`
+
+### Indexes (`follows`)
+
+- `idx_follows_run_turn_agent`: `run_id`, `turn_number`, `agent_handle`
+
+### Check constraints (`follows`)
+
+- `ck_follows_turn_number_gte_0`: `turn_number >= 0`
+
+## `generated_feeds`
+
+### Columns (`generated_feeds`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `feed_id` | `TEXT` | no | `` | `` |
+| `run_id` | `TEXT` | no | `` | `2` |
+| `turn_number` | `INTEGER` | no | `` | `3` |
+| `agent_handle` | `TEXT` | no | `` | `1` |
+| `post_ids` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+
+### Primary key (`generated_feeds`)
+
+- Name: `pk_generated_feeds`
+- Columns: `agent_handle`, `run_id`, `turn_number`
+
+### Foreign keys (`generated_feeds`)
+
+- `fk_generated_feeds_run_id`: `run_id` → `runs(run_id)`
+
+## `likes`
+
+### Columns (`likes`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `like_id` | `TEXT` | no | `` | `1` |
+| `run_id` | `TEXT` | no | `` | `` |
+| `turn_number` | `INTEGER` | no | `` | `` |
+| `agent_handle` | `TEXT` | no | `` | `` |
+| `post_id` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+| `explanation` | `TEXT` | yes | `` | `` |
+| `model_used` | `TEXT` | yes | `` | `` |
+| `generation_metadata_json` | `TEXT` | yes | `` | `` |
+| `generation_created_at` | `TEXT` | yes | `` | `` |
+
+### Primary key (`likes`)
+
+- Name: `pk_likes`
+- Columns: `like_id`
+
+### Foreign keys (`likes`)
+
+- `fk_likes_run_id`: `run_id` → `runs(run_id)`
+
+### Unique constraints (`likes`)
+
+- `uq_likes_run_turn_agent_post`: `run_id`, `turn_number`, `agent_handle`, `post_id`
+
+### Indexes (`likes`)
+
+- `idx_likes_run_turn_agent`: `run_id`, `turn_number`, `agent_handle`
+
+### Check constraints (`likes`)
+
+- `ck_likes_turn_number_gte_0`: `turn_number >= 0`
+
+## `run_metrics`
+
+### Columns (`run_metrics`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `run_id` | `TEXT` | no | `` | `1` |
+| `metrics` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+
+### Primary key (`run_metrics`)
+
+- Name: `pk_run_metrics`
+- Columns: `run_id`
+
+### Foreign keys (`run_metrics`)
+
+- `fk_run_metrics_run_id`: `run_id` → `runs(run_id)`
+
+## `runs`
+
+### Columns (`runs`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `run_id` | `TEXT` | no | `` | `1` |
+| `created_at` | `TEXT` | no | `` | `` |
+| `total_turns` | `INTEGER` | no | `` | `` |
+| `total_agents` | `INTEGER` | no | `` | `` |
+| `started_at` | `TEXT` | no | `` | `` |
+| `status` | `TEXT` | no | `` | `` |
+| `completed_at` | `TEXT` | yes | `` | `` |
+| `feed_algorithm` | `TEXT` | no | `'chronological'` | `` |
+| `metric_keys` | `TEXT` | yes | `` | `` |
+| `app_user_id` | `TEXT` | yes | `` | `` |
+
+### Primary key (`runs`)
+
+- Name: (none)
+- Columns: `run_id`
+
+### Indexes (`runs`)
+
+- `idx_runs_app_user_id`: `app_user_id`
+- `idx_runs_created_at`: `created_at`
+- `idx_runs_status`: `status`
+
+### Check constraints (`runs`)
+
+- `ck_runs_completed_at_consistent`: `((status = 'completed' AND completed_at IS NOT NULL AND completed_at >= started_at) OR (status != 'completed' AND completed_at IS NULL))`
+- `ck_runs_status_valid`: `status IN ('running', 'completed', 'failed')`
+- `ck_runs_total_agents_gt_0`: `total_agents > 0`
+- `ck_runs_total_turns_gt_0`: `total_turns > 0`
+
+### Referenced by (`runs`)
+
+- `comments` `fk_comments_run_id`: `run_id` → `run_id`
+- `follows` `fk_follows_run_id`: `run_id` → `run_id`
+- `generated_feeds` `fk_generated_feeds_run_id`: `run_id` → `run_id`
+- `likes` `fk_likes_run_id`: `run_id` → `run_id`
+- `run_metrics` `fk_run_metrics_run_id`: `run_id` → `run_id`
+- `turn_metadata` `fk_turn_metadata_run_id`: `run_id` → `run_id`
+- `turn_metrics` `fk_turn_metrics_run_id`: `run_id` → `run_id`
+
+## `turn_metadata`
+
+### Columns (`turn_metadata`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `run_id` | `TEXT` | no | `` | `1` |
+| `turn_number` | `INTEGER` | no | `` | `2` |
+| `total_actions` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+
+### Primary key (`turn_metadata`)
+
+- Name: `pk_turn_metadata`
+- Columns: `run_id`, `turn_number`
+
+### Foreign keys (`turn_metadata`)
+
+- `fk_turn_metadata_run_id`: `run_id` → `runs(run_id)`
+
+### Indexes (`turn_metadata`)
+
+- `idx_turn_metadata_run_id`: `run_id`
+
+### Check constraints (`turn_metadata`)
+
+- `ck_turn_metadata_turn_number_gte_0`: `turn_number >= 0`
+
+## `turn_metrics`
+
+### Columns (`turn_metrics`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `run_id` | `TEXT` | no | `` | `1` |
+| `turn_number` | `INTEGER` | no | `` | `2` |
+| `metrics` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+
+### Primary key (`turn_metrics`)
+
+- Name: `pk_turn_metrics`
+- Columns: `run_id`, `turn_number`
+
+### Foreign keys (`turn_metrics`)
+
+- `fk_turn_metrics_run_id`: `run_id` → `runs(run_id)`
+
+### Indexes (`turn_metrics`)
+
+- `idx_turn_metrics_run_id`: `run_id`
+
+### Check constraints (`turn_metrics`)
+
+- `ck_turn_metrics_turn_number_gte_0`: `turn_number >= 0`
+
+## `user_agent_profile_metadata`
+
+### Columns (`user_agent_profile_metadata`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `id` | `TEXT` | no | `` | `1` |
+| `agent_id` | `TEXT` | no | `` | `` |
+| `followers_count` | `INTEGER` | no | `` | `` |
+| `follows_count` | `INTEGER` | no | `` | `` |
+| `posts_count` | `INTEGER` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+| `updated_at` | `TEXT` | no | `` | `` |
+
+### Primary key (`user_agent_profile_metadata`)
+
+- Name: `pk_user_agent_profile_metadata`
+- Columns: `id`
+
+### Foreign keys (`user_agent_profile_metadata`)
+
+- `fk_user_agent_profile_metadata_agent_id`: `agent_id` → `agent(agent_id)`
+
+### Unique constraints (`user_agent_profile_metadata`)
+
+- `uq_user_agent_profile_metadata_agent_id`: `agent_id`

--- a/docs/db/2026_03_13-231045-cursor__agent-follow-edges-table-6ec4/schema.snapshot.json
+++ b/docs/db/2026_03_13-231045-cursor__agent-follow-edges-table-6ec4/schema.snapshot.json
@@ -1,0 +1,1475 @@
+{
+  "dialect": "sqlite",
+  "referenced_by": {
+    "agent": [
+      {
+        "from_columns": [
+          "follower_agent_id"
+        ],
+        "from_table": "agent_follow_edges",
+        "name": "fk_agent_follow_edges_follower_agent_id",
+        "to_columns": [
+          "agent_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "target_agent_id"
+        ],
+        "from_table": "agent_follow_edges",
+        "name": "fk_agent_follow_edges_target_agent_id",
+        "to_columns": [
+          "agent_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "agent_id"
+        ],
+        "from_table": "agent_persona_bios",
+        "name": "fk_agent_persona_bios_agent_id",
+        "to_columns": [
+          "agent_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "agent_id"
+        ],
+        "from_table": "user_agent_profile_metadata",
+        "name": "fk_user_agent_profile_metadata_agent_id",
+        "to_columns": [
+          "agent_id"
+        ]
+      }
+    ],
+    "agent_bios": [],
+    "agent_follow_edges": [],
+    "agent_persona_bios": [],
+    "app_users": [],
+    "bluesky_profiles": [],
+    "comments": [],
+    "feed_posts": [],
+    "follows": [],
+    "generated_feeds": [],
+    "likes": [],
+    "run_metrics": [],
+    "runs": [
+      {
+        "from_columns": [
+          "run_id"
+        ],
+        "from_table": "comments",
+        "name": "fk_comments_run_id",
+        "to_columns": [
+          "run_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id"
+        ],
+        "from_table": "follows",
+        "name": "fk_follows_run_id",
+        "to_columns": [
+          "run_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id"
+        ],
+        "from_table": "generated_feeds",
+        "name": "fk_generated_feeds_run_id",
+        "to_columns": [
+          "run_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id"
+        ],
+        "from_table": "likes",
+        "name": "fk_likes_run_id",
+        "to_columns": [
+          "run_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id"
+        ],
+        "from_table": "run_metrics",
+        "name": "fk_run_metrics_run_id",
+        "to_columns": [
+          "run_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id"
+        ],
+        "from_table": "turn_metadata",
+        "name": "fk_turn_metadata_run_id",
+        "to_columns": [
+          "run_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id"
+        ],
+        "from_table": "turn_metrics",
+        "name": "fk_turn_metrics_run_id",
+        "to_columns": [
+          "run_id"
+        ]
+      }
+    ],
+    "turn_metadata": [],
+    "turn_metrics": [],
+    "user_agent_profile_metadata": []
+  },
+  "tables": {
+    "agent": {
+      "check_constraints": [],
+      "columns": [
+        {
+          "default": null,
+          "name": "agent_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "handle",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "persona_source",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "display_name",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "updated_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "indexes": [],
+      "primary_key": {
+        "columns": [
+          "agent_id"
+        ],
+        "name": "pk_agent"
+      },
+      "unique_constraints": [
+        {
+          "columns": [
+            "handle"
+          ],
+          "name": "uq_agent_handle"
+        }
+      ]
+    },
+    "agent_bios": {
+      "check_constraints": [],
+      "columns": [
+        {
+          "default": null,
+          "name": "handle",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generated_bio",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "indexes": [],
+      "primary_key": {
+        "columns": [
+          "handle"
+        ],
+        "name": null
+      },
+      "unique_constraints": []
+    },
+    "agent_follow_edges": {
+      "check_constraints": [
+        {
+          "name": "ck_agent_follow_edges_no_self_follow",
+          "sqltext": "follower_agent_id != target_agent_id"
+        }
+      ],
+      "columns": [
+        {
+          "default": null,
+          "name": "agent_follow_edge_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "follower_agent_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "target_agent_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "follower_agent_id"
+          ],
+          "name": "fk_agent_follow_edges_follower_agent_id",
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "agent_id"
+          ],
+          "referred_table": "agent"
+        },
+        {
+          "columns": [
+            "target_agent_id"
+          ],
+          "name": "fk_agent_follow_edges_target_agent_id",
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "agent_id"
+          ],
+          "referred_table": "agent"
+        }
+      ],
+      "indexes": [
+        {
+          "columns": [
+            "follower_agent_id"
+          ],
+          "name": "idx_agent_follow_edges_follower_agent_id",
+          "unique": false
+        },
+        {
+          "columns": [
+            "target_agent_id"
+          ],
+          "name": "idx_agent_follow_edges_target_agent_id",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "agent_follow_edge_id"
+        ],
+        "name": "pk_agent_follow_edges"
+      },
+      "unique_constraints": [
+        {
+          "columns": [
+            "follower_agent_id",
+            "target_agent_id"
+          ],
+          "name": "uq_agent_follow_edges_follower_target"
+        }
+      ]
+    },
+    "agent_persona_bios": {
+      "check_constraints": [],
+      "columns": [
+        {
+          "default": null,
+          "name": "id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "agent_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "persona_bio",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "persona_bio_source",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "updated_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "agent_id"
+          ],
+          "name": "fk_agent_persona_bios_agent_id",
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "agent_id"
+          ],
+          "referred_table": "agent"
+        }
+      ],
+      "indexes": [
+        {
+          "columns": [
+            "agent_id",
+            "created_at"
+          ],
+          "name": "idx_agent_persona_bios_agent_id_created_at",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "id"
+        ],
+        "name": "pk_agent_persona_bios"
+      },
+      "unique_constraints": []
+    },
+    "app_users": {
+      "check_constraints": [],
+      "columns": [
+        {
+          "default": null,
+          "name": "id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "auth_provider_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "email",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "display_name",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "last_seen_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "indexes": [
+        {
+          "columns": [
+            "auth_provider_id"
+          ],
+          "name": "idx_app_users_auth_provider_id",
+          "unique": true
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "id"
+        ],
+        "name": null
+      },
+      "unique_constraints": []
+    },
+    "bluesky_profiles": {
+      "check_constraints": [],
+      "columns": [
+        {
+          "default": null,
+          "name": "handle",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "did",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "display_name",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "bio",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "followers_count",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "follows_count",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "posts_count",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        }
+      ],
+      "foreign_keys": [],
+      "indexes": [],
+      "primary_key": {
+        "columns": [
+          "handle"
+        ],
+        "name": null
+      },
+      "unique_constraints": []
+    },
+    "comments": {
+      "check_constraints": [
+        {
+          "name": "ck_comments_turn_number_gte_0",
+          "sqltext": "turn_number >= 0"
+        }
+      ],
+      "columns": [
+        {
+          "default": null,
+          "name": "comment_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "turn_number",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "agent_handle",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "post_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "text",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "explanation",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "model_used",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_metadata_json",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_created_at",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": "fk_comments_run_id",
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id"
+          ],
+          "referred_table": "runs"
+        }
+      ],
+      "indexes": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "agent_handle"
+          ],
+          "name": "idx_comments_run_turn_agent",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "comment_id"
+        ],
+        "name": "pk_comments"
+      },
+      "unique_constraints": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "agent_handle",
+            "post_id"
+          ],
+          "name": "uq_comments_run_turn_agent_post"
+        }
+      ]
+    },
+    "feed_posts": {
+      "check_constraints": [],
+      "columns": [
+        {
+          "default": null,
+          "name": "post_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "source",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "uri",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "author_display_name",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "author_handle",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "text",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "bookmark_count",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "like_count",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "quote_count",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "reply_count",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "repost_count",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "indexes": [
+        {
+          "columns": [
+            "author_handle"
+          ],
+          "name": "idx_feed_posts_author_handle",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "post_id"
+        ],
+        "name": null
+      },
+      "unique_constraints": []
+    },
+    "follows": {
+      "check_constraints": [
+        {
+          "name": "ck_follows_turn_number_gte_0",
+          "sqltext": "turn_number >= 0"
+        }
+      ],
+      "columns": [
+        {
+          "default": null,
+          "name": "follow_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "turn_number",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "agent_handle",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "user_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "explanation",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "model_used",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_metadata_json",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_created_at",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": "fk_follows_run_id",
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id"
+          ],
+          "referred_table": "runs"
+        }
+      ],
+      "indexes": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "agent_handle"
+          ],
+          "name": "idx_follows_run_turn_agent",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "follow_id"
+        ],
+        "name": "pk_follows"
+      },
+      "unique_constraints": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "agent_handle",
+            "user_id"
+          ],
+          "name": "uq_follows_run_turn_agent_user"
+        }
+      ]
+    },
+    "generated_feeds": {
+      "check_constraints": [],
+      "columns": [
+        {
+          "default": null,
+          "name": "feed_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 2,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "turn_number",
+          "nullable": false,
+          "primary_key": 3,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "agent_handle",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "post_ids",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": "fk_generated_feeds_run_id",
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id"
+          ],
+          "referred_table": "runs"
+        }
+      ],
+      "indexes": [],
+      "primary_key": {
+        "columns": [
+          "agent_handle",
+          "run_id",
+          "turn_number"
+        ],
+        "name": "pk_generated_feeds"
+      },
+      "unique_constraints": []
+    },
+    "likes": {
+      "check_constraints": [
+        {
+          "name": "ck_likes_turn_number_gte_0",
+          "sqltext": "turn_number >= 0"
+        }
+      ],
+      "columns": [
+        {
+          "default": null,
+          "name": "like_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "turn_number",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "agent_handle",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "post_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "explanation",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "model_used",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_metadata_json",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_created_at",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": "fk_likes_run_id",
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id"
+          ],
+          "referred_table": "runs"
+        }
+      ],
+      "indexes": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "agent_handle"
+          ],
+          "name": "idx_likes_run_turn_agent",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "like_id"
+        ],
+        "name": "pk_likes"
+      },
+      "unique_constraints": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "agent_handle",
+            "post_id"
+          ],
+          "name": "uq_likes_run_turn_agent_post"
+        }
+      ]
+    },
+    "run_metrics": {
+      "check_constraints": [],
+      "columns": [
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "metrics",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": "fk_run_metrics_run_id",
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id"
+          ],
+          "referred_table": "runs"
+        }
+      ],
+      "indexes": [],
+      "primary_key": {
+        "columns": [
+          "run_id"
+        ],
+        "name": "pk_run_metrics"
+      },
+      "unique_constraints": []
+    },
+    "runs": {
+      "check_constraints": [
+        {
+          "name": "ck_runs_completed_at_consistent",
+          "sqltext": "((status = 'completed' AND completed_at IS NOT NULL AND completed_at >= started_at) OR (status != 'completed' AND completed_at IS NULL))"
+        },
+        {
+          "name": "ck_runs_status_valid",
+          "sqltext": "status IN ('running', 'completed', 'failed')"
+        },
+        {
+          "name": "ck_runs_total_agents_gt_0",
+          "sqltext": "total_agents > 0"
+        },
+        {
+          "name": "ck_runs_total_turns_gt_0",
+          "sqltext": "total_turns > 0"
+        }
+      ],
+      "columns": [
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "total_turns",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "total_agents",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "started_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "status",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "completed_at",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": "'chronological'",
+          "name": "feed_algorithm",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "metric_keys",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "app_user_id",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "indexes": [
+        {
+          "columns": [
+            "app_user_id"
+          ],
+          "name": "idx_runs_app_user_id",
+          "unique": false
+        },
+        {
+          "columns": [
+            "created_at"
+          ],
+          "name": "idx_runs_created_at",
+          "unique": false
+        },
+        {
+          "columns": [
+            "status"
+          ],
+          "name": "idx_runs_status",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "run_id"
+        ],
+        "name": null
+      },
+      "unique_constraints": []
+    },
+    "turn_metadata": {
+      "check_constraints": [
+        {
+          "name": "ck_turn_metadata_turn_number_gte_0",
+          "sqltext": "turn_number >= 0"
+        }
+      ],
+      "columns": [
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "turn_number",
+          "nullable": false,
+          "primary_key": 2,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "total_actions",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": "fk_turn_metadata_run_id",
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id"
+          ],
+          "referred_table": "runs"
+        }
+      ],
+      "indexes": [
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": "idx_turn_metadata_run_id",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "run_id",
+          "turn_number"
+        ],
+        "name": "pk_turn_metadata"
+      },
+      "unique_constraints": []
+    },
+    "turn_metrics": {
+      "check_constraints": [
+        {
+          "name": "ck_turn_metrics_turn_number_gte_0",
+          "sqltext": "turn_number >= 0"
+        }
+      ],
+      "columns": [
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "turn_number",
+          "nullable": false,
+          "primary_key": 2,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "metrics",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": "fk_turn_metrics_run_id",
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id"
+          ],
+          "referred_table": "runs"
+        }
+      ],
+      "indexes": [
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": "idx_turn_metrics_run_id",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "run_id",
+          "turn_number"
+        ],
+        "name": "pk_turn_metrics"
+      },
+      "unique_constraints": []
+    },
+    "user_agent_profile_metadata": {
+      "check_constraints": [],
+      "columns": [
+        {
+          "default": null,
+          "name": "id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "agent_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "followers_count",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "follows_count",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "posts_count",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "updated_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "agent_id"
+          ],
+          "name": "fk_user_agent_profile_metadata_agent_id",
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "agent_id"
+          ],
+          "referred_table": "agent"
+        }
+      ],
+      "indexes": [],
+      "primary_key": {
+        "columns": [
+          "id"
+        ],
+        "name": "pk_user_agent_profile_metadata"
+      },
+      "unique_constraints": [
+        {
+          "columns": [
+            "agent_id"
+          ],
+          "name": "uq_user_agent_profile_metadata_agent_id"
+        }
+      ]
+    }
+  }
+}

--- a/docs/db/LATEST.txt
+++ b/docs/db/LATEST.txt
@@ -1,1 +1,1 @@
-2026_02_26-193638-codex__post-source-refactor
+2026_03_13-231045-cursor__agent-follow-edges-table-6ec4

--- a/docs/plans/2026-03-13_pr3_agent_follow_edges_593821/README.md
+++ b/docs/plans/2026-03-13_pr3_agent_follow_edges_593821/README.md
@@ -1,0 +1,11 @@
+---
+description: Planning notes and verification references for the agent_follow_edges seed-state PR.
+tags: [plan, database, api, agent-follow-edges, seed-state]
+---
+
+# PR-3 agent follow edges
+
+- Assets directory reserved for implementation notes and verification artifacts for the
+  `agent_follow_edges` seed-state table rollout.
+- This PR keeps legacy `follows` as the immutable run-turn event log and adds
+  `agent_follow_edges` for editable pre-run internal agent-to-agent follows.

--- a/simulation/api/constants.py
+++ b/simulation/api/constants.py
@@ -10,6 +10,9 @@ from simulation.core.metrics.defaults import get_default_metric_keys
 DEFAULT_AGENT_LIST_LIMIT: int = 100
 MAX_AGENT_LIST_LIMIT: int = 500
 DEFAULT_AGENT_LIST_OFFSET: int = 0
+DEFAULT_AGENT_FOLLOWS_LIST_LIMIT: int = 100
+MAX_AGENT_FOLLOWS_LIST_LIMIT: int = 500
+DEFAULT_AGENT_FOLLOWS_LIST_OFFSET: int = 0
 
 DEFAULT_SIMULATION_CONFIG: DefaultConfigSchema = DefaultConfigSchema(
     num_agents=5,

--- a/simulation/api/errors.py
+++ b/simulation/api/errors.py
@@ -20,6 +20,32 @@ class ApiAgentNotFoundError(Exception):
         self.handle = handle
 
 
+class ApiTargetAgentNotFoundError(Exception):
+    def __init__(self, handle: str):
+        super().__init__(handle)
+        self.handle = handle
+
+
+class ApiAgentFollowEdgeAlreadyExistsError(Exception):
+    def __init__(self, follower_handle: str, target_handle: str):
+        super().__init__(follower_handle, target_handle)
+        self.follower_handle = follower_handle
+        self.target_handle = target_handle
+
+
+class ApiAgentFollowEdgeNotFoundError(Exception):
+    def __init__(self, follower_handle: str, target_handle: str):
+        super().__init__(follower_handle, target_handle)
+        self.follower_handle = follower_handle
+        self.target_handle = target_handle
+
+
+class ApiSelfFollowNotAllowedError(Exception):
+    def __init__(self, handle: str):
+        super().__init__(handle)
+        self.handle = handle
+
+
 class ApiRunNotFoundError(Exception):
     def __init__(self, run_id: str):
         super().__init__(run_id)

--- a/simulation/api/main.py
+++ b/simulation/api/main.py
@@ -25,6 +25,9 @@ from db.adapters.sqlite.sqlite import (
     initialize_database,
 )
 from db.repositories.agent_bio_repository import create_sqlite_agent_bio_repository
+from db.repositories.agent_follow_edge_repository import (
+    create_sqlite_agent_follow_edge_repository,
+)
 from db.repositories.agent_repository import create_sqlite_agent_repository
 from db.repositories.app_user_repository import create_sqlite_app_user_repository
 from db.repositories.user_agent_profile_metadata_repository import (
@@ -88,6 +91,9 @@ async def lifespan(app: FastAPI):
         transaction_provider=transaction_provider
     )
     app.state.agent_bio_repo = create_sqlite_agent_bio_repository(
+        transaction_provider=transaction_provider
+    )
+    app.state.agent_follow_edge_repo = create_sqlite_agent_follow_edge_repository(
         transaction_provider=transaction_provider
     )
     app.state.agent_metadata_repo = (

--- a/simulation/api/routes/simulation.py
+++ b/simulation/api/routes/simulation.py
@@ -10,23 +10,33 @@ from lib.decorators import timed
 from lib.rate_limiting import RATE_LIMIT_AGENTS_CREATE, limiter
 from lib.request_logging import RunIdSource, log_route_completion_decorator
 from simulation.api.constants import (
+    DEFAULT_AGENT_FOLLOWS_LIST_LIMIT,
+    DEFAULT_AGENT_FOLLOWS_LIST_OFFSET,
     DEFAULT_AGENT_LIST_LIMIT,
     DEFAULT_AGENT_LIST_OFFSET,
     DEFAULT_SIMULATION_CONFIG,
+    MAX_AGENT_FOLLOWS_LIST_LIMIT,
     MAX_AGENT_LIST_LIMIT,
 )
 from simulation.api.dependencies.app_user import require_current_app_user
 from simulation.api.errors import (
+    ApiAgentFollowEdgeAlreadyExistsError,
+    ApiAgentFollowEdgeNotFoundError,
     ApiAgentNotFoundError,
     ApiHandleAlreadyExistsError,
     ApiRunCreationFailedError,
     ApiRunNotFoundError,
+    ApiSelfFollowNotAllowedError,
+    ApiTargetAgentNotFoundError,
 )
 from simulation.api.schemas.simulation import (
+    AgentFollowEdgeSchema,
     AgentSchema,
+    CreateAgentFollowRequest,
     CreateAgentRequest,
     DefaultConfigSchema,
     FeedAlgorithmSchema,
+    ListAgentFollowsResponse,
     MetricSchema,
     PostSchema,
     RunDetailsResponse,
@@ -36,6 +46,11 @@ from simulation.api.schemas.simulation import (
     TurnSchema,
 )
 from simulation.api.services.agent_command_service import create_agent, delete_agent
+from simulation.api.services.agent_follows_command_service import (
+    create_agent_follow,
+    delete_agent_follow,
+)
+from simulation.api.services.agent_follows_query_service import list_agent_follows
 from simulation.api.services.agent_query_service import list_agents
 from simulation.api.services.metadata_service import list_feed_algorithms, list_metrics
 from simulation.api.services.run_execution_service import execute
@@ -59,6 +74,13 @@ SIMULATION_RUN_TURNS_ROUTE: str = "GET /v1/simulations/runs/{run_id}/turns"
 SIMULATION_AGENTS_ROUTE: str = "GET /v1/simulations/agents"
 SIMULATION_AGENTS_CREATE_ROUTE: str = "POST /v1/simulations/agents"
 SIMULATION_AGENTS_DELETE_ROUTE: str = "DELETE /v1/simulations/agents/{handle}"
+SIMULATION_AGENT_FOLLOWS_ROUTE: str = "GET /v1/simulations/agents/{handle}/follows"
+SIMULATION_AGENT_FOLLOWS_CREATE_ROUTE: str = (
+    "POST /v1/simulations/agents/{handle}/follows"
+)
+SIMULATION_AGENT_FOLLOWS_DELETE_ROUTE: str = (
+    "DELETE /v1/simulations/agents/{handle}/follows/{target_handle}"
+)
 SIMULATION_POSTS_ROUTE: str = "GET /v1/simulations/posts"
 SIMULATION_FEED_ALGORITHMS_ROUTE: str = "GET /v1/simulations/feed-algorithms"
 SIMULATION_METRICS_ROUTE: str = "GET /v1/simulations/metrics"
@@ -184,6 +206,88 @@ async def get_simulation_agents(
 async def delete_simulation_agent(request: Request, handle: str) -> Response:
     """Delete an agent and its related data."""
     return await _execute_delete_simulation_agent(request, handle=handle)
+
+
+@router.get(
+    "/simulations/agents/{handle}/follows",
+    response_model=ListAgentFollowsResponse,
+    status_code=200,
+    summary="List editable pre-run follows for an agent",
+    description="Return paginated internal agent-to-agent seed follow edges for the given follower handle.",
+)
+@log_route_completion_decorator(
+    route=SIMULATION_AGENT_FOLLOWS_ROUTE,
+    success_type=ListAgentFollowsResponse,
+)
+async def get_simulation_agent_follows(
+    request: Request,
+    handle: str,
+    limit: int = Query(
+        default=DEFAULT_AGENT_FOLLOWS_LIST_LIMIT,
+        ge=1,
+        le=MAX_AGENT_FOLLOWS_LIST_LIMIT,
+        description="Maximum number of follow edges to return.",
+    ),
+    offset: int = Query(
+        default=DEFAULT_AGENT_FOLLOWS_LIST_OFFSET,
+        ge=0,
+        description="Number of follow edges to skip before returning results.",
+    ),
+) -> ListAgentFollowsResponse | Response:
+    """Return editable pre-run follows for a specific follower handle."""
+    return await _execute_get_simulation_agent_follows(
+        request,
+        handle=handle,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post(
+    "/simulations/agents/{handle}/follows",
+    response_model=AgentFollowEdgeSchema,
+    status_code=201,
+    summary="Create editable pre-run follow edge",
+    description="Create an internal agent-to-agent seed follow edge for the given follower handle.",
+)
+@log_route_completion_decorator(
+    route=SIMULATION_AGENT_FOLLOWS_CREATE_ROUTE,
+    success_type=AgentFollowEdgeSchema,
+)
+async def post_simulation_agent_follow(
+    request: Request,
+    handle: str,
+    body: CreateAgentFollowRequest,
+) -> AgentFollowEdgeSchema | Response:
+    """Create an editable pre-run follow edge."""
+    return await _execute_post_simulation_agent_follow(
+        request,
+        handle=handle,
+        body=body,
+    )
+
+
+@router.delete(
+    "/simulations/agents/{handle}/follows/{target_handle}",
+    status_code=204,
+    summary="Delete editable pre-run follow edge",
+    description="Delete an internal agent-to-agent seed follow edge for the given follower handle.",
+)
+@log_route_completion_decorator(
+    route=SIMULATION_AGENT_FOLLOWS_DELETE_ROUTE,
+    success_type=type(None),
+)
+async def delete_simulation_agent_follow(
+    request: Request,
+    handle: str,
+    target_handle: str,
+) -> Response:
+    """Delete an editable pre-run follow edge."""
+    return await _execute_delete_simulation_agent_follow(
+        request,
+        handle=handle,
+        target_handle=target_handle,
+    )
 
 
 @router.get(
@@ -466,6 +570,171 @@ async def _execute_delete_simulation_agent(
         )
     except Exception:
         logger.exception("Unexpected error while deleting agent")
+        return _error_response(
+            status_code=500,
+            code="INTERNAL_ERROR",
+            message="Internal server error",
+            detail=None,
+        )
+
+
+@timed(attach_attr="duration_ms", log_level=None)
+async def _execute_get_simulation_agent_follows(
+    request: Request,
+    *,
+    handle: str,
+    limit: int,
+    offset: int,
+) -> ListAgentFollowsResponse | Response:
+    """Fetch editable follow edges and convert known failures to HTTP responses."""
+    try:
+        app_state = request.app.state
+        return await asyncio.to_thread(
+            list_agent_follows,
+            handle=handle,
+            agent_repo=app_state.agent_repo,
+            agent_follow_edge_repo=app_state.agent_follow_edge_repo,
+            limit=limit,
+            offset=offset,
+        )
+    except ApiAgentNotFoundError as e:
+        return _error_response(
+            status_code=404,
+            code="AGENT_NOT_FOUND",
+            message="Agent not found",
+            detail=e.handle,
+        )
+    except ValueError as e:
+        return _error_response(
+            status_code=422,
+            code="VALIDATION_ERROR",
+            message=str(e),
+            detail=None,
+        )
+    except Exception:
+        logger.exception("Unexpected error while listing simulation agent follows")
+        return _error_response(
+            status_code=500,
+            code="INTERNAL_ERROR",
+            message="Internal server error",
+            detail=None,
+        )
+
+
+@timed(attach_attr="duration_ms", log_level=None)
+async def _execute_post_simulation_agent_follow(
+    request: Request,
+    *,
+    handle: str,
+    body: CreateAgentFollowRequest,
+) -> AgentFollowEdgeSchema | Response:
+    """Create a follow edge and convert known failures to HTTP responses."""
+    try:
+        app_state = request.app.state
+        return await asyncio.to_thread(
+            create_agent_follow,
+            handle,
+            body,
+            transaction_provider=app_state.transaction_provider,
+            agent_repo=app_state.agent_repo,
+            agent_follow_edge_repo=app_state.agent_follow_edge_repo,
+            metadata_repo=app_state.agent_metadata_repo,
+        )
+    except ApiAgentNotFoundError as e:
+        return _error_response(
+            status_code=404,
+            code="AGENT_NOT_FOUND",
+            message="Agent not found",
+            detail=e.handle,
+        )
+    except ApiTargetAgentNotFoundError as e:
+        return _error_response(
+            status_code=404,
+            code="TARGET_AGENT_NOT_FOUND",
+            message="Target agent not found",
+            detail=e.handle,
+        )
+    except ApiAgentFollowEdgeAlreadyExistsError as e:
+        return _error_response(
+            status_code=409,
+            code="FOLLOW_EDGE_ALREADY_EXISTS",
+            message="Follow edge already exists",
+            detail=f"{e.follower_handle}->{e.target_handle}",
+        )
+    except ApiSelfFollowNotAllowedError as e:
+        return _error_response(
+            status_code=422,
+            code="SELF_FOLLOW_NOT_ALLOWED",
+            message="Agents cannot follow themselves",
+            detail=e.handle,
+        )
+    except ValueError as e:
+        return _error_response(
+            status_code=422,
+            code="VALIDATION_ERROR",
+            message=str(e),
+            detail=None,
+        )
+    except Exception:
+        logger.exception("Unexpected error while creating simulation agent follow")
+        return _error_response(
+            status_code=500,
+            code="INTERNAL_ERROR",
+            message="Internal server error",
+            detail=None,
+        )
+
+
+@timed(attach_attr="duration_ms", log_level=None)
+async def _execute_delete_simulation_agent_follow(
+    request: Request,
+    *,
+    handle: str,
+    target_handle: str,
+) -> Response:
+    """Delete a follow edge and convert known failures to HTTP responses."""
+    try:
+        app_state = request.app.state
+        await asyncio.to_thread(
+            delete_agent_follow,
+            handle,
+            target_handle,
+            transaction_provider=app_state.transaction_provider,
+            agent_repo=app_state.agent_repo,
+            agent_follow_edge_repo=app_state.agent_follow_edge_repo,
+            metadata_repo=app_state.agent_metadata_repo,
+        )
+        return Response(status_code=204)
+    except ApiAgentNotFoundError as e:
+        return _error_response(
+            status_code=404,
+            code="AGENT_NOT_FOUND",
+            message="Agent not found",
+            detail=e.handle,
+        )
+    except ApiTargetAgentNotFoundError as e:
+        return _error_response(
+            status_code=404,
+            code="TARGET_AGENT_NOT_FOUND",
+            message="Target agent not found",
+            detail=e.handle,
+        )
+    except ApiAgentFollowEdgeNotFoundError as e:
+        return _error_response(
+            status_code=404,
+            code="FOLLOW_EDGE_NOT_FOUND",
+            message="Follow edge not found",
+            detail=f"{e.follower_handle}->{e.target_handle}",
+        )
+    except ValueError as e:
+        return _error_response(
+            status_code=422,
+            code="VALIDATION_ERROR",
+            message=str(e),
+            detail=None,
+        )
+    except Exception:
+        logger.exception("Unexpected error while deleting simulation agent follow")
         return _error_response(
             status_code=500,
             code="INTERNAL_ERROR",

--- a/simulation/api/schemas/simulation.py
+++ b/simulation/api/schemas/simulation.py
@@ -178,6 +178,35 @@ class AgentSchema(BaseModel):
     posts_count: int
 
 
+class CreateAgentFollowRequest(BaseModel):
+    """Request body for POST /v1/simulations/agents/{handle}/follows."""
+
+    target_handle: str
+
+    @field_validator("target_handle")
+    @classmethod
+    def _validate_target_handle(cls, v: str) -> str:
+        from lib.validation_utils import validate_non_empty_string
+
+        return validate_non_empty_string(v.strip())
+
+
+class AgentFollowEdgeSchema(BaseModel):
+    """Editable pre-run follow relationship for the simulation UI."""
+
+    agent_follow_edge_id: str
+    follower_handle: str
+    target_handle: str
+    created_at: str
+
+
+class ListAgentFollowsResponse(BaseModel):
+    """Paginated follow-edge response for one follower handle."""
+
+    total: int
+    items: list[AgentFollowEdgeSchema]
+
+
 class FeedSchema(BaseModel):
     """Feed metadata for one agent in a turn."""
 

--- a/simulation/api/services/agent_follows_command_service.py
+++ b/simulation/api/services/agent_follows_command_service.py
@@ -1,0 +1,184 @@
+"""Write-side service for editable pre-run agent follow edges."""
+
+from __future__ import annotations
+
+import uuid
+
+from db.adapters.base import TransactionProvider
+from db.repositories.agent_follow_edge_repository import DuplicateAgentFollowEdgeError
+from db.repositories.interfaces import (
+    AgentFollowEdgeRepository,
+    AgentRepository,
+    UserAgentProfileMetadataRepository,
+)
+from lib.timestamp_utils import get_current_timestamp
+from simulation.api.errors import (
+    ApiAgentFollowEdgeAlreadyExistsError,
+    ApiAgentFollowEdgeNotFoundError,
+    ApiAgentNotFoundError,
+    ApiSelfFollowNotAllowedError,
+    ApiTargetAgentNotFoundError,
+)
+from simulation.api.schemas.simulation import (
+    AgentFollowEdgeSchema,
+    CreateAgentFollowRequest,
+)
+from simulation.core.models.agent import Agent
+from simulation.core.models.agent_follow_edge import AgentFollowEdge
+from simulation.core.models.user_agent_profile_metadata import UserAgentProfileMetadata
+from simulation.core.utils.handle_utils import normalize_handle
+
+DEFAULT_METADATA_POSTS_COUNT: int = 0
+
+
+def create_agent_follow(
+    handle: str,
+    req: CreateAgentFollowRequest,
+    *,
+    transaction_provider: TransactionProvider,
+    agent_repo: AgentRepository,
+    agent_follow_edge_repo: AgentFollowEdgeRepository,
+    metadata_repo: UserAgentProfileMetadataRepository,
+) -> AgentFollowEdgeSchema:
+    """Create one editable pre-run follow edge and sync cached counts."""
+    follower_handle = normalize_handle(handle)
+    target_handle = normalize_handle(req.target_handle)
+    now = get_current_timestamp()
+
+    with transaction_provider.run_transaction() as conn:
+        follower, target = _resolve_follower_and_target_agents(
+            follower_handle=follower_handle,
+            target_handle=target_handle,
+            agent_repo=agent_repo,
+            conn=conn,
+        )
+        if follower.agent_id == target.agent_id:
+            raise ApiSelfFollowNotAllowedError(follower_handle)
+
+        edge = AgentFollowEdge(
+            agent_follow_edge_id=uuid.uuid4().hex,
+            follower_agent_id=follower.agent_id,
+            target_agent_id=target.agent_id,
+            created_at=now,
+        )
+        try:
+            agent_follow_edge_repo.create_agent_follow_edge(edge, conn=conn)
+        except DuplicateAgentFollowEdgeError as exc:
+            raise ApiAgentFollowEdgeAlreadyExistsError(
+                follower.handle,
+                target.handle,
+            ) from exc
+
+        _sync_follow_counts(
+            agent_ids=[follower.agent_id, target.agent_id],
+            now=now,
+            agent_follow_edge_repo=agent_follow_edge_repo,
+            metadata_repo=metadata_repo,
+            conn=conn,
+        )
+
+    return AgentFollowEdgeSchema(
+        agent_follow_edge_id=edge.agent_follow_edge_id,
+        follower_handle=follower.handle,
+        target_handle=target.handle,
+        created_at=edge.created_at,
+    )
+
+
+def delete_agent_follow(
+    handle: str,
+    target_handle: str,
+    *,
+    transaction_provider: TransactionProvider,
+    agent_repo: AgentRepository,
+    agent_follow_edge_repo: AgentFollowEdgeRepository,
+    metadata_repo: UserAgentProfileMetadataRepository,
+) -> None:
+    """Delete one editable pre-run follow edge and sync cached counts."""
+    normalized_follower_handle = normalize_handle(handle)
+    normalized_target_handle = normalize_handle(target_handle)
+    now = get_current_timestamp()
+
+    with transaction_provider.run_transaction() as conn:
+        follower, target = _resolve_follower_and_target_agents(
+            follower_handle=normalized_follower_handle,
+            target_handle=normalized_target_handle,
+            agent_repo=agent_repo,
+            conn=conn,
+        )
+        deleted = agent_follow_edge_repo.delete_agent_follow_edge(
+            follower.agent_id,
+            target.agent_id,
+            conn=conn,
+        )
+        if not deleted:
+            raise ApiAgentFollowEdgeNotFoundError(follower.handle, target.handle)
+
+        _sync_follow_counts(
+            agent_ids=[follower.agent_id, target.agent_id],
+            now=now,
+            agent_follow_edge_repo=agent_follow_edge_repo,
+            metadata_repo=metadata_repo,
+            conn=conn,
+        )
+
+
+def _resolve_follower_and_target_agents(
+    *,
+    follower_handle: str,
+    target_handle: str,
+    agent_repo: AgentRepository,
+    conn: object,
+) -> tuple[Agent, Agent]:
+    """Resolve handles to internal agent rows for follow-edge commands."""
+    follower = agent_repo.get_agent_by_handle(follower_handle, conn=conn)
+    if follower is None:
+        raise ApiAgentNotFoundError(follower_handle)
+
+    target = agent_repo.get_agent_by_handle(target_handle, conn=conn)
+    if target is None:
+        raise ApiTargetAgentNotFoundError(target_handle)
+
+    return follower, target
+
+
+def _sync_follow_counts(
+    *,
+    agent_ids: list[str],
+    now: str,
+    agent_follow_edge_repo: AgentFollowEdgeRepository,
+    metadata_repo: UserAgentProfileMetadataRepository,
+    conn: object,
+) -> None:
+    """Recompute cached follow counts for the affected agents inside one transaction."""
+    for agent_id in sorted(set(agent_ids)):
+        existing_metadata = metadata_repo.get_by_agent_id(agent_id, conn=conn)
+        followers_count = (
+            agent_follow_edge_repo.count_agent_follow_edges_by_target_agent_id(
+                agent_id,
+                conn=conn,
+            )
+        )
+        follows_count = (
+            agent_follow_edge_repo.count_agent_follow_edges_by_follower_agent_id(
+                agent_id,
+                conn=conn,
+            )
+        )
+
+        metadata_repo.create_or_update_metadata(
+            UserAgentProfileMetadata(
+                id=existing_metadata.id if existing_metadata else uuid.uuid4().hex,
+                agent_id=agent_id,
+                followers_count=followers_count,
+                follows_count=follows_count,
+                posts_count=(
+                    existing_metadata.posts_count
+                    if existing_metadata
+                    else DEFAULT_METADATA_POSTS_COUNT
+                ),
+                created_at=existing_metadata.created_at if existing_metadata else now,
+                updated_at=now,
+            ),
+            conn=conn,
+        )

--- a/simulation/api/services/agent_follows_query_service.py
+++ b/simulation/api/services/agent_follows_query_service.py
@@ -1,0 +1,72 @@
+"""Read-side service for editable pre-run agent follow edges."""
+
+from db.repositories.interfaces import AgentFollowEdgeRepository, AgentRepository
+from simulation.api.errors import ApiAgentNotFoundError
+from simulation.api.schemas.simulation import (
+    AgentFollowEdgeSchema,
+    ListAgentFollowsResponse,
+)
+from simulation.core.models.agent import Agent
+from simulation.core.models.agent_follow_edge import AgentFollowEdge
+from simulation.core.utils.handle_utils import normalize_handle
+
+
+def list_agent_follows(
+    *,
+    handle: str,
+    agent_repo: AgentRepository,
+    agent_follow_edge_repo: AgentFollowEdgeRepository,
+    limit: int,
+    offset: int,
+) -> ListAgentFollowsResponse:
+    """List editable follow edges for one follower handle."""
+    normalized_handle = normalize_handle(handle)
+    follower = agent_repo.get_agent_by_handle(normalized_handle)
+    if follower is None:
+        raise ApiAgentNotFoundError(normalized_handle)
+
+    edges = agent_follow_edge_repo.list_agent_follow_edges_by_follower_agent_id(
+        follower.agent_id,
+        limit=limit,
+        offset=offset,
+    )
+    total = agent_follow_edge_repo.count_agent_follow_edges_by_follower_agent_id(
+        follower.agent_id
+    )
+    target_agents_by_id = agent_repo.get_agents_by_ids(
+        [edge.target_agent_id for edge in edges]
+    )
+
+    return ListAgentFollowsResponse(
+        total=total,
+        items=[
+            _edge_to_schema(
+                edge=edge,
+                follower=follower,
+                target_agents_by_id=target_agents_by_id,
+            )
+            for edge in edges
+        ],
+    )
+
+
+def _edge_to_schema(
+    *,
+    edge: AgentFollowEdge,
+    follower: Agent,
+    target_agents_by_id: dict[str, Agent | None],
+) -> AgentFollowEdgeSchema:
+    """Map a follow-edge row plus hydrated agents to the API schema."""
+    target_agent = target_agents_by_id.get(edge.target_agent_id)
+    if target_agent is None:
+        raise RuntimeError(
+            "agent_follow_edges row references missing target agent "
+            f"{edge.target_agent_id}"
+        )
+
+    return AgentFollowEdgeSchema(
+        agent_follow_edge_id=edge.agent_follow_edge_id,
+        follower_handle=follower.handle,
+        target_handle=target_agent.handle,
+        created_at=edge.created_at,
+    )

--- a/simulation/core/models/agent_follow_edge.py
+++ b/simulation/core/models/agent_follow_edge.py
@@ -1,0 +1,29 @@
+"""Domain model for editable pre-run agent follow edges."""
+
+from pydantic import BaseModel, field_validator
+
+from lib.validation_utils import validate_non_empty_string
+
+
+class AgentFollowEdge(BaseModel):
+    """Durable seed-state row describing one internal agent-to-agent follow edge."""
+
+    agent_follow_edge_id: str
+    follower_agent_id: str
+    target_agent_id: str
+    created_at: str
+
+    @field_validator("agent_follow_edge_id")
+    @classmethod
+    def validate_agent_follow_edge_id(cls, v: str) -> str:
+        return validate_non_empty_string(v)
+
+    @field_validator("follower_agent_id")
+    @classmethod
+    def validate_follower_agent_id(cls, v: str) -> str:
+        return validate_non_empty_string(v)
+
+    @field_validator("target_agent_id")
+    @classmethod
+    def validate_target_agent_id(cls, v: str) -> str:
+        return validate_non_empty_string(v)

--- a/simulation/local_dev/seed_fixtures/agent_follow_edges.json
+++ b/simulation/local_dev/seed_fixtures/agent_follow_edges.json
@@ -1,0 +1,86 @@
+[
+  {
+    "agent_follow_edge_id": "afe_0240dc0d4a4c7e73_0c75608c7dd8e6c7",
+    "follower_agent_id": "agent_0240dc0d4a4c7e73",
+    "target_agent_id": "agent_0c75608c7dd8e6c7",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_0240dc0d4a4c7e73_7b3e5a6b1b0394d1",
+    "follower_agent_id": "agent_0240dc0d4a4c7e73",
+    "target_agent_id": "agent_7b3e5a6b1b0394d1",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_0c75608c7dd8e6c7_0240dc0d4a4c7e73",
+    "follower_agent_id": "agent_0c75608c7dd8e6c7",
+    "target_agent_id": "agent_0240dc0d4a4c7e73",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_0c75608c7dd8e6c7_c2cf0fd46387f19a",
+    "follower_agent_id": "agent_0c75608c7dd8e6c7",
+    "target_agent_id": "agent_c2cf0fd46387f19a",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_7b3e5a6b1b0394d1_0240dc0d4a4c7e73",
+    "follower_agent_id": "agent_7b3e5a6b1b0394d1",
+    "target_agent_id": "agent_0240dc0d4a4c7e73",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_c2cf0fd46387f19a_0240dc0d4a4c7e73",
+    "follower_agent_id": "agent_c2cf0fd46387f19a",
+    "target_agent_id": "agent_0240dc0d4a4c7e73",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_c2cf0fd46387f19a_0c75608c7dd8e6c7",
+    "follower_agent_id": "agent_c2cf0fd46387f19a",
+    "target_agent_id": "agent_0c75608c7dd8e6c7",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_c2cf0fd46387f19a_ce3084ff7dd186dc",
+    "follower_agent_id": "agent_c2cf0fd46387f19a",
+    "target_agent_id": "agent_ce3084ff7dd186dc",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_d5aaff22974ebc2c_0240dc0d4a4c7e73",
+    "follower_agent_id": "agent_d5aaff22974ebc2c",
+    "target_agent_id": "agent_0240dc0d4a4c7e73",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_ce3084ff7dd186dc_98a2ebefd3059f7e",
+    "follower_agent_id": "agent_ce3084ff7dd186dc",
+    "target_agent_id": "agent_98a2ebefd3059f7e",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_ce3084ff7dd186dc_10c2fc5dda9f71dc",
+    "follower_agent_id": "agent_ce3084ff7dd186dc",
+    "target_agent_id": "agent_10c2fc5dda9f71dc",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_98a2ebefd3059f7e_0240dc0d4a4c7e73",
+    "follower_agent_id": "agent_98a2ebefd3059f7e",
+    "target_agent_id": "agent_0240dc0d4a4c7e73",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_98a2ebefd3059f7e_0c75608c7dd8e6c7",
+    "follower_agent_id": "agent_98a2ebefd3059f7e",
+    "target_agent_id": "agent_0c75608c7dd8e6c7",
+    "created_at": "2025-01-01T00:00:00"
+  },
+  {
+    "agent_follow_edge_id": "afe_10c2fc5dda9f71dc_ce3084ff7dd186dc",
+    "follower_agent_id": "agent_10c2fc5dda9f71dc",
+    "target_agent_id": "agent_ce3084ff7dd186dc",
+    "created_at": "2025-01-01T00:00:00"
+  }
+]

--- a/simulation/local_dev/seed_fixtures/user_agent_profile_metadata.json
+++ b/simulation/local_dev/seed_fixtures/user_agent_profile_metadata.json
@@ -2,8 +2,8 @@
   {
     "agent_id": "agent_0240dc0d4a4c7e73",
     "created_at": "2025-01-01T00:00:00",
-    "followers_count": 12450,
-    "follows_count": 892,
+    "followers_count": 5,
+    "follows_count": 2,
     "id": "md_0240dc0d4a4c7e73",
     "posts_count": 3421,
     "updated_at": "2025-01-01T00:00:00"
@@ -11,8 +11,8 @@
   {
     "agent_id": "agent_0c75608c7dd8e6c7",
     "created_at": "2025-01-01T00:00:00",
-    "followers_count": 8765,
-    "follows_count": 1203,
+    "followers_count": 3,
+    "follows_count": 2,
     "id": "md_0c75608c7dd8e6c7",
     "posts_count": 2105,
     "updated_at": "2025-01-01T00:00:00"
@@ -20,8 +20,8 @@
   {
     "agent_id": "agent_7b3e5a6b1b0394d1",
     "created_at": "2025-01-01T00:00:00",
-    "followers_count": 15432,
-    "follows_count": 567,
+    "followers_count": 1,
+    "follows_count": 1,
     "id": "md_7b3e5a6b1b0394d1",
     "posts_count": 4521,
     "updated_at": "2025-01-01T00:00:00"
@@ -29,8 +29,8 @@
   {
     "agent_id": "agent_c2cf0fd46387f19a",
     "created_at": "2025-01-01T00:00:00",
-    "followers_count": 9876,
-    "follows_count": 1456,
+    "followers_count": 1,
+    "follows_count": 3,
     "id": "md_c2cf0fd46387f19a",
     "posts_count": 1876,
     "updated_at": "2025-01-01T00:00:00"
@@ -38,8 +38,8 @@
   {
     "agent_id": "agent_d5aaff22974ebc2c",
     "created_at": "2025-01-01T00:00:00",
-    "followers_count": 11234,
-    "follows_count": 789,
+    "followers_count": 0,
+    "follows_count": 1,
     "id": "md_d5aaff22974ebc2c",
     "posts_count": 3210,
     "updated_at": "2025-01-01T00:00:00"
@@ -47,8 +47,8 @@
   {
     "agent_id": "agent_ce3084ff7dd186dc",
     "created_at": "2025-01-01T00:00:00",
-    "followers_count": 6543,
-    "follows_count": 923,
+    "followers_count": 2,
+    "follows_count": 2,
     "id": "md_ce3084ff7dd186dc",
     "posts_count": 1567,
     "updated_at": "2025-01-01T00:00:00"
@@ -56,8 +56,8 @@
   {
     "agent_id": "agent_98a2ebefd3059f7e",
     "created_at": "2025-01-01T00:00:00",
-    "followers_count": 14567,
-    "follows_count": 612,
+    "followers_count": 1,
+    "follows_count": 2,
     "id": "md_98a2ebefd3059f7e",
     "posts_count": 2890,
     "updated_at": "2025-01-01T00:00:00"
@@ -65,8 +65,8 @@
   {
     "agent_id": "agent_10c2fc5dda9f71dc",
     "created_at": "2025-01-01T00:00:00",
-    "followers_count": 8765,
-    "follows_count": 1345,
+    "followers_count": 1,
+    "follows_count": 1,
     "id": "md_10c2fc5dda9f71dc",
     "posts_count": 2103,
     "updated_at": "2025-01-01T00:00:00"

--- a/simulation/local_dev/seed_loader.py
+++ b/simulation/local_dev/seed_loader.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 from db.adapters.sqlite.agent_adapter import SQLiteAgentAdapter
 from db.adapters.sqlite.agent_bio_adapter import SQLiteAgentBioAdapter
+from db.adapters.sqlite.agent_follow_edge_adapter import SQLiteAgentFollowEdgeAdapter
 from db.adapters.sqlite.feed_post_adapter import SQLiteFeedPostAdapter
 from db.adapters.sqlite.generated_feed_adapter import SQLiteGeneratedFeedAdapter
 from db.adapters.sqlite.metrics_adapter import SQLiteMetricsAdapter
@@ -31,6 +32,7 @@ from lib.timestamp_utils import get_current_timestamp
 from simulation.core.models.actions import TurnAction
 from simulation.core.models.agent import Agent, PersonaSource
 from simulation.core.models.agent_bio import AgentBio, PersonaBioSource
+from simulation.core.models.agent_follow_edge import AgentFollowEdge
 from simulation.core.models.feeds import GeneratedFeed
 from simulation.core.models.metrics import RunMetrics, TurnMetrics
 from simulation.core.models.posts import Post, PostSource
@@ -61,6 +63,7 @@ class SeedFixtures:
     agents: list[Agent]
     agent_persona_bios: list[AgentBio]
     user_agent_profile_metadata: list[UserAgentProfileMetadata]
+    agent_follow_edges: list[AgentFollowEdge]
 
 
 def _read_json_list(path: Path) -> list[dict]:
@@ -113,6 +116,7 @@ def _load_fixtures(fixtures_dir: Path) -> SeedFixtures:
     agents_raw = _read_json_list(fixtures_dir / "agents.json")
     bios_raw = _read_json_list(fixtures_dir / "agent_persona_bios.json")
     metadata_raw = _read_json_list(fixtures_dir / "user_agent_profile_metadata.json")
+    follow_edges_raw = _read_json_list(fixtures_dir / "agent_follow_edges.json")
     posts_raw = _read_json_list(fixtures_dir / "bluesky_feed_posts.json")
     feeds_raw = _read_json_list(fixtures_dir / "generated_feeds.json")
     turn_md_raw = _read_json_list(fixtures_dir / "turn_metadata.json")
@@ -146,6 +150,7 @@ def _load_fixtures(fixtures_dir: Path) -> SeedFixtures:
             )
         )
     user_md = [UserAgentProfileMetadata.model_validate(item) for item in metadata_raw]
+    follow_edges = [AgentFollowEdge.model_validate(item) for item in follow_edges_raw]
     posts = [
         Post.model_validate({**item, "source": PostSource.BLUESKY})
         for item in posts_raw
@@ -179,7 +184,48 @@ def _load_fixtures(fixtures_dir: Path) -> SeedFixtures:
         agents=agents,
         agent_persona_bios=bios,
         user_agent_profile_metadata=user_md,
+        agent_follow_edges=follow_edges,
     )
+
+
+def _sync_follow_edge_metadata_counts(
+    *,
+    conn: sqlite3.Connection,
+    agent_ids: list[str],
+    user_md_adapter: SQLiteUserAgentProfileMetadataAdapter,
+    follow_edge_adapter: SQLiteAgentFollowEdgeAdapter,
+    updated_at: str,
+) -> None:
+    """Recompute cached follow counts after seeding follow-edge rows."""
+    for agent_id in sorted(set(agent_ids)):
+        existing = user_md_adapter.read_by_agent_id(agent_id, conn=conn)
+        if existing is None:
+            continue
+
+        followers_count = (
+            follow_edge_adapter.count_agent_follow_edges_by_target_agent_id(
+                agent_id,
+                conn=conn,
+            )
+        )
+        follows_count = (
+            follow_edge_adapter.count_agent_follow_edges_by_follower_agent_id(
+                agent_id,
+                conn=conn,
+            )
+        )
+        user_md_adapter.write_user_agent_profile_metadata(
+            UserAgentProfileMetadata(
+                id=existing.id,
+                agent_id=agent_id,
+                followers_count=followers_count,
+                follows_count=follows_count,
+                posts_count=existing.posts_count,
+                created_at=existing.created_at,
+                updated_at=updated_at,
+            ),
+            conn=conn,
+        )
 
 
 def seed_local_db_if_needed(*, db_path: str, fixtures_dir: Path = FIXTURES_DIR) -> None:
@@ -218,6 +264,7 @@ def seed_local_db_if_needed(*, db_path: str, fixtures_dir: Path = FIXTURES_DIR) 
         post_adapter = SQLiteFeedPostAdapter()
         agent_adapter = SQLiteAgentAdapter()
         bio_adapter = SQLiteAgentBioAdapter()
+        follow_edge_adapter = SQLiteAgentFollowEdgeAdapter()
         user_md_adapter = SQLiteUserAgentProfileMetadataAdapter()
 
         now = get_current_timestamp()
@@ -233,6 +280,15 @@ def seed_local_db_if_needed(*, db_path: str, fixtures_dir: Path = FIXTURES_DIR) 
                 bio_adapter.write_agent_bio(bio, conn=conn)
             for md in fixtures.user_agent_profile_metadata:
                 user_md_adapter.write_user_agent_profile_metadata(md, conn=conn)
+            for edge in fixtures.agent_follow_edges:
+                follow_edge_adapter.write_agent_follow_edge(edge, conn=conn)
+            _sync_follow_edge_metadata_counts(
+                conn=conn,
+                agent_ids=[agent.agent_id for agent in fixtures.agents],
+                user_md_adapter=user_md_adapter,
+                follow_edge_adapter=follow_edge_adapter,
+                updated_at=now,
+            )
 
             post_adapter.write_feed_posts(fixtures.feed_posts, conn=conn)
             for feed in fixtures.generated_feeds:

--- a/tests/api/test_simulation_agent_follows.py
+++ b/tests/api/test_simulation_agent_follows.py
@@ -1,0 +1,292 @@
+"""Tests for editable agent follow-edge API endpoints."""
+
+from simulation.core.models.agent import PersonaSource
+from tests.factories import AgentRecordFactory, UserAgentProfileMetadataFactory
+
+
+class TestSimulationAgentFollows:
+    def test_get_agent_follows_returns_empty_paginated_response_for_existing_agent(
+        self,
+        simulation_client,
+        agent_repo,
+    ):
+        _seed_agent(
+            agent_repo=agent_repo,
+            agent_id="did:plc:alice",
+            handle="@alice.bsky.social",
+        )
+
+        client, _ = simulation_client
+        response = client.get("/v1/simulations/agents/@alice.bsky.social/follows")
+
+        expected_result = {"status_code": 200, "body": {"total": 0, "items": []}}
+        assert response.status_code == expected_result["status_code"]
+        assert response.json() == expected_result["body"]
+
+    def test_get_agent_follows_returns_404_when_follower_agent_missing(
+        self,
+        simulation_client,
+    ):
+        client, _ = simulation_client
+        response = client.get("/v1/simulations/agents/@missing.bsky.social/follows")
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "AGENT_NOT_FOUND"
+
+    def test_post_agent_follow_creates_edge_and_syncs_cached_counts(
+        self,
+        simulation_client,
+        agent_repo,
+        user_agent_profile_metadata_repo,
+    ):
+        _seed_agent_with_metadata(
+            agent_repo=agent_repo,
+            metadata_repo=user_agent_profile_metadata_repo,
+            agent_id="did:plc:alice",
+            handle="@alice.bsky.social",
+            followers_count=17,
+            follows_count=23,
+            posts_count=7,
+        )
+        _seed_agent_with_metadata(
+            agent_repo=agent_repo,
+            metadata_repo=user_agent_profile_metadata_repo,
+            agent_id="did:plc:bob",
+            handle="@bob.tech",
+            followers_count=31,
+            follows_count=29,
+            posts_count=11,
+        )
+
+        client, _ = simulation_client
+        response = client.post(
+            "/v1/simulations/agents/@alice.bsky.social/follows",
+            json={"target_handle": "@bob.tech"},
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["follower_handle"] == "@alice.bsky.social"
+        assert body["target_handle"] == "@bob.tech"
+        assert body["agent_follow_edge_id"]
+
+        follow_list = client.get("/v1/simulations/agents/@alice.bsky.social/follows")
+        assert follow_list.status_code == 200
+        assert follow_list.json()["total"] == 1
+        assert follow_list.json()["items"][0]["target_handle"] == "@bob.tech"
+
+        agents_response = client.get("/v1/simulations/agents?limit=10&offset=0")
+        assert agents_response.status_code == 200
+        agents_by_handle = {agent["handle"]: agent for agent in agents_response.json()}
+
+        assert agents_by_handle["@alice.bsky.social"]["following"] == 1
+        assert agents_by_handle["@alice.bsky.social"]["followers"] == 0
+        assert agents_by_handle["@alice.bsky.social"]["posts_count"] == 7
+        assert agents_by_handle["@bob.tech"]["followers"] == 1
+        assert agents_by_handle["@bob.tech"]["following"] == 0
+        assert agents_by_handle["@bob.tech"]["posts_count"] == 11
+
+    def test_post_agent_follow_duplicate_returns_409(
+        self,
+        simulation_client,
+        agent_repo,
+        user_agent_profile_metadata_repo,
+    ):
+        _seed_agent_with_metadata(
+            agent_repo=agent_repo,
+            metadata_repo=user_agent_profile_metadata_repo,
+            agent_id="did:plc:alice",
+            handle="@alice.bsky.social",
+            followers_count=0,
+            follows_count=0,
+            posts_count=1,
+        )
+        _seed_agent_with_metadata(
+            agent_repo=agent_repo,
+            metadata_repo=user_agent_profile_metadata_repo,
+            agent_id="did:plc:bob",
+            handle="@bob.tech",
+            followers_count=0,
+            follows_count=0,
+            posts_count=1,
+        )
+
+        client, _ = simulation_client
+        first = client.post(
+            "/v1/simulations/agents/@alice.bsky.social/follows",
+            json={"target_handle": "@bob.tech"},
+        )
+        second = client.post(
+            "/v1/simulations/agents/@alice.bsky.social/follows",
+            json={"target_handle": "@bob.tech"},
+        )
+
+        assert first.status_code == 201
+        assert second.status_code == 409
+        assert second.json()["error"]["code"] == "FOLLOW_EDGE_ALREADY_EXISTS"
+
+    def test_post_agent_follow_self_follow_returns_422(
+        self,
+        simulation_client,
+        agent_repo,
+        user_agent_profile_metadata_repo,
+    ):
+        _seed_agent_with_metadata(
+            agent_repo=agent_repo,
+            metadata_repo=user_agent_profile_metadata_repo,
+            agent_id="did:plc:alice",
+            handle="@alice.bsky.social",
+            followers_count=0,
+            follows_count=0,
+            posts_count=1,
+        )
+
+        client, _ = simulation_client
+        response = client.post(
+            "/v1/simulations/agents/@alice.bsky.social/follows",
+            json={"target_handle": "@alice.bsky.social"},
+        )
+
+        assert response.status_code == 422
+        assert response.json()["error"]["code"] == "SELF_FOLLOW_NOT_ALLOWED"
+
+    def test_post_agent_follow_target_missing_returns_404(
+        self,
+        simulation_client,
+        agent_repo,
+        user_agent_profile_metadata_repo,
+    ):
+        _seed_agent_with_metadata(
+            agent_repo=agent_repo,
+            metadata_repo=user_agent_profile_metadata_repo,
+            agent_id="did:plc:alice",
+            handle="@alice.bsky.social",
+            followers_count=0,
+            follows_count=0,
+            posts_count=1,
+        )
+
+        client, _ = simulation_client
+        response = client.post(
+            "/v1/simulations/agents/@alice.bsky.social/follows",
+            json={"target_handle": "@missing.bsky.social"},
+        )
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "TARGET_AGENT_NOT_FOUND"
+
+    def test_delete_agent_follow_removes_edge_and_syncs_cached_counts(
+        self,
+        simulation_client,
+        agent_repo,
+        user_agent_profile_metadata_repo,
+    ):
+        _seed_agent_with_metadata(
+            agent_repo=agent_repo,
+            metadata_repo=user_agent_profile_metadata_repo,
+            agent_id="did:plc:alice",
+            handle="@alice.bsky.social",
+            followers_count=0,
+            follows_count=0,
+            posts_count=3,
+        )
+        _seed_agent_with_metadata(
+            agent_repo=agent_repo,
+            metadata_repo=user_agent_profile_metadata_repo,
+            agent_id="did:plc:bob",
+            handle="@bob.tech",
+            followers_count=0,
+            follows_count=0,
+            posts_count=4,
+        )
+
+        client, _ = simulation_client
+        create_response = client.post(
+            "/v1/simulations/agents/@alice.bsky.social/follows",
+            json={"target_handle": "@bob.tech"},
+        )
+        assert create_response.status_code == 201
+
+        delete_response = client.delete(
+            "/v1/simulations/agents/@alice.bsky.social/follows/@bob.tech"
+        )
+        assert delete_response.status_code == 204
+
+        follow_list = client.get("/v1/simulations/agents/@alice.bsky.social/follows")
+        assert follow_list.status_code == 200
+        assert follow_list.json() == {"total": 0, "items": []}
+
+        agents_response = client.get("/v1/simulations/agents?limit=10&offset=0")
+        agents_by_handle = {agent["handle"]: agent for agent in agents_response.json()}
+        assert agents_by_handle["@alice.bsky.social"]["following"] == 0
+        assert agents_by_handle["@bob.tech"]["followers"] == 0
+
+    def test_delete_agent_follow_missing_edge_returns_404(
+        self,
+        simulation_client,
+        agent_repo,
+        user_agent_profile_metadata_repo,
+    ):
+        _seed_agent_with_metadata(
+            agent_repo=agent_repo,
+            metadata_repo=user_agent_profile_metadata_repo,
+            agent_id="did:plc:alice",
+            handle="@alice.bsky.social",
+            followers_count=0,
+            follows_count=0,
+            posts_count=1,
+        )
+        _seed_agent_with_metadata(
+            agent_repo=agent_repo,
+            metadata_repo=user_agent_profile_metadata_repo,
+            agent_id="did:plc:bob",
+            handle="@bob.tech",
+            followers_count=0,
+            follows_count=0,
+            posts_count=1,
+        )
+
+        client, _ = simulation_client
+        response = client.delete(
+            "/v1/simulations/agents/@alice.bsky.social/follows/@bob.tech"
+        )
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "FOLLOW_EDGE_NOT_FOUND"
+
+
+def _seed_agent(*, agent_repo, agent_id: str, handle: str) -> None:
+    agent_repo.create_or_update_agent(
+        AgentRecordFactory.create(
+            agent_id=agent_id,
+            handle=handle,
+            persona_source=PersonaSource.SYNC_BLUESKY,
+            display_name=handle,
+            created_at="2026_03_13-10:00:00",
+            updated_at="2026_03_13-10:00:00",
+        )
+    )
+
+
+def _seed_agent_with_metadata(
+    *,
+    agent_repo,
+    metadata_repo,
+    agent_id: str,
+    handle: str,
+    followers_count: int,
+    follows_count: int,
+    posts_count: int,
+) -> None:
+    _seed_agent(agent_repo=agent_repo, agent_id=agent_id, handle=handle)
+    metadata_repo.create_or_update_metadata(
+        UserAgentProfileMetadataFactory.create(
+            metadata_id=f"meta_{agent_id}",
+            agent_id=agent_id,
+            followers_count=followers_count,
+            follows_count=follows_count,
+            posts_count=posts_count,
+            created_at="2026_03_13-10:00:00",
+            updated_at="2026_03_13-10:00:00",
+        )
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,9 @@ from faker import Faker
 
 from db.adapters.sqlite.sqlite import SqliteTransactionProvider
 from db.repositories.agent_bio_repository import create_sqlite_agent_bio_repository
+from db.repositories.agent_follow_edge_repository import (
+    create_sqlite_agent_follow_edge_repository,
+)
 from db.repositories.agent_repository import create_sqlite_agent_repository
 from db.repositories.comment_repository import create_sqlite_comment_repository
 from db.repositories.feed_post_repository import create_sqlite_feed_post_repository
@@ -71,6 +74,11 @@ def agent_repo(temp_db, sqlite_tx):
 @pytest.fixture
 def agent_bio_repo(temp_db, sqlite_tx):
     return create_sqlite_agent_bio_repository(transaction_provider=sqlite_tx)
+
+
+@pytest.fixture
+def agent_follow_edge_repo(temp_db, sqlite_tx):
+    return create_sqlite_agent_follow_edge_repository(transaction_provider=sqlite_tx)
 
 
 @pytest.fixture

--- a/tests/db/repositories/test_agent_follow_edge_repository_integration.py
+++ b/tests/db/repositories/test_agent_follow_edge_repository_integration.py
@@ -1,0 +1,224 @@
+"""Integration tests for db.repositories.agent_follow_edge_repository module."""
+
+from db.repositories.agent_follow_edge_repository import DuplicateAgentFollowEdgeError
+from simulation.core.models.agent import PersonaSource
+from tests.factories import AgentFollowEdgeFactory, AgentRecordFactory
+
+
+class TestSQLiteAgentFollowEdgeRepositoryIntegration:
+    """Integration tests for AgentFollowEdgeRepository using a real database."""
+
+    def test_create_and_get_agent_follow_edge(self, agent_follow_edge_repo, agent_repo):
+        follower_agent_id = "did:plc:follower"
+        target_agent_id = "did:plc:target"
+        _seed_agent(
+            agent_repo=agent_repo,
+            agent_id=follower_agent_id,
+            handle="@follower.bsky.social",
+        )
+        _seed_agent(
+            agent_repo=agent_repo,
+            agent_id=target_agent_id,
+            handle="@target.bsky.social",
+        )
+
+        edge = AgentFollowEdgeFactory.create(
+            agent_follow_edge_id="edge_1",
+            follower_agent_id=follower_agent_id,
+            target_agent_id=target_agent_id,
+            created_at="2026_03_13-10:00:00",
+        )
+
+        created = agent_follow_edge_repo.create_agent_follow_edge(edge)
+        retrieved = agent_follow_edge_repo.get_agent_follow_edge(
+            follower_agent_id,
+            target_agent_id,
+        )
+
+        assert created.agent_follow_edge_id == "edge_1"
+        assert retrieved is not None
+        assert retrieved.agent_follow_edge_id == "edge_1"
+        assert retrieved.follower_agent_id == follower_agent_id
+        assert retrieved.target_agent_id == target_agent_id
+
+    def test_list_agent_follow_edges_by_follower_agent_id_is_paginated_and_deterministic(
+        self, agent_follow_edge_repo, agent_repo
+    ):
+        follower_agent_id = "did:plc:follower"
+        _seed_agent(
+            agent_repo=agent_repo,
+            agent_id=follower_agent_id,
+            handle="@follower.bsky.social",
+        )
+        for target_agent_id, handle, edge_id in [
+            ("did:plc:ccc", "@ccc.bsky.social", "edge_c"),
+            ("did:plc:aaa", "@aaa.bsky.social", "edge_a"),
+            ("did:plc:bbb", "@bbb.bsky.social", "edge_b"),
+        ]:
+            _seed_agent(agent_repo=agent_repo, agent_id=target_agent_id, handle=handle)
+            agent_follow_edge_repo.create_agent_follow_edge(
+                AgentFollowEdgeFactory.create(
+                    agent_follow_edge_id=edge_id,
+                    follower_agent_id=follower_agent_id,
+                    target_agent_id=target_agent_id,
+                    created_at="2026_03_13-10:00:00",
+                )
+            )
+
+        page0 = agent_follow_edge_repo.list_agent_follow_edges_by_follower_agent_id(
+            follower_agent_id,
+            limit=2,
+            offset=0,
+        )
+        page1 = agent_follow_edge_repo.list_agent_follow_edges_by_follower_agent_id(
+            follower_agent_id,
+            limit=2,
+            offset=2,
+        )
+
+        assert [edge.target_agent_id for edge in page0] == [
+            "did:plc:aaa",
+            "did:plc:bbb",
+        ]
+        assert [edge.target_agent_id for edge in page1] == ["did:plc:ccc"]
+
+    def test_count_methods_reflect_current_edges(
+        self, agent_follow_edge_repo, agent_repo
+    ):
+        _seed_agent(
+            agent_repo=agent_repo,
+            agent_id="did:plc:a",
+            handle="@a.bsky.social",
+        )
+        _seed_agent(
+            agent_repo=agent_repo,
+            agent_id="did:plc:b",
+            handle="@b.bsky.social",
+        )
+        _seed_agent(
+            agent_repo=agent_repo,
+            agent_id="did:plc:c",
+            handle="@c.bsky.social",
+        )
+
+        agent_follow_edge_repo.create_agent_follow_edge(
+            AgentFollowEdgeFactory.create(
+                agent_follow_edge_id="edge_ab",
+                follower_agent_id="did:plc:a",
+                target_agent_id="did:plc:b",
+                created_at="2026_03_13-10:00:00",
+            )
+        )
+        agent_follow_edge_repo.create_agent_follow_edge(
+            AgentFollowEdgeFactory.create(
+                agent_follow_edge_id="edge_ac",
+                follower_agent_id="did:plc:a",
+                target_agent_id="did:plc:c",
+                created_at="2026_03_13-10:00:00",
+            )
+        )
+
+        assert (
+            agent_follow_edge_repo.count_agent_follow_edges_by_follower_agent_id(
+                "did:plc:a"
+            )
+            == 2
+        )
+        assert (
+            agent_follow_edge_repo.count_agent_follow_edges_by_target_agent_id(
+                "did:plc:b"
+            )
+            == 1
+        )
+
+    def test_delete_agent_follow_edge_returns_true_only_when_row_exists(
+        self, agent_follow_edge_repo, agent_repo
+    ):
+        follower_agent_id = "did:plc:follower"
+        target_agent_id = "did:plc:target"
+        _seed_agent(
+            agent_repo=agent_repo,
+            agent_id=follower_agent_id,
+            handle="@follower.bsky.social",
+        )
+        _seed_agent(
+            agent_repo=agent_repo,
+            agent_id=target_agent_id,
+            handle="@target.bsky.social",
+        )
+        agent_follow_edge_repo.create_agent_follow_edge(
+            AgentFollowEdgeFactory.create(
+                agent_follow_edge_id="edge_delete",
+                follower_agent_id=follower_agent_id,
+                target_agent_id=target_agent_id,
+                created_at="2026_03_13-10:00:00",
+            )
+        )
+
+        assert (
+            agent_follow_edge_repo.delete_agent_follow_edge(
+                follower_agent_id,
+                target_agent_id,
+            )
+            is True
+        )
+        assert (
+            agent_follow_edge_repo.delete_agent_follow_edge(
+                follower_agent_id,
+                target_agent_id,
+            )
+            is False
+        )
+
+    def test_create_duplicate_agent_follow_edge_raises_repository_error(
+        self, agent_follow_edge_repo, agent_repo
+    ):
+        follower_agent_id = "did:plc:follower"
+        target_agent_id = "did:plc:target"
+        _seed_agent(
+            agent_repo=agent_repo,
+            agent_id=follower_agent_id,
+            handle="@follower.bsky.social",
+        )
+        _seed_agent(
+            agent_repo=agent_repo,
+            agent_id=target_agent_id,
+            handle="@target.bsky.social",
+        )
+
+        edge = AgentFollowEdgeFactory.create(
+            agent_follow_edge_id="edge_dup",
+            follower_agent_id=follower_agent_id,
+            target_agent_id=target_agent_id,
+            created_at="2026_03_13-10:00:00",
+        )
+        agent_follow_edge_repo.create_agent_follow_edge(edge)
+
+        try:
+            agent_follow_edge_repo.create_agent_follow_edge(
+                AgentFollowEdgeFactory.create(
+                    agent_follow_edge_id="edge_dup_2",
+                    follower_agent_id=follower_agent_id,
+                    target_agent_id=target_agent_id,
+                    created_at="2026_03_13-10:00:01",
+                )
+            )
+        except DuplicateAgentFollowEdgeError:
+            pass
+        else:
+            raise AssertionError(
+                "Expected DuplicateAgentFollowEdgeError for duplicate follow edge"
+            )
+
+
+def _seed_agent(*, agent_repo, agent_id: str, handle: str) -> None:
+    agent_repo.create_or_update_agent(
+        AgentRecordFactory.create(
+            agent_id=agent_id,
+            handle=handle,
+            persona_source=PersonaSource.SYNC_BLUESKY,
+            display_name=handle,
+            created_at="2026_03_13-10:00:00",
+            updated_at="2026_03_13-10:00:00",
+        )
+    )

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -20,6 +20,7 @@ from tests.factories.posts import PostFactory
 from tests.factories.profiles import BlueskyProfileFactory
 from tests.factories.records import (
     AgentBioFactory,
+    AgentFollowEdgeFactory,
     AgentRecordFactory,
     UserAgentProfileMetadataFactory,
 )
@@ -29,6 +30,7 @@ from tests.factories.turns import TurnMetadataFactory, TurnResultFactory
 __all__ = [
     "AgentFactory",
     "AgentBioFactory",
+    "AgentFollowEdgeFactory",
     "AgentRecordFactory",
     "BlueskyProfileFactory",
     "CommentFactory",

--- a/tests/factories/records.py
+++ b/tests/factories/records.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from simulation.core.models.agent import Agent, PersonaSource
 from simulation.core.models.agent_bio import AgentBio, PersonaBioSource
+from simulation.core.models.agent_follow_edge import AgentFollowEdge
 from simulation.core.models.user_agent_profile_metadata import UserAgentProfileMetadata
 from tests.factories._helpers import _timestamp_utc_compact
 from tests.factories.base import BaseFactory
@@ -103,4 +104,40 @@ class UserAgentProfileMetadataFactory(BaseFactory[UserAgentProfileMetadata]):
             else fake.random_int(0, 10_000),
             created_at=created_at_value,
             updated_at=updated_at_value,
+        )
+
+
+class AgentFollowEdgeFactory(BaseFactory[AgentFollowEdge]):
+    @classmethod
+    def create(
+        cls,
+        *,
+        agent_follow_edge_id: str | None = None,
+        follower_agent_id: str | None = None,
+        target_agent_id: str | None = None,
+        created_at: str | None = None,
+    ) -> AgentFollowEdge:
+        fake = get_faker()
+        created_at_value = (
+            created_at if created_at is not None else _timestamp_utc_compact()
+        )
+        follower_agent_id_value = (
+            follower_agent_id
+            if follower_agent_id is not None
+            else f"did:plc:{fake.uuid4()}"
+        )
+        target_agent_id_value = (
+            target_agent_id
+            if target_agent_id is not None
+            else f"did:plc:{fake.uuid4()}"
+        )
+        return AgentFollowEdge(
+            agent_follow_edge_id=(
+                agent_follow_edge_id
+                if agent_follow_edge_id is not None
+                else f"afe_{fake.uuid4()}"
+            ),
+            follower_agent_id=follower_agent_id_value,
+            target_agent_id=target_agent_id_value,
+            created_at=created_at_value,
         )

--- a/tests/local_dev/test_local_mode_seed.py
+++ b/tests/local_dev/test_local_mode_seed.py
@@ -43,6 +43,10 @@ class TestLocalModeSeed:
 
             runs_count = conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
             assert runs_count > 0
+            follow_edges_count = conn.execute(
+                "SELECT COUNT(*) FROM agent_follow_edges"
+            ).fetchone()[0]
+            assert follow_edges_count > 0
         finally:
             conn.close()
 
@@ -74,6 +78,34 @@ class TestLocalModeSeed:
         assert runs_count_after == runs_count_before
 
         assert any("Local seed already applied" in r.message for r in caplog.records)
+
+    def test_seed_local_db_if_needed__syncs_follow_edge_metadata(
+        self,
+        temp_db,
+    ) -> None:
+        seed_local_db_if_needed(db_path=temp_db, fixtures_dir=FIXTURES_DIR)
+
+        conn = sqlite3.connect(temp_db)
+        try:
+            alice_counts = conn.execute(
+                """
+                SELECT followers_count, follows_count
+                FROM user_agent_profile_metadata
+                WHERE agent_id = 'agent_0240dc0d4a4c7e73'
+                """
+            ).fetchone()
+            edward_counts = conn.execute(
+                """
+                SELECT followers_count, follows_count
+                FROM user_agent_profile_metadata
+                WHERE agent_id = 'agent_d5aaff22974ebc2c'
+                """
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert alice_counts == (5, 2)
+        assert edward_counts == (0, 1)
 
     def test_api_endpoints__db_backed_with_seeded_db(
         self, temp_db, monkeypatch


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `agent_follow_edges` as the authoritative, editable seed-state for internal agent-to-agent follow relationships.

This PR introduces the `agent_follow_edges` table, core model, persistence layer, and API endpoints to manage pre-run follow relationships as durable row-level facts. It also updates `user_agent_profile_metadata.{follows_count,followers_count}` as derived/cache values transactionally on edge writes, establishing the first concrete pattern for seed-state row-level facts and avoiding lossy backfill from aggregate counts. Existing `follows` remains the immutable run-turn event log.

<div><a href="https://cursor.com/agents/bc-b2bb0e75-fb0c-4169-84be-f5d62bc9409e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2bb0e75-fb0c-4169-84be-f5d62bc9409e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->