### PR TITLE
Add repo/adapter conn contract lint rule

### DIFF
--- a/scripts/lint_architecture.py
+++ b/scripts/lint_architecture.py
@@ -804,7 +804,7 @@ def _find_py13_repo_conn_contract(
             return False
         return _is_none_literal(test.comparators[0])
 
-    def is_transaction_with_as_c(node: ast.With) -> bool:
+    def is_transaction_with_as_c(node: ast.With | ast.AsyncWith) -> bool:
         # Pattern: with self._transaction_provider.run_transaction() as c:
         for item in node.items:
             ctx = item.context_expr
@@ -955,7 +955,8 @@ def _find_py13_repo_conn_contract(
             tx_with_nodes = [
                 n
                 for n in ast.walk(fn)
-                if isinstance(n, ast.With) and is_transaction_with_as_c(n)
+                if isinstance(n, (ast.With, ast.AsyncWith))
+                and is_transaction_with_as_c(n)
             ]
             with_node = tx_with_nodes[0] if tx_with_nodes else None
             if with_node is None:
@@ -994,6 +995,136 @@ def _find_py13_repo_conn_contract(
     return violations
 
 
+def _find_py14_adapter_conn_signature(path: str, tree: ast.AST) -> list[Violation]:
+    """Enforce `conn` parameter presence on adapter implementations.
+
+    For every concrete adapter class that subclasses an ABC in
+    `db/adapters/base.py`, check all methods implemented in the concrete class
+    whose names exist on the ABC *and* whose ABC signature includes a `conn`
+    parameter. Those concrete methods must also include `conn` in their own
+    signature.
+
+    This lint is intentionally name-based and does not validate `conn` types.
+    """
+
+    p = _posix(path)
+    if not p.startswith("db/adapters/"):
+        return []
+    if p.endswith("db/adapters/base.py") or p.endswith("/base.py"):
+        return []
+
+    imports = _build_import_table(tree)
+
+    # Base ABC class name -> set(method names) where base method signature has `conn`.
+    if not hasattr(_find_py14_adapter_conn_signature, "_cache"):
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        base_path = os.path.join(repo_root, "db", "adapters", "base.py")
+        try:
+            with open(base_path, "r", encoding="utf-8") as f:
+                base_source = f.read()
+            base_tree = ast.parse(base_source, filename=base_path)
+        except OSError:
+            base_tree = ast.Module(body=[], type_ignores=[])
+
+        abc_methods_with_conn: dict[str, set[str]] = {}
+
+        for class_node in ast.walk(base_tree):
+            if not isinstance(class_node, ast.ClassDef):
+                continue
+            method_names: set[str] = set()
+            for stmt in class_node.body:
+                if not isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if not stmt.decorator_list:
+                    continue
+
+                # Detect `@abstractmethod` via simple decorator-name matching.
+                has_abstractmethod = any(
+                    isinstance(d, ast.Name) and d.id == "abstractmethod"
+                    for d in stmt.decorator_list
+                ) or any(
+                    isinstance(d, ast.Attribute) and d.attr == "abstractmethod"
+                    for d in stmt.decorator_list
+                )
+                if not has_abstractmethod:
+                    continue
+
+                arg_names: set[str] = {a.arg for a in stmt.args.args}
+                arg_names |= {a.arg for a in stmt.args.posonlyargs}
+                arg_names |= {a.arg for a in stmt.args.kwonlyargs}
+                if "conn" in arg_names:
+                    method_names.add(stmt.name)
+
+            if method_names:
+                abc_methods_with_conn[class_node.name] = method_names
+
+        setattr(
+            _find_py14_adapter_conn_signature,
+            "_cache",
+            abc_methods_with_conn,
+        )
+
+    abc_methods_with_conn = getattr(
+        _find_py14_adapter_conn_signature,
+        "_cache",
+        {},
+    )
+
+    def _base_class_names(class_def: ast.ClassDef) -> set[str]:
+        names: set[str] = set()
+        for base in class_def.bases:
+            if isinstance(base, ast.Name):
+                # Best effort: resolve local import alias -> fully-qualified symbol.
+                local = base.id
+                resolved = imports.symbols.get(local, local)
+                names.add(resolved.split(".")[-1])
+            elif isinstance(base, ast.Attribute):
+                names.add(base.attr)
+        return names
+
+    def _method_includes_conn(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+        arg_names: set[str] = {a.arg for a in fn.args.args}
+        arg_names |= {a.arg for a in fn.args.posonlyargs}
+        arg_names |= {a.arg for a in fn.args.kwonlyargs}
+        return "conn" in arg_names
+
+    violations: list[Violation] = []
+
+    for class_node in ast.walk(tree):
+        if not isinstance(class_node, ast.ClassDef):
+            continue
+        base_names = _base_class_names(class_node)
+        matching_abc_names = [n for n in base_names if n in abc_methods_with_conn]
+        if not matching_abc_names:
+            continue
+
+        required_methods: set[str] = set()
+        for abc_name in matching_abc_names:
+            required_methods |= abc_methods_with_conn.get(abc_name, set())
+
+        for stmt in class_node.body:
+            if not isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if stmt.name not in required_methods:
+                continue
+            if not _method_includes_conn(stmt):
+                violations.append(
+                    Violation(
+                        path=path,
+                        line=stmt.lineno,
+                        col=stmt.col_offset + 1,
+                        rule="PY-14",
+                        message=(
+                            f"Adapter method '{class_node.name}.{stmt.name}' must "
+                            "include a `conn` parameter in its signature (type is "
+                            "database-specific)."
+                        ),
+                    )
+                )
+
+    return violations
+
+
 def lint_file(path: str, source: str) -> tuple[int, list[Violation]]:
     try:
         tree = ast.parse(source, filename=path)
@@ -1019,6 +1150,7 @@ def lint_file(path: str, source: str) -> tuple[int, list[Violation]]:
     violations.extend(_find_py8_service_to_service_in_core(path, tree, imports))
     violations.extend(_find_py9_concrete_infra_type_hints(path, tree, imports))
     violations.extend(_find_py13_repo_conn_contract(path, tree))
+    violations.extend(_find_py14_adapter_conn_signature(path, tree))
 
     return (0, violations)
 

--- a/tests/lint/test_lint_architecture.py
+++ b/tests/lint/test_lint_architecture.py
@@ -89,6 +89,25 @@ class TestLintArchitecturePY13RepoConnContract:
         )
         assert "PY-13" in _rules(violations)
 
+    def test_accepts_async_transaction_fallback_with_as_c(self):
+        violations = _lint(
+            "db/repositories/test_agent_posts_repository.py",
+            """
+            class SQLiteTestAgentPostsRepository(AgentPostRepository):
+                def __init__(self):
+                    pass
+
+                async def list_posts_for_agent_ids(self, agent_ids: list[str], conn: object | None = None):
+                    if not agent_ids:
+                        return []
+                    if conn is not None:
+                        return self._db_adapter.read_posts_for_agent_ids(agent_ids, conn=conn)
+                    async with self._transaction_provider.run_transaction() as c:
+                        return self._db_adapter.read_posts_for_agent_ids(agent_ids, conn=c)
+            """,
+        )
+        assert "PY-13" not in _rules(violations)
+
     def test_ignores_public_methods_without_db_adapter_call(self):
         violations = _lint(
             "db/repositories/test_agent_posts_repository.py",
@@ -103,3 +122,47 @@ class TestLintArchitecturePY13RepoConnContract:
             """,
         )
         assert "PY-13" not in _rules(violations)
+
+
+class TestLintArchitecturePY14AdapterConnSignature:
+    def test_accepts_conn_parameter_in_adapter_method_signature(self):
+        violations = _lint(
+            "db/adapters/test_adapter.py",
+            """
+            class AgentPostDatabaseAdapter:
+                pass
+
+            class SQLiteTestAgentPostAdapter(AgentPostDatabaseAdapter):
+                def read_posts_for_agent_ids(self, agent_ids, *, conn):
+                    return []
+            """,
+        )
+        assert "PY-14" not in _rules(violations)
+
+    def test_rejects_missing_conn_parameter_in_adapter_method_signature(self):
+        violations = _lint(
+            "db/adapters/test_adapter.py",
+            """
+            class AgentPostDatabaseAdapter:
+                pass
+
+            class SQLiteTestAgentPostAdapter(AgentPostDatabaseAdapter):
+                def read_posts_for_agent_ids(self, agent_ids):
+                    return []
+            """,
+        )
+        assert "PY-14" in _rules(violations)
+
+    def test_ignores_classes_not_subclassing_known_adapter_abc(self):
+        violations = _lint(
+            "db/adapters/test_adapter.py",
+            """
+            class NotAnAdapter:
+                pass
+
+            class ConcreteNotAdapter(NotAnAdapter):
+                def read_posts_for_agent_ids(self, agent_ids):
+                    return []
+            """,
+        )
+        assert "PY-14" not in _rules(violations)


### PR DESCRIPTION
## Overview
We will extend the existing architecture AST linter to enforce the repository transaction contract: only public methods in concrete repository implementations that invoke `self._db_adapter.*` must expose `conn: ... = None`, short-circuit via `if conn is not None:`, and include a transaction fallback with `with self._transaction_provider.run_transaction() as c`. This keeps transaction participation explicit and prevents accidental nested transactions while reusing the current pre-commit/CI lint pipeline.

## Problem / motivation
Transaction lifecycles are easy to get subtly wrong in repository code: without a guardrail, public repository methods can ignore an existing `conn`, fail to provide an explicit fallback transaction, or accidentally diverge from the established Option B pattern. That leads to inconsistent transaction participation and harder-to-debug nested transaction behavior.

## Solution
Add a new `PY-13` AST linter rule plus unit tests to mechanically enforce the repository `conn`/fallback transaction contract for repository methods that declare an optional `conn` in their interface.

Add an additional `PY-14` AST linter rule plus unit tests to mechanically enforce adapter consistency: any concrete adapter subclass of `db/adapters/base.py` ABCs must expose a `conn` parameter in the signatures of methods corresponding to ABC methods that take `conn` (name-based, type-agnostic).

## Happy Flow
1. Developer modifies repository code in `[db/repositories](/Users/mark/Documents/work/agent_simulation_platform/db/repositories)`. 
2. Pre-commit runs the existing DI guard hook from `[.pre-commit-config.yaml](/Users/mark/Documents/work/agent_simulation_platform/.pre-commit-config.yaml)`, which already executes `[scripts/lint_architecture.py](/Users/mark/Documents/work/agent_simulation_platform/scripts/lint_architecture.py)`. 
3. New AST rules (e.g., `PY-13` and `PY-14`) scan concrete repository/adapter code and inspect each relevant public method.
4. For `PY-13`: if a public repository method contains a call to `self._db_adapter.<method>(...)`, the rule validates signature + body contract (`conn` param defaulting to `None`, `if conn is not None:` branch, and `run_transaction()` fallback).
5. For `PY-14`: if a concrete adapter implements an abstract base adapter method whose ABC signature includes `conn`, the rule validates the concrete implementation also includes a `conn` parameter in its signature.
6. Violations are emitted in existing `path:line:col [PY-13] message` / `path:line:col [PY-14] message` format and fail lint in pre-commit/CI.
7. Tests in `[tests/lint](/Users/mark/Documents/work/agent_simulation_platform/tests/lint)` protect both positive and negative cases.

## Data Flow
`lint_file()` parses each tracked Python file into an AST, then `_find_py13_repo_conn_contract()` walks repository classes/methods. For methods that declare an optional `conn` in the corresponding repository interface, it requires: (1) a public method that calls `self._db_adapter.*`, (2) a signature that includes `conn` with default `None`, (3) an `if conn is not None:` branch, and (4) a fallback `with self._transaction_provider.run_transaction() as c:` block that invokes the adapter.

`lint_file()` also runs `_find_py14_adapter_conn_signature()` for adapter files. For each concrete adapter class that subclasses an ABC in `db/adapters/base.py`, it checks that concrete implementations include a `conn` parameter in their own signatures whenever the ABC abstract method signature includes `conn`.

## Changes
- `scripts/lint_architecture.py`: add `PY-13` matcher for the repo `conn` + transaction-fallback contract.
- `scripts/lint_architecture.py`: add `PY-14` matcher for adapter `conn` parameter signature presence.
- `tests/lint/test_lint_architecture.py`: add focused unit tests for both `PY-13` and `PY-14`.

## Manual Verification
- From repo root, run `uv run pytest tests/lint/test_lint_architecture.py -q` and confirm all tests pass.
- Run `uv run --extra test python scripts/lint_architecture.py` and confirm no violations on current tree.
- Run `uv run pre-commit run python_dependency_injection_guard --all-files` and confirm hook passes.
- Spot-check one real repository file (e.g., `[db/repositories/agent_post_repository.py](/Users/mark/Documents/work/agent_simulation_platform/db/repositories/agent_post_repository.py`) to ensure the rule intent matches actual coding pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added two new architecture lint rules to validate database connection/transaction handling patterns across repository and adapter modules.
  * Improved lint performance with per-rule caching to avoid repeated interface parsing.
* **Tests**
  * Added comprehensive tests covering positive and negative cases for the new rules, including sync/async and signature variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->