### PR TITLE
Add Cursor Cloud setup for repo-wide quality gates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         pass_filenames: false
       - id: pyright
         name: pyright
-        entry: bash -lc "root=$(git rev-parse --show-toplevel) && cd \"$root\" && PYTHONPATH=\"$root\" uv run --extra test pyright ."
+        entry: bash -lc "root=$(git rev-parse --show-toplevel) && cd \"$root\" && PYTHONPATH=\"$root\" uv run --extra test --extra ner pyright ."
         language: system
         pass_filenames: false
       - id: python_lint_import_dependency_boundaries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,12 @@ Use `docs/runbooks/LOCAL_DEV_AUTH.md` for the authoritative steps.
   - Frontend: set `NEXT_PUBLIC_DISABLE_AUTH=true` in `ui/.env.local`.
 - Do **not** enable these flags in production or commit them to the repo.
 
+## Cursor Cloud specific instructions
+
+- For Cursor Cloud or other ephemeral agent environments that need repo-wide linting/type-checking, run `bash scripts/setup_cursor_cloud_env.sh`.
+- That script installs `uv sync --frozen --extra test --extra ner`, which is the expected dependency set for `uv run pre-commit run --all-files` and `uv run pyright .`.
+- Keep the default local-dev setup lightweight (`uv sync --extra test`) unless you need whole-repo checks that touch `ml_tooling/ner/`.
+
 ## Database + migrations (SQLite + Alembic)
 
 Canonical reference: `db/migrations/README`

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Quick start
 
 - **Setup:** `uv sync --extra test`
+- **Cursor Cloud / repo-wide lint + type checks:** `bash scripts/setup_cursor_cloud_env.sh`
 - **Run API:** `PYTHONPATH=. uv run uvicorn simulation.api.main:app --reload`
 - **Health check:** `http://localhost:8000/health` — API docs at `http://localhost:8000/docs`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Quick lookup table of contents for project documentation.
 | [runbooks/SMOKE_TEST.md](runbooks/SMOKE_TEST.md) | Run smoke tests against a live API |
 | [runbooks/LOAD_TESTING.md](runbooks/LOAD_TESTING.md) | Run load tests with scripts |
 | [runbooks/PRE_COMMIT_AND_LINTING.md](runbooks/PRE_COMMIT_AND_LINTING.md) | Pre-commit, Ruff, Pyright, complexipy |
+| [runbooks/CURSOR_CLOUD_ENV_SETUP.md](runbooks/CURSOR_CLOUD_ENV_SETUP.md) | Configure Cursor Cloud startup for repo-wide quality gates |
 | [runbooks/CREATE_NEW_PYTHON_TESTS.md](runbooks/CREATE_NEW_PYTHON_TESTS.md) | Add new Python tests (pytest) using factories + Hypothesis |
 | [runbooks/HOW_TO_CREATE_NEW_METRIC.md](runbooks/HOW_TO_CREATE_NEW_METRIC.md) | Add a new metric to the simulation |
 

--- a/docs/runbooks/CURSOR_CLOUD_ENV_SETUP.md
+++ b/docs/runbooks/CURSOR_CLOUD_ENV_SETUP.md
@@ -1,0 +1,53 @@
+---
+description: Configure Cursor Cloud startup so repo-wide quality gates run without manual Python installs.
+tags: [cursor, cloud, onboarding, environment, pre-commit, pyright]
+---
+
+# Cursor Cloud Environment Setup
+
+Use this runbook when configuring Cursor Cloud or any other ephemeral agent environment for this repo.
+
+## Goal
+
+Make these repo-wide quality gates work without manual Python installs:
+
+- `uv run pre-commit run --all-files`
+- `uv run pyright .`
+
+## Recommended startup command
+
+From the repository root, run:
+
+```bash
+bash scripts/setup_cursor_cloud_env.sh
+```
+
+That script installs the Python dependencies needed for repo-wide linting and type checking:
+
+```bash
+uv sync --frozen --extra test --extra ner
+```
+
+## Why `--extra ner` is required
+
+Whole-repo type checking touches `ml_tooling/ner/`, which imports `transformers`.
+
+- `pre-commit`, `pyright`, and other quality tools live in the `test` extra.
+- `transformers` (and `torch`) live in the `ner` extra.
+
+If Cursor Cloud only installs `--extra test`, `uv run pyright .` can fail on missing NER imports.
+
+## Verify the environment
+
+After startup completes, run:
+
+```bash
+uv run pre-commit run --all-files
+uv run pyright .
+```
+
+## Minimal fallback
+
+There is no smaller project-managed extra combination that still guarantees both commands pass. If startup time is a concern, keep the startup command the same and rely on caching rather than dropping `--extra ner`.
+
+Do not replace `--extra ner` with an ad-hoc `pip install transformers`; keep dependency resolution in `uv` so agents and CI stay aligned.

--- a/docs/runbooks/PRE_COMMIT_AND_LINTING.md
+++ b/docs/runbooks/PRE_COMMIT_AND_LINTING.md
@@ -7,18 +7,28 @@ tags: [pre-commit, linting, ruff, pyright, complexipy, code-quality]
 
 This runbook covers pre-commit hooks and code quality tools (Ruff, Pyright, complexipy).
 
+## Setup for repo-wide checks
+
+Install the quality-gate dependencies before running repo-wide checks:
+
+```bash
+uv sync --frozen --extra test --extra ner
+```
+
+The `test` extra provides `pre-commit`, `pyright`, and related tooling. The `ner` extra is also required because whole-repo type checking reaches `ml_tooling/ner/`, which imports `transformers`.
+
 ## Pre-commit
 
 Install hooks so Ruff, complexipy, and pyright run before each commit:
 
 ```bash
-pre-commit install
+uv run pre-commit install
 ```
 
 Run on all files:
 
 ```bash
-pre-commit run --all-files
+uv run pre-commit run --all-files
 ```
 
 ## Ruff (lint and format)

--- a/scripts/setup_cursor_cloud_env.sh
+++ b/scripts/setup_cursor_cloud_env.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+uv sync --frozen --extra test --extra ner


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a checked-in `scripts/setup_cursor_cloud_env.sh` startup script that installs `uv sync --frozen --extra test --extra ner`
- document Cursor Cloud environment setup in a new runbook and link it from the repo docs and README
- align the local `pyright` pre-commit hook with CI by requesting the `ner` extra

## Testing
- `bash scripts/setup_cursor_cloud_env.sh`
- `uv run python scripts/check_docs_metadata.py docs/runbooks/CURSOR_CLOUD_ENV_SETUP.md docs/runbooks/PRE_COMMIT_AND_LINTING.md`
- `uv run pre-commit run --all-files`
- `uv run pyright .`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e9abfaa-704d-4d11-afc9-ed5d0ec5ec9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e9abfaa-704d-4d11-afc9-ed5d0ec5ec9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pre-commit hook configuration to include additional dependency support.
  * Added automated environment setup script for proper dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->