### PR TITLE
Refactor AgentActionRulesValidator branching into data-driven dispatch (Closes #243)

### DIFF
--- a/simulation/core/action_policy/rules_validator.py
+++ b/simulation/core/action_policy/rules_validator.py
@@ -1,12 +1,139 @@
 from __future__ import annotations
 
 from collections import Counter
+from typing import Callable
 
 from simulation.core.action_history.interfaces import ActionHistoryStore
 from simulation.core.models.actions import TurnAction
 from simulation.core.models.generated.comment import GeneratedComment
 from simulation.core.models.generated.follow import GeneratedFollow
 from simulation.core.models.generated.like import GeneratedLike
+
+# Type alias for duplicate validator: (validator, run_id, turn_number, agent_handle, identifiers) -> None
+_DuplicateValidator = Callable[
+    ["AgentActionRulesValidator", str, int, str, list[str]], None
+]
+# Type alias for history validator: (validator, run_id, turn_number, agent_handle, identifiers, store) -> None
+_HistoryValidator = Callable[
+    [
+        "AgentActionRulesValidator",
+        str,
+        int,
+        str,
+        list[str],
+        ActionHistoryStore,
+    ],
+    None,
+]
+
+
+def _dispatch_duplicate_like(
+    validator: AgentActionRulesValidator,
+    run_id: str,
+    turn_number: int,
+    agent_handle: str,
+    identifiers: list[str],
+) -> None:
+    validator._validate_duplicate_likes(
+        run_id=run_id,
+        turn_number=turn_number,
+        agent_handle=agent_handle,
+        like_post_ids=identifiers,
+    )
+
+
+def _dispatch_duplicate_comment(
+    validator: AgentActionRulesValidator,
+    run_id: str,
+    turn_number: int,
+    agent_handle: str,
+    identifiers: list[str],
+) -> None:
+    validator._validate_duplicate_comments(
+        run_id=run_id,
+        turn_number=turn_number,
+        agent_handle=agent_handle,
+        comment_post_ids=identifiers,
+    )
+
+
+def _dispatch_duplicate_follow(
+    validator: AgentActionRulesValidator,
+    run_id: str,
+    turn_number: int,
+    agent_handle: str,
+    identifiers: list[str],
+) -> None:
+    validator._validate_duplicate_follows(
+        run_id=run_id,
+        turn_number=turn_number,
+        agent_handle=agent_handle,
+        follow_user_ids=identifiers,
+    )
+
+
+def _dispatch_history_like(
+    validator: AgentActionRulesValidator,
+    run_id: str,
+    turn_number: int,
+    agent_handle: str,
+    identifiers: list[str],
+    action_history_store: ActionHistoryStore,
+) -> None:
+    validator._validate_previously_liked(
+        run_id=run_id,
+        turn_number=turn_number,
+        agent_handle=agent_handle,
+        like_post_ids=identifiers,
+        action_history_store=action_history_store,
+    )
+
+
+def _dispatch_history_comment(
+    validator: AgentActionRulesValidator,
+    run_id: str,
+    turn_number: int,
+    agent_handle: str,
+    identifiers: list[str],
+    action_history_store: ActionHistoryStore,
+) -> None:
+    validator._validate_previously_commented(
+        run_id=run_id,
+        turn_number=turn_number,
+        agent_handle=agent_handle,
+        comment_post_ids=identifiers,
+        action_history_store=action_history_store,
+    )
+
+
+def _dispatch_history_follow(
+    validator: AgentActionRulesValidator,
+    run_id: str,
+    turn_number: int,
+    agent_handle: str,
+    identifiers: list[str],
+    action_history_store: ActionHistoryStore,
+) -> None:
+    validator._validate_previously_followed(
+        run_id=run_id,
+        turn_number=turn_number,
+        agent_handle=agent_handle,
+        follow_user_ids=identifiers,
+        action_history_store=action_history_store,
+    )
+
+
+_DUPLICATE_DISPATCH: dict[TurnAction, _DuplicateValidator] = {
+    TurnAction.LIKE: _dispatch_duplicate_like,
+    TurnAction.COMMENT: _dispatch_duplicate_comment,
+    TurnAction.FOLLOW: _dispatch_duplicate_follow,
+}
+
+_HISTORY_DISPATCH: dict[TurnAction, _HistoryValidator] = {
+    TurnAction.LIKE: _dispatch_history_like,
+    TurnAction.COMMENT: _dispatch_history_comment,
+    TurnAction.FOLLOW: _dispatch_history_follow,
+}
 
 
 class AgentActionRulesValidator:
@@ -126,31 +253,12 @@ class AgentActionRulesValidator:
         agent_handle: str,
         identifiers: list[str],
     ) -> None:
-        if action_type == TurnAction.LIKE:
-            self._validate_duplicate_likes(
-                run_id=run_id,
-                turn_number=turn_number,
-                agent_handle=agent_handle,
-                like_post_ids=identifiers,
-            )
-        elif action_type == TurnAction.COMMENT:
-            self._validate_duplicate_comments(
-                run_id=run_id,
-                turn_number=turn_number,
-                agent_handle=agent_handle,
-                comment_post_ids=identifiers,
-            )
-        elif action_type == TurnAction.FOLLOW:
-            self._validate_duplicate_follows(
-                run_id=run_id,
-                turn_number=turn_number,
-                agent_handle=agent_handle,
-                follow_user_ids=identifiers,
-            )
-        else:
+        validator_fn = _DUPLICATE_DISPATCH.get(action_type)
+        if validator_fn is None:
             raise ValueError(
                 f"Unknown action_type for duplicate validation: {action_type}"
             )
+        validator_fn(self, run_id, turn_number, agent_handle, identifiers)
 
     def _validate_previously_acted_on(
         self,
@@ -162,34 +270,19 @@ class AgentActionRulesValidator:
         identifiers: list[str],
         action_history_store: ActionHistoryStore,
     ) -> None:
-        if action_type == TurnAction.LIKE:
-            self._validate_previously_liked(
-                run_id=run_id,
-                turn_number=turn_number,
-                agent_handle=agent_handle,
-                like_post_ids=identifiers,
-                action_history_store=action_history_store,
-            )
-        elif action_type == TurnAction.COMMENT:
-            self._validate_previously_commented(
-                run_id=run_id,
-                turn_number=turn_number,
-                agent_handle=agent_handle,
-                comment_post_ids=identifiers,
-                action_history_store=action_history_store,
-            )
-        elif action_type == TurnAction.FOLLOW:
-            self._validate_previously_followed(
-                run_id=run_id,
-                turn_number=turn_number,
-                agent_handle=agent_handle,
-                follow_user_ids=identifiers,
-                action_history_store=action_history_store,
-            )
-        else:
+        validator_fn = _HISTORY_DISPATCH.get(action_type)
+        if validator_fn is None:
             raise ValueError(
                 f"Unknown action_type for history validation: {action_type}"
             )
+        validator_fn(
+            self,
+            run_id,
+            turn_number,
+            agent_handle,
+            identifiers,
+            action_history_store,
+        )
 
     def _validate_duplicate_likes(
         self,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors `AgentActionRulesValidator` to replace repeated `if action_type == ...` branches with data-driven dispatch tables, as requested in #243.

## Changes

- **Dispatch tables**: Added `_DUPLICATE_DISPATCH` and `_HISTORY_DISPATCH` mapping `TurnAction` to validator callables
- **Module-level dispatchers**: Introduced `_dispatch_duplicate_*` and `_dispatch_history_*` functions that forward common args to the appropriate `_validate_duplicate_*` / `_validate_previously_*` methods
- **Simplified branching**: Replaced `if/elif/else` in `_validate_duplicates` and `_validate_previously_acted_on` with a single lookup and call

## Acceptance criteria (from #243)

- [x] Same validation behavior and error messages (preserved)
- [x] Adding a new action type requires only small, localized changes (add dispatch entry + implement validator method)
- [x] `uv run ruff check .`, `uv run pyright .`, and `uv run pytest` pass for the modified module and dependent tests

## Testing

- All 5 `test_agent_action_rules_validator` tests pass
- All 134 `tests/simulation/core/` tests pass
- Pyright reports 0 errors on `simulation/core/action_policy/`

Closes #243
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04c9ddd1-2f7d-476b-9690-c32a0f540a5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04c9ddd1-2f7d-476b-9690-c32a0f540a5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal validation logic for improved code maintainability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->