### PR TITLE
Make create_agent handle race-safe

### DIFF
--- a/db/adapters/sqlite/agent_adapter.py
+++ b/db/adapters/sqlite/agent_adapter.py
@@ -14,8 +14,15 @@ from simulation.core.utils.validators import validate_agent_id, validate_handle_
 AGENT_COLUMNS = ordered_column_names(agent_table)
 AGENT_REQUIRED_FIELDS = required_column_names(agent_table)
 _INSERT_AGENT_SQL = (
-    f"INSERT OR REPLACE INTO agent ({', '.join(AGENT_COLUMNS)}) "
-    f"VALUES ({', '.join('?' for _ in AGENT_COLUMNS)})"
+    # Intentionally *not* using `OR REPLACE`:
+    # - `OR REPLACE` can delete+reinsert on conflicts, which prevents unique
+    #   handle violations from reliably surfacing to the API layer.
+    # - For correct semantics, we want `uq_agent_handle` violations to raise
+    #   `sqlite3.IntegrityError` so the service can map them to HTTP 409.
+    f"INSERT INTO agent ({', '.join(AGENT_COLUMNS)}) "
+    f"VALUES ({', '.join('?' for _ in AGENT_COLUMNS)}) "
+    f"ON CONFLICT(agent_id) DO UPDATE SET "
+    + ", ".join(f"{col}=excluded.{col}" for col in AGENT_COLUMNS if col != "agent_id")
 )
 
 

--- a/db/repositories/agent_repository.py
+++ b/db/repositories/agent_repository.py
@@ -1,11 +1,13 @@
 """SQLite implementation of agent repositories."""
 
+import sqlite3
 from collections.abc import Iterable
 
 from db.adapters.base import AgentDatabaseAdapter, TransactionProvider
 from db.repositories.interfaces import AgentRepository
 from lib.validation_decorators import validate_inputs
 from simulation.core.models.agent import Agent
+from simulation.core.utils.exceptions import HandleAlreadyExistsError
 from simulation.core.utils.validators import validate_agent_id, validate_handle_exists
 
 
@@ -24,11 +26,22 @@ class SQLiteAgentRepository(AgentRepository):
 
     def create_or_update_agent(self, agent: Agent, conn: object | None = None) -> Agent:
         """Create or update an agent in SQLite."""
-        if conn is not None:
-            self._db_adapter.write_agent(agent, conn=conn)
-        else:
-            with self._transaction_provider.run_transaction() as c:
-                self._db_adapter.write_agent(agent, conn=c)
+        try:
+            if conn is not None:
+                self._db_adapter.write_agent(agent, conn=conn)
+            else:
+                with self._transaction_provider.run_transaction() as c:
+                    self._db_adapter.write_agent(agent, conn=c)
+        except sqlite3.IntegrityError as exc:
+            # `agent.handle` is unique; translate constraint violations into a
+            # stable domain error so API services can map to HTTP 409.
+            msg = str(exc).lower()
+            is_unique_handle_violation = "uq_agent_handle" in msg or (
+                "unique constraint failed" in msg and "agent.handle" in msg
+            )
+            if is_unique_handle_violation:
+                raise HandleAlreadyExistsError(agent.handle) from exc
+            raise
         return agent
 
     @validate_inputs((validate_agent_id, "agent_id"))

--- a/simulation/api/services/agent_command_service.py
+++ b/simulation/api/services/agent_command_service.py
@@ -18,6 +18,7 @@ from simulation.api.services.agent_follows_command_service import (
 from simulation.core.models.agent import Agent, PersonaSource
 from simulation.core.models.agent_bio import AgentBio, PersonaBioSource
 from simulation.core.models.user_agent_profile_metadata import UserAgentProfileMetadata
+from simulation.core.utils.exceptions import HandleAlreadyExistsError
 from simulation.core.utils.handle_utils import normalize_handle
 
 
@@ -34,12 +35,6 @@ def create_agent(
     display_name = req.display_name.strip()
     bio_text = (req.bio or "").strip() or "No bio provided."
 
-    # TODO: that this can cause a slight race condition if we do this check
-    # before the below context manager for writing the agent to the database.
-    # This is a known issue, and we'll revisit this in the future.
-    if agent_repo.get_agent_by_handle(handle) is not None:
-        raise ApiHandleAlreadyExistsError(handle)
-
     agent_id = _generate_agent_id()
     now = get_current_timestamp()
 
@@ -47,10 +42,15 @@ def create_agent(
     agent_bio = _generate_agent_bio(agent_id, bio_text, now)
     metadata = _generate_user_agent_profile_metadata(agent_id, now)
 
-    with transaction_provider.run_transaction() as conn:
-        agent_repo.create_or_update_agent(agent, conn=conn)
-        bio_repo.create_agent_bio(agent_bio, conn=conn)
-        metadata_repo.create_or_update_metadata(metadata, conn=conn)
+    try:
+        with transaction_provider.run_transaction() as conn:
+            agent_repo.create_or_update_agent(agent, conn=conn)
+            bio_repo.create_agent_bio(agent_bio, conn=conn)
+            metadata_repo.create_or_update_metadata(metadata, conn=conn)
+    except HandleAlreadyExistsError as e:
+        # `agent.handle` is unique in the DB; translate the stable domain error
+        # to the API-level error expected by the route layer.
+        raise ApiHandleAlreadyExistsError(e.handle) from e
 
     return _build_agent_schema(agent.handle, agent.display_name, bio_text)
 

--- a/tests/api/test_simulation_agents.py
+++ b/tests/api/test_simulation_agents.py
@@ -1,8 +1,16 @@
 """Tests for agent API endpoints."""
 
+import queue
+import threading
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 
 from simulation.api.constants import DEFAULT_AGENT_LIST_LIMIT
+from simulation.api.errors import ApiHandleAlreadyExistsError
+from simulation.api.schemas.simulation import CreateAgentRequest
+from simulation.api.services.agent_command_service import (
+    create_agent as create_agent_service,
+)
 from simulation.core.models.agent import PersonaSource
 from tests.factories import AgentRecordFactory
 
@@ -126,6 +134,56 @@ class TestSimulationAgents:
         err = r2.json()
         assert "error" in err
         assert err["error"]["code"] == expected_result["error_code"]
+
+    def test_post_simulations_agents_duplicate_handle_concurrent_returns_409(
+        self,
+        temp_db,
+        sqlite_tx,
+        agent_repo,
+        agent_bio_repo,
+        user_agent_profile_metadata_repo,
+    ):
+        """Concurrent create attempts for the same handle produce exactly one 409."""
+        handle = f"dup-{uuid.uuid4().hex[:8]}.bsky.social"
+        req = CreateAgentRequest(handle=handle, display_name="First", bio="")
+
+        barrier = threading.Barrier(2)
+        result_queue: queue.Queue[tuple[str, str]] = queue.Queue()
+
+        def worker() -> None:
+            barrier.wait()
+            try:
+                res = create_agent_service(
+                    req,
+                    transaction_provider=sqlite_tx,
+                    agent_repo=agent_repo,
+                    bio_repo=agent_bio_repo,
+                    metadata_repo=user_agent_profile_metadata_repo,
+                )
+                result_queue.put(("ok", res.handle))
+            except ApiHandleAlreadyExistsError:
+                result_queue.put(("dup", req.handle))
+            except Exception as e:  # pragma: no cover (diagnostic)
+                result_queue.put(("err", f"{type(e).__name__}: {e}"))
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(worker) for _ in range(2)]
+            for f in futures:
+                f.result()
+
+        results = [result_queue.get() for _ in range(2)]
+        ok = [r for (kind, r) in results if kind == "ok"]
+        dup = [r for (kind, r) in results if kind == "dup"]
+        errs = [r for (kind, r) in results if kind == "err"]
+
+        assert not errs, f"Unexpected errors during concurrent create: {errs}"
+        assert len(ok) == 1
+        assert len(dup) == 1
+
+        normalized_handle = f"@{handle.lower()}"
+        created = agent_repo.get_agent_by_handle(normalized_handle)
+        assert created is not None
+        assert created.handle == normalized_handle
 
     def test_post_simulations_agents_validation_empty_handle_returns_422(
         self,


### PR DESCRIPTION
## Summary
- Removed the check-then-insert race in `create_agent`.
- SQLite now raises a stable domain error (`HandleAlreadyExistsError`) when the unique `agent.handle` constraint is violated.
- API services translate that into the existing HTTP 409 response (`HANDLE_ALREADY_EXISTS`).
- Added a concurrency regression test to ensure only one request succeeds for the same handle.

Fixes https://github.com/METResearchGroup/social_agent_simulation_platform/issues/245

## Test plan
- `uv run ruff check .`
- `uv run pyright .`
- `uv run pytest`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate agent handle creation with clearer error messaging when attempting to create an agent with an existing handle. Enhanced protection against race conditions during concurrent creation attempts.

* **Tests**
  * Added concurrent execution test coverage to validate duplicate handle creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->