### PR TITLE
[2026-03-18] Codex repo automation - conventions

### DIFF
--- a/db/migrations/versions/6a7b8c9d0e1f_add_run_agents.py
+++ b/db/migrations/versions/6a7b8c9d0e1f_add_run_agents.py
@@ -6,16 +6,16 @@ Create Date: 2026-03-13 00:00:00.000000
 
 """
 
-from typing import Sequence, Union
+from typing import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "6a7b8c9d0e1f"
-down_revision: Union[str, Sequence[str], None] = "e1f0d1c2b3a4"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = "e1f0d1c2b3a4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/db/migrations/versions/7b363560da3c_add_agent_posts.py
+++ b/db/migrations/versions/7b363560da3c_add_agent_posts.py
@@ -6,16 +6,16 @@ Create Date: 2026-03-17 13:37:00.610644
 
 """
 
-from typing import Sequence, Union
+from typing import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "7b363560da3c"
-down_revision: Union[str, Sequence[str], None] = "8f6c2a1b4d3e"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = "8f6c2a1b4d3e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/db/migrations/versions/8f6c2a1b4d3e_add_run_follow_edges.py
+++ b/db/migrations/versions/8f6c2a1b4d3e_add_run_follow_edges.py
@@ -6,16 +6,16 @@ Create Date: 2026-03-17 17:30:00.000000
 
 """
 
-from typing import Sequence, Union
+from typing import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "8f6c2a1b4d3e"
-down_revision: Union[str, Sequence[str], None] = "d31fef7e41c3"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = "d31fef7e41c3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/db/migrations/versions/d31fef7e41c3_add_agent_follow_edges.py
+++ b/db/migrations/versions/d31fef7e41c3_add_agent_follow_edges.py
@@ -6,16 +6,16 @@ Create Date: 2026-03-17 14:46:54.879594
 
 """
 
-from typing import Sequence, Union
+from typing import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "d31fef7e41c3"
-down_revision: Union[str, Sequence[str], None] = "6a7b8c9d0e1f"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = "6a7b8c9d0e1f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Codex automation
This PR was created by Codex repo automation after reviewing recent commits against repo conventions.

## Improvements
- Replaced `Union[str, Sequence[str], None]` with `str | Sequence[str] | None` in migration revision metadata annotations.
- Removed unused `Union` imports in the touched migration files.
- Kept scope minimal to convention-only typing updates in recently added migrations.

## Files updated
- `db/migrations/versions/6a7b8c9d0e1f_add_run_agents.py`
- `db/migrations/versions/d31fef7e41c3_add_agent_follow_edges.py`
- `db/migrations/versions/8f6c2a1b4d3e_add_run_follow_edges.py`
- `db/migrations/versions/7b363560da3c_add_agent_posts.py`

## Local validation
- `ruff check` on touched migration files passed.
- `python3 -m pytest tests/scripts/test_backfill_agent_posts.py -q` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized type annotations across database migration files to use Python 3.10+ union syntax for improved code clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->