### PR TITLE
refactor: pass Run through _simulate_turn to avoid per-turn get_run (fixes #244)

### DIFF
--- a/simulation/core/command_service.py
+++ b/simulation/core/command_service.py
@@ -234,12 +234,12 @@ class SimulationCommandService:
                 run_config.feed_algorithm_config
             )
             self._simulate_turn(
-                run.run_id,
-                turn_number,
-                agents,
-                run_config.feed_algorithm,
-                action_history_store,
-                turn_metric_keys,
+                run=run,
+                turn_number=turn_number,
+                agents=agents,
+                feed_algorithm=run_config.feed_algorithm,
+                action_history_store=action_history_store,
+                turn_metric_keys=turn_metric_keys,
                 feed_algorithm_config=feed_algorithm_config,
             )
         except Exception as e:
@@ -270,6 +270,7 @@ class SimulationCommandService:
         action_history_store: ActionHistoryStore,
         turn_metric_keys: list[str],
     ) -> None:
+        validate_run_exists(run=run, run_id=run.run_id)
         for turn_number in range(total_turns):
             self.simulate_turn(
                 run=run,
@@ -297,7 +298,7 @@ class SimulationCommandService:
     @timed()
     def _simulate_turn(
         self,
-        run_id: str,
+        run: Run,
         turn_number: int,
         agents: list[SimulationAgent],
         feed_algorithm: str,
@@ -306,9 +307,7 @@ class SimulationCommandService:
         feed_algorithm_config: Mapping[str, JsonValue] | None = None,
     ) -> TurnResult:
         """Simulate a single turn of the simulation."""
-
-        run = self.run_repo.get_run(run_id)
-        validate_run_exists(run=run, run_id=run_id)
+        run_id: str = run.run_id
 
         agent_to_hydrated_feeds: dict[str, list[Post]] = (
             self.feed_generator.generate_feeds(

--- a/tests/simulation/core/test_command_service.py
+++ b/tests/simulation/core/test_command_service.py
@@ -638,7 +638,7 @@ class TestSimulationCommandServiceExecuteRun:
         ):
             action_history_store = Mock()
             result = command_service._simulate_turn(
-                run_id=sample_run.run_id,
+                run=sample_run,
                 turn_number=0,
                 agents=[agent],
                 feed_algorithm="chronological",
@@ -747,7 +747,7 @@ class TestSimulationCommandServiceExecuteRun:
         ):
             action_history_store = Mock()
             result = command_service._simulate_turn(
-                run_id=sample_run.run_id,
+                run=sample_run,
                 turn_number=0,
                 agents=[agent],
                 feed_algorithm="chronological",
@@ -824,7 +824,7 @@ class TestSimulationCommandServiceExecuteRun:
 
         action_history_store = InMemoryActionHistoryStore()
         result = command_service._simulate_turn(
-            run_id=sample_run.run_id,
+            run=sample_run,
             turn_number=0,
             agents=[agent],
             feed_algorithm="chronological",
@@ -982,7 +982,7 @@ class TestSimulationCommandServiceActionPersistence:
             ),
         ):
             command_service._simulate_turn(
-                run_id=run_id,
+                run=run,
                 turn_number=0,
                 agents=[agent],
                 feed_algorithm="chronological",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses #244: Avoid per-turn `run_repo.get_run` by passing the `Run` object through simulation turn execution.

## Problem

`_simulate_turn` re-fetched `Run` via `run_repo.get_run(run_id)` every turn even though callers already had the `Run` object. This added unnecessary DB traffic and complicated control flow.

## Changes

- **`simulation/core/command_service.py`**
  - Changed `_simulate_turn` to accept `run: Run` instead of `run_id: str`
  - Removed the per-turn `run_repo.get_run(run_id)` call
  - Added `validate_run_exists(run=run, run_id=run.run_id)` once at the start of `simulate_turns` before entering the turn loop
  - Use `run.run_id` locally within `_simulate_turn` where the ID is needed

- **`tests/simulation/core/test_command_service.py`**
  - Updated all direct calls to `_simulate_turn` to pass `run=sample_run` or `run=run` instead of `run_id=...`

## Acceptance criteria

- [x] No per-turn `get_run` call
- [x] Run existence/status validation remains correct (validated once before turn loop)
- [x] `uv run ruff check .` passes
- [x] `uv run pyright .` passes (pre-existing ml_tooling transformers errors unrelated)
- [x] `uv run pytest` passes for simulation, api, db, feeds, lib tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39854467-47e0-4a31-b166-ec0ff918ff60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39854467-47e0-4a31-b166-ec0ff918ff60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal simulation execution architecture to improve code maintainability and reduce dependencies between components. Enhanced how run context flows through the turn execution pipeline, consolidating validation logic and improving separation of concerns. These foundational improvements strengthen overall code organization and support more reliable simulation processing for future development work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->