### PR TITLE
Add agent ID migration closeout verification and canonical fixtures

### DIFF
--- a/docs/plans/2026-03-22_agent_id_phase7_closeout/verification.md
+++ b/docs/plans/2026-03-22_agent_id_phase7_closeout/verification.md
@@ -1,0 +1,62 @@
+---
+description: Milestone verification record for agent ID Phase 7 closeout (head-state verifier, fixture cleanup, API persistence proof).
+tags: [plan, verification, agent_id, migration]
+---
+
+# Agent ID Migration Phase 7 — Verification Record
+
+Verification performed per the closeout plan (agent_id migration: canonical inventory, legacy-shape negative pass, ordinary fixture cleanup, `POST /v1/simulations/agents` persistence proof).
+
+The strategy proposal [strategy_planning/2026-03-20_agent_id_migration/proposal.md](../../../strategy_planning/2026-03-20_agent_id_migration/proposal.md) Phase 7 closeout criteria are satisfied: all listed commands exited **0**, and the new head-state verifier covers the full proposal column inventory on a real SQLite database upgraded to `head`.
+
+## Canonical helper and migration mapping
+
+```bash
+uv run pytest tests/lib/test_agent_id.py tests/scripts/migrations/test_agent_id_migration.py tests/db/test_agent_id_pk_migration.py -q
+```
+
+**Result**: exit 0 — 25 passed
+
+## Profile migration and local-dev seed
+
+```bash
+uv run pytest tests/jobs/test_migrate_agents_to_new_schema.py tests/local_dev/test_local_mode_seed.py -q
+```
+
+**Result**: exit 0 — 4 passed
+
+## Repository and persistence boundaries
+
+```bash
+uv run pytest tests/db/repositories/test_action_repositories_integration.py tests/db/repositories/test_generated_feed_repository.py tests/db/repositories/test_generated_feed_repository_integration.py tests/db/repositories/test_feed_post_repository.py tests/db/repositories/test_feed_post_repository_integration.py -q
+```
+
+**Result**: exit 0 — 81 passed
+
+## Runtime, query, and feed surfaces
+
+```bash
+uv run pytest tests/simulation/core/test_command_service.py tests/simulation/core/test_query_service.py tests/feeds/test_feed_generator.py -q
+```
+
+**Result**: exit 0 — 44 passed
+
+## API surfaces
+
+```bash
+uv run pytest tests/api/test_simulation_agents.py tests/api/test_run_query_service.py tests/api/test_simulation_run.py -q
+```
+
+**Result**: exit 0 — 35 passed
+
+## Lint
+
+```bash
+uv run ruff check tests/db/agent_id_inventory.py tests/db/test_agent_id_pk_migration.py
+```
+
+**Result**: All checks passed
+
+## Proposal status
+
+With the above green runs and the head-state inventory verifier in place, the **agent ID migration proposal Phase 7 closeout work described in this effort is complete** from an automated verification standpoint.

--- a/strategy_planning/2026-03-20_agent_id_migration/proposal.md
+++ b/strategy_planning/2026-03-20_agent_id_migration/proposal.md
@@ -556,6 +556,8 @@ Prove the canonicalization is complete and prevent regressions.
 - action/feed/query tests pass
 - verification proves no non-canonical IDs remain
 
+**Phase 7 closeout (2026-03-22):** Head-state inventory verification, ordinary test fixture canonicalization, and `POST /v1/simulations/agents` persistence proof are implemented; milestone results are recorded in [docs/plans/2026-03-22_agent_id_phase7_closeout/verification.md](../../docs/plans/2026-03-22_agent_id_phase7_closeout/verification.md).
+
 ---
 
 ## Tables And Columns To Verify Explicitly After Implementation

--- a/tests/api/test_simulation_agents.py
+++ b/tests/api/test_simulation_agents.py
@@ -1,10 +1,16 @@
 """Tests for agent API endpoints."""
 
+import sqlite3
 import uuid
 
+from lib.agent_id import canonical_agent_id, is_canonical_agent_id
 from simulation.api.constants import DEFAULT_AGENT_LIST_LIMIT
 from simulation.core.models.agent import PersonaSource
 from tests.factories import AgentRecordFactory
+
+
+def _aid(seed: str) -> str:
+    return canonical_agent_id(f"api_sim_agents_{seed}")
 
 
 class TestSimulationAgents:
@@ -25,7 +31,7 @@ class TestSimulationAgents:
         # Seed the temp DB in non-sorted order so ordering assertions are meaningful.
         agent_repo.create_or_update_agent(
             AgentRecordFactory.create(
-                agent_id="did:plc:z",
+                agent_id=_aid("z"),
                 handle="@z.bsky.social",
                 persona_source=PersonaSource.SYNC_BLUESKY,
                 display_name="@z.bsky.social",
@@ -35,7 +41,7 @@ class TestSimulationAgents:
         )
         agent_repo.create_or_update_agent(
             AgentRecordFactory.create(
-                agent_id="did:plc:a",
+                agent_id=_aid("a"),
                 handle="@a.bsky.social",
                 persona_source=PersonaSource.SYNC_BLUESKY,
                 display_name="@a.bsky.social",
@@ -108,6 +114,47 @@ class TestSimulationAgents:
         assert data["following"] == expected_result["following"]
         assert data["posts_count"] == expected_result["posts_count"]
 
+    def test_post_simulations_agents_persists_canonical_agent_id_across_core_tables(
+        self, simulation_client, temp_db
+    ):
+        """POST creates matching canonical agent_id rows in agent, bios, and metadata tables."""
+        client, _ = simulation_client
+        handle = f"persist-{uuid.uuid4().hex[:8]}.bsky.social"
+        body = {
+            "handle": handle,
+            "display_name": "Persistence Test",
+            "bio": "bio",
+        }
+        resp = client.post("/v1/simulations/agents", json=body)
+        assert resp.status_code == 201
+        data = resp.json()
+        normalized_handle = data["handle"]
+
+        conn = sqlite3.connect(temp_db)
+        try:
+            row_a = conn.execute(
+                "SELECT agent_id FROM agent WHERE handle = ?",
+                (normalized_handle,),
+            ).fetchone()
+            assert row_a is not None
+            agent_id = row_a[0]
+            assert isinstance(agent_id, str)
+            assert is_canonical_agent_id(agent_id)
+
+            row_bio = conn.execute(
+                "SELECT 1 FROM agent_persona_bios WHERE agent_id = ?",
+                (agent_id,),
+            ).fetchone()
+            assert row_bio is not None
+
+            row_meta = conn.execute(
+                "SELECT 1 FROM user_agent_profile_metadata WHERE agent_id = ?",
+                (agent_id,),
+            ).fetchone()
+            assert row_meta is not None
+        finally:
+            conn.close()
+
     def test_post_simulations_agents_duplicate_handle_returns_409(
         self, simulation_client, temp_db
     ):
@@ -159,7 +206,7 @@ class TestSimulationAgents:
         """POST agent then GET /agents returns the new agent newest-first."""
         agent_repo.create_or_update_agent(
             AgentRecordFactory.create(
-                agent_id="did:plc:existing",
+                agent_id=_aid("existing"),
                 handle="@existing.bsky.social",
                 persona_source=PersonaSource.SYNC_BLUESKY,
                 display_name="@existing.bsky.social",
@@ -193,9 +240,9 @@ class TestSimulationAgents:
         """GET /v1/simulations/agents supports limit/offset pagination."""
         repo = agent_repo
         for handle, agent_id in [
-            ("@c.bsky.social", "did:plc:c"),
-            ("@a.bsky.social", "did:plc:a"),
-            ("@b.bsky.social", "did:plc:b"),
+            ("@c.bsky.social", _aid("c")),
+            ("@a.bsky.social", _aid("a")),
+            ("@b.bsky.social", _aid("b")),
         ]:
             repo.create_or_update_agent(
                 AgentRecordFactory.create(
@@ -225,7 +272,7 @@ class TestSimulationAgents:
         """GET /v1/simulations/agents?q supports case-insensitive substring matching on handle."""
         agent_repo.create_or_update_agent(
             AgentRecordFactory.create(
-                agent_id="did:plc:alpha",
+                agent_id=_aid("alpha"),
                 handle="@alpha.bsky.social",
                 persona_source=PersonaSource.SYNC_BLUESKY,
                 display_name="@alpha.bsky.social",
@@ -235,7 +282,7 @@ class TestSimulationAgents:
         )
         agent_repo.create_or_update_agent(
             AgentRecordFactory.create(
-                agent_id="did:plc:beta",
+                agent_id=_aid("beta"),
                 handle="@beta.bsky.social",
                 persona_source=PersonaSource.SYNC_BLUESKY,
                 display_name="@beta.bsky.social",
@@ -269,8 +316,8 @@ class TestSimulationAgents:
     ):
         """Whitespace-only q is treated as unset (no filtering)."""
         for handle, agent_id in [
-            ("@alpha.bsky.social", "did:plc:alpha"),
-            ("@beta.bsky.social", "did:plc:beta"),
+            ("@alpha.bsky.social", _aid("alpha")),
+            ("@beta.bsky.social", _aid("beta")),
         ]:
             agent_repo.create_or_update_agent(
                 AgentRecordFactory.create(
@@ -299,9 +346,9 @@ class TestSimulationAgents:
     ):
         """GET /v1/simulations/agents?q supports * and ? wildcards on handle."""
         for handle, agent_id in [
-            ("@alpha.bsky.social", "did:plc:alpha"),
-            ("@alxha.bsky.social", "did:plc:alxha"),
-            ("@beta.bsky.social", "did:plc:beta"),
+            ("@alpha.bsky.social", _aid("alpha")),
+            ("@alxha.bsky.social", _aid("alxha")),
+            ("@beta.bsky.social", _aid("beta")),
         ]:
             agent_repo.create_or_update_agent(
                 AgentRecordFactory.create(
@@ -340,10 +387,10 @@ class TestSimulationAgents:
     ):
         """SQL LIKE metacharacters are treated as literals (% _ \\) in q."""
         for handle, agent_id in [
-            ("@has%percent.bsky.social", "did:plc:percent"),
-            ("@has_under_score.bsky.social", "did:plc:underscore"),
-            (r"@has\backslash.bsky.social", "did:plc:backslash"),
-            ("@control.bsky.social", "did:plc:control"),
+            ("@has%percent.bsky.social", _aid("percent")),
+            ("@has_under_score.bsky.social", _aid("underscore")),
+            (r"@has\backslash.bsky.social", _aid("backslash")),
+            ("@control.bsky.social", _aid("control")),
         ]:
             agent_repo.create_or_update_agent(
                 AgentRecordFactory.create(
@@ -384,9 +431,9 @@ class TestSimulationAgents:
     ):
         """GET /v1/simulations/agents?q supports pagination with deterministic ordering."""
         for handle, agent_id in [
-            ("@c.bsky.social", "did:plc:c"),
-            ("@a.bsky.social", "did:plc:a"),
-            ("@b.bsky.social", "did:plc:b"),
+            ("@c.bsky.social", _aid("c")),
+            ("@a.bsky.social", _aid("a")),
+            ("@b.bsky.social", _aid("b")),
         ]:
             agent_repo.create_or_update_agent(
                 AgentRecordFactory.create(
@@ -414,8 +461,8 @@ class TestSimulationAgents:
     ):
         """Whitespace in q is scrubbed so '  a  ' behaves like 'a'."""
         for handle, agent_id in [
-            ("@alpha.bsky.social", "did:plc:alpha"),
-            ("@beta.bsky.social", "did:plc:beta"),
+            ("@alpha.bsky.social", _aid("alpha")),
+            ("@beta.bsky.social", _aid("beta")),
         ]:
             agent_repo.create_or_update_agent(
                 AgentRecordFactory.create(
@@ -447,7 +494,7 @@ class TestSimulationAgents:
             handle = f"@user{i:03d}.bsky.social"
             repo.create_or_update_agent(
                 AgentRecordFactory.create(
-                    agent_id=f"did:plc:{i:03d}",
+                    agent_id=_aid(f"user{i:03d}"),
                     handle=handle,
                     persona_source=PersonaSource.SYNC_BLUESKY,
                     display_name=handle,

--- a/tests/db/agent_id_inventory.py
+++ b/tests/db/agent_id_inventory.py
@@ -1,0 +1,110 @@
+"""Proposal inventory of agent-key columns for head-state migration verification."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from typing import NamedTuple
+
+from lib.agent_id import is_canonical_agent_id
+
+# Full proposal inventory (strategy_planning/2026-03-20_agent_id_migration/proposal.md).
+AGENT_KEY_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("agent", "agent_id"),
+    ("agent_persona_bios", "agent_id"),
+    ("user_agent_profile_metadata", "agent_id"),
+    ("agent_follow_edges", "follower_agent_id"),
+    ("agent_follow_edges", "target_agent_id"),
+    ("agent_posts", "agent_id"),
+    ("agent_post_likes", "liker_agent_id"),
+    ("agent_post_comments", "author_agent_id"),
+    ("run_agents", "agent_id"),
+    ("run_posts", "author_agent_id"),
+    ("run_post_likes", "liker_agent_id"),
+    ("run_post_comments", "author_agent_id"),
+    ("run_follow_edges", "follower_agent_id"),
+    ("run_follow_edges", "target_agent_id"),
+    ("likes", "agent_id"),
+    ("comments", "agent_id"),
+    ("follows", "agent_id"),
+    ("follows", "target_agent_id"),
+    ("generated_feeds", "agent_id"),
+)
+
+_UUID_HYPHENATED = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+_UUID_PLAIN_32 = re.compile(r"^[0-9a-fA-F]{32}$")
+
+
+class AgentKeyViolation(NamedTuple):
+    table: str
+    column: str
+    value: str
+
+
+def is_legacy_shaped_agent_id(value: str) -> bool:
+    """True when *value* looks like a pre-migration ID shape (not necessarily 16-char hex).
+
+    Canonical IDs are checked separately via ``is_canonical_agent_id``; this covers
+    negative patterns from the proposal: ``did:*``, ``agent_*``, UUID-like, handle-like.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    if value.startswith("did:"):
+        return True
+    if value.startswith("agent_"):
+        return True
+    if _UUID_HYPHENATED.match(value):
+        return True
+    if _UUID_PLAIN_32.match(value):
+        return True
+    # Handle-shaped (e.g. alice.bsky.social) — canonical storage never contains dots.
+    return "." in value and "@" not in value
+
+
+def collect_non_canonical_agent_key_values(
+    conn: sqlite3.Connection,
+) -> list[AgentKeyViolation]:
+    """Return (table, column, value) for every non-null agent-key value that is not canonical."""
+    bad: list[AgentKeyViolation] = []
+    for table, column in AGENT_KEY_COLUMNS:
+        cur = conn.execute(
+            f'SELECT "{column}" FROM "{table}" WHERE "{column}" IS NOT NULL'
+        )
+        for (raw,) in cur.fetchall():
+            if not isinstance(raw, str):
+                bad.append(
+                    AgentKeyViolation(table, column, repr(raw)),
+                )
+                continue
+            if not is_canonical_agent_id(raw):
+                bad.append(AgentKeyViolation(table, column, raw))
+    return bad
+
+
+def collect_legacy_shaped_agent_key_values(
+    conn: sqlite3.Connection,
+) -> list[AgentKeyViolation]:
+    """Return rows where a legacy-shaped ID appears in an agent-key column."""
+    bad: list[AgentKeyViolation] = []
+    for table, column in AGENT_KEY_COLUMNS:
+        cur = conn.execute(
+            f'SELECT "{column}" FROM "{table}" WHERE "{column}" IS NOT NULL'
+        )
+        for (raw,) in cur.fetchall():
+            if isinstance(raw, str) and is_legacy_shaped_agent_id(raw):
+                bad.append(AgentKeyViolation(table, column, raw))
+    return bad
+
+
+def assert_agent_key_inventory_tables_exist(conn: sqlite3.Connection) -> None:
+    """Fail fast with a clear message if the head schema is missing an inventoried table."""
+    for table, _ in AGENT_KEY_COLUMNS:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1",
+            (table,),
+        ).fetchone()
+        if row is None:
+            msg = f"Head-state verifier: expected table {table!r} to exist"
+            raise AssertionError(msg)

--- a/tests/db/repositories/conftest.py
+++ b/tests/db/repositories/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from db.adapters.base import TransactionProvider
 from db.adapters.sqlite.sqlite import get_connection
+from lib.agent_id import canonical_agent_id
 from simulation.core.models.agent import Agent, PersonaSource
 from simulation.core.models.feeds import GeneratedFeed
 
@@ -51,8 +52,9 @@ def ensure_run_exists(run_id: str) -> None:
 @pytest.fixture
 def agent_in_db(agent_repo):
     """Create an agent in the database for bio tests (test.bsky.social)."""
+    aid = canonical_agent_id("repo_test_test123")
     agent = Agent(
-        agent_id="did:plc:test123",
+        agent_id=aid,
         handle="test.bsky.social",
         persona_source=PersonaSource.SYNC_BLUESKY,
         display_name="Test User",
@@ -60,14 +62,15 @@ def agent_in_db(agent_repo):
         updated_at="2026_02_19-10:00:00",
     )
     agent_repo.create_or_update_agent(agent)
-    return "did:plc:test123"
+    return aid
 
 
 @pytest.fixture
 def agent_in_db_meta(agent_repo):
     """Create an agent in the database for metadata tests (meta.bsky.social)."""
+    aid = canonical_agent_id("repo_test_meta123")
     agent = Agent(
-        agent_id="did:plc:meta123",
+        agent_id=aid,
         handle="meta.bsky.social",
         persona_source=PersonaSource.SYNC_BLUESKY,
         display_name="Meta User",
@@ -75,7 +78,7 @@ def agent_in_db_meta(agent_repo):
         updated_at="2026_02_19-10:00:00",
     )
     agent_repo.create_or_update_agent(agent)
-    return "did:plc:meta123"
+    return aid
 
 
 def make_mock_transaction_provider() -> TransactionProvider:

--- a/tests/db/test_agent_id_pk_migration.py
+++ b/tests/db/test_agent_id_pk_migration.py
@@ -17,6 +17,12 @@ from scripts.migrations.agent_id_migration import (
     migration_pairs,
     stable_source_for_agent_row,
 )
+from tests.db.agent_id_inventory import (
+    assert_agent_key_inventory_tables_exist,
+    collect_legacy_shaped_agent_key_values,
+    collect_non_canonical_agent_key_values,
+    is_legacy_shaped_agent_id,
+)
 
 
 def _cfg(monkeypatch: pytest.MonkeyPatch, db_path: str) -> Config:
@@ -333,5 +339,83 @@ class TestAgentIdPkMigration:
             ).fetchone()
             assert post is not None
             assert post[0] == id_b
+        finally:
+            conn.close()
+
+
+class TestHeadStateAgentKeyColumns:
+    """Head-state audit: every proposal-listed agent-key column is canonical at ``head``."""
+
+    def test_legacy_shape_helper_matches_proposal_negative_rules(self) -> None:
+        assert is_legacy_shaped_agent_id("did:plc:example")
+        assert is_legacy_shaped_agent_id("agent_0240dc0d4a4c7e73")
+        assert is_legacy_shaped_agent_id("550e8400-e29b-41d4-a716-446655440000")
+        assert is_legacy_shaped_agent_id(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        )  # 32-hex UUID-like
+        assert is_legacy_shaped_agent_id("alice.bsky.social")
+        assert not is_legacy_shaped_agent_id("0f3a91c4d8e27b6a")
+
+    def test_empty_database_at_head_has_only_canonical_agent_key_values(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        db_path = str(tmp_path / "head_empty.sqlite")
+        cfg = _cfg(monkeypatch, db_path)
+        command.upgrade(cfg, "b2c4d6e8f0a1")
+        command.upgrade(cfg, "head")
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert_agent_key_inventory_tables_exist(conn)
+            non_canonical = collect_non_canonical_agent_key_values(conn)
+            assert non_canonical == [], non_canonical
+            legacy = collect_legacy_shaped_agent_key_values(conn)
+            assert legacy == [], legacy
+        finally:
+            conn.close()
+
+    def test_after_typical_agent_migration_all_inventory_columns_are_canonical(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same seed/upgrade as ``test_rewrites_agent_and_agent_posts``; then full inventory audit."""
+        db_path = str(tmp_path / "head_after_typical.sqlite")
+        cfg = _cfg(monkeypatch, db_path)
+        command.upgrade(cfg, "b2c4d6e8f0a1")
+
+        legacy = "550e8400-e29b-41d4-a716-446655440000"
+        handle = "alice.integration.bsky.social"
+
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                """
+                INSERT INTO agent (
+                  agent_id, handle, persona_source, display_name, created_at, updated_at
+                ) VALUES (?, ?, 'test', 'Alice', '2026-01-01', '2026-01-01')
+                """,
+                (legacy, handle),
+            )
+            conn.execute(
+                """
+                INSERT INTO agent_posts (
+                  agent_post_id, agent_id, body_text, published_at, created_at, updated_at
+                ) VALUES (?, ?, 'body', '2026-01-01', '2026-01-01', '2026-01-01')
+                """,
+                ("post-1", legacy),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        command.upgrade(cfg, "head")
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert _fk_violations(conn) == []
+            assert_agent_key_inventory_tables_exist(conn)
+            non_canonical = collect_non_canonical_agent_key_values(conn)
+            assert non_canonical == [], non_canonical
+            shaped = collect_legacy_shaped_agent_key_values(conn)
+            assert shaped == [], shaped
         finally:
             conn.close()

--- a/tests/factories/records.py
+++ b/tests/factories/records.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from lib.agent_id import canonical_agent_id
 from simulation.core.models.agent import Agent, PersonaSource
 from simulation.core.models.agent_bio import AgentBio, PersonaBioSource
 from simulation.core.models.user_agent_profile_metadata import UserAgentProfileMetadata
@@ -21,7 +22,9 @@ class AgentRecordFactory(BaseFactory[Agent]):
         updated_at: str | None = None,
     ) -> Agent:
         fake = get_faker()
-        agent_id_value = agent_id if agent_id is not None else f"did:plc:{fake.uuid4()}"
+        agent_id_value = (
+            agent_id if agent_id is not None else canonical_agent_id(fake.uuid4())
+        )
         handle_value = (
             handle if handle is not None else f"@{fake.user_name()}.bsky.social"
         )
@@ -53,7 +56,9 @@ class AgentBioFactory(BaseFactory[AgentBio]):
         updated_at: str | None = None,
     ) -> AgentBio:
         fake = get_faker()
-        agent_id_value = agent_id if agent_id is not None else f"did:plc:{fake.uuid4()}"
+        agent_id_value = (
+            agent_id if agent_id is not None else canonical_agent_id(fake.uuid4())
+        )
         created_at_value = (
             created_at if created_at is not None else _timestamp_utc_compact()
         )
@@ -84,7 +89,9 @@ class UserAgentProfileMetadataFactory(BaseFactory[UserAgentProfileMetadata]):
         updated_at: str | None = None,
     ) -> UserAgentProfileMetadata:
         fake = get_faker()
-        agent_id_value = agent_id if agent_id is not None else f"did:plc:{fake.uuid4()}"
+        agent_id_value = (
+            agent_id if agent_id is not None else canonical_agent_id(fake.uuid4())
+        )
         created_at_value = (
             created_at if created_at is not None else _timestamp_utc_compact()
         )

--- a/tests/factories/run_agents.py
+++ b/tests/factories/run_agents.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from lib.agent_id import canonical_agent_id
 from simulation.core.models.run_agents import RunAgentSnapshot
 from tests.factories.base import BaseFactory
 from tests.factories.context import get_faker
@@ -29,7 +30,9 @@ class RunAgentSnapshotFactory(BaseFactory[RunAgentSnapshot]):
         )
         return RunAgentSnapshot(
             run_id=run_id if run_id is not None else "run_123",
-            agent_id=agent_id if agent_id is not None else f"did:plc:{fake.uuid4()}",
+            agent_id=agent_id
+            if agent_id is not None
+            else canonical_agent_id(fake.uuid4()),
             selection_order=selection_order,
             handle_at_start=handle,
             display_name_at_start=(

--- a/tests/factories/run_follow_edges.py
+++ b/tests/factories/run_follow_edges.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from lib.agent_id import canonical_agent_id
 from simulation.core.models.run_follow_edges import RunFollowEdgeSnapshot
 from tests.factories.base import BaseFactory
 
@@ -10,13 +11,17 @@ class RunFollowEdgeSnapshotFactory(BaseFactory[RunFollowEdgeSnapshot]):
         cls,
         *,
         run_id: str | None = None,
-        follower_agent_id: str = "did:plc:follower",
-        target_agent_id: str = "did:plc:target",
+        follower_agent_id: str | None = None,
+        target_agent_id: str | None = None,
         created_at: str = "2024-01-01T00:00:00Z",
     ) -> RunFollowEdgeSnapshot:
         return RunFollowEdgeSnapshot(
             run_id=run_id if run_id is not None else "run_123",
-            follower_agent_id=follower_agent_id,
-            target_agent_id=target_agent_id,
+            follower_agent_id=follower_agent_id
+            if follower_agent_id is not None
+            else canonical_agent_id("run_follow_follower"),
+            target_agent_id=target_agent_id
+            if target_agent_id is not None
+            else canonical_agent_id("run_follow_target"),
             created_at=created_at,
         )

--- a/tests/factories/run_posts.py
+++ b/tests/factories/run_posts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from lib.agent_id import canonical_agent_id
 from simulation.core.models.run_posts import RunPostSnapshot
 from tests.factories.base import BaseFactory
 from tests.factories.context import get_faker
@@ -13,7 +14,7 @@ class RunPostSnapshotFactory(BaseFactory[RunPostSnapshot]):
         run_post_id: str | None = None,
         run_id: str | None = None,
         agent_post_id: str | None = None,
-        author_agent_id: str = "did:plc:author",
+        author_agent_id: str | None = None,
         author_handle_at_start: str | None = None,
         author_display_name_at_start: str | None = None,
         body_text_at_start: str = "Post body at start",
@@ -24,6 +25,11 @@ class RunPostSnapshotFactory(BaseFactory[RunPostSnapshot]):
         created_at: str = "2024-01-01T00:00:00Z",
     ) -> RunPostSnapshot:
         fake = get_faker()
+        resolved_author = (
+            author_agent_id
+            if author_agent_id is not None
+            else canonical_agent_id("run_post_default_author")
+        )
         return RunPostSnapshot(
             run_post_id=run_post_id
             if run_post_id is not None
@@ -32,7 +38,7 @@ class RunPostSnapshotFactory(BaseFactory[RunPostSnapshot]):
             agent_post_id=agent_post_id
             if agent_post_id is not None
             else f"ap_{fake.uuid4()}",
-            author_agent_id=author_agent_id,
+            author_agent_id=resolved_author,
             author_handle_at_start=(
                 author_handle_at_start
                 if author_handle_at_start is not None

--- a/tests/feeds/test_feed_generator.py
+++ b/tests/feeds/test_feed_generator.py
@@ -13,6 +13,7 @@ from db.repositories.interfaces import (
 from feeds.algorithms.implementations.chronological import ChronologicalFeedAlgorithm
 from feeds.algorithms.interfaces import FeedAlgorithmResult
 from feeds.feed_generator import _generate_feed, generate_feeds
+from lib.agent_id import canonical_agent_id
 from simulation.core.models.feeds import GeneratedFeed
 from simulation.core.models.posts import Post, PostSource
 from tests.factories import AgentFactory, PostFactory, RunPostSnapshotFactory
@@ -34,7 +35,7 @@ def mock_run_post_repo(sample_posts):
             run_post_id=p.post_id,
             run_id="run_123",
             agent_post_id=f"ap_{p.post_id}",
-            author_agent_id="did:plc:author",
+            author_agent_id=canonical_agent_id("feed_mock_author"),
             author_handle_at_start=p.author_handle,
             author_display_name_at_start=p.author_display_name,
             body_text_at_start=p.text,

--- a/tests/simulation/core/test_command_service.py
+++ b/tests/simulation/core/test_command_service.py
@@ -48,6 +48,10 @@ from tests.factories import (
     UserAgentProfileMetadataFactory,
 )
 
+_AGENT1 = canonical_agent_id("agent1.bsky.social")
+_AGENT2 = canonical_agent_id("agent2.bsky.social")
+_AGENT3 = canonical_agent_id("agent3.bsky.social")
+
 
 @pytest.fixture
 def mock_agent_factory():
@@ -86,7 +90,7 @@ def command_service(
 ):
     seed_agent_records = [
         AgentRecordFactory.create(
-            agent_id=f"did:plc:agent{i}",
+            agent_id=canonical_agent_id(f"agent{i}.bsky.social"),
             handle=f"agent{i}.bsky.social",
             display_name=f"Agent {i}",
             created_at="2026-03-13T00:00:00Z",
@@ -314,14 +318,14 @@ class TestSimulationCommandServiceExecuteRun:
         ].list_edges_for_follower_agent_ids.return_value = [
             AgentFollowEdge(
                 agent_follow_edge_id="edge_internal",
-                follower_agent_id="did:plc:agent1",
-                target_agent_id="did:plc:agent2",
+                follower_agent_id=_AGENT1,
+                target_agent_id=_AGENT2,
                 created_at="2026-03-17T00:00:00Z",
             ),
             AgentFollowEdge(
                 agent_follow_edge_id="edge_external",
-                follower_agent_id="did:plc:agent1",
-                target_agent_id="did:plc:agent3",
+                follower_agent_id=_AGENT1,
+                target_agent_id=_AGENT3,
                 created_at="2026-03-17T00:00:00Z",
             ),
         ]
@@ -337,7 +341,7 @@ class TestSimulationCommandServiceExecuteRun:
         mock_repos[
             "agent_follow_edge_repo"
         ].list_edges_for_follower_agent_ids.assert_called_once_with(
-            ["did:plc:agent1", "did:plc:agent2"],
+            [_AGENT1, _AGENT2],
             conn=mock_transaction_provider.mock_conn,
         )
         mock_repos["run_agent_repo"].write_run_agents.assert_called_once_with(
@@ -358,7 +362,7 @@ class TestSimulationCommandServiceExecuteRun:
         assert [
             (snapshot.follower_agent_id, snapshot.target_agent_id)
             for snapshot in follow_snapshots
-        ] == [("did:plc:agent1", "did:plc:agent2")]
+        ] == [(_AGENT1, _AGENT2)]
         assert all(
             snapshot.created_at == sample_run.created_at
             for snapshot in follow_snapshots
@@ -385,14 +389,14 @@ class TestSimulationCommandServiceExecuteRun:
 
         seed_agents = [
             AgentRecordFactory.create(
-                agent_id="did:plc:agent1",
+                agent_id=_AGENT1,
                 handle="agent1.bsky.social",
                 display_name="Agent One",
                 created_at="2026-03-13T00:00:00Z",
                 updated_at="2026-03-13T00:00:00Z",
             ),
             AgentRecordFactory.create(
-                agent_id="did:plc:agent2",
+                agent_id=_AGENT2,
                 handle="agent2.bsky.social",
                 display_name="Agent Two",
                 created_at="2026-03-13T00:00:01Z",
@@ -405,14 +409,14 @@ class TestSimulationCommandServiceExecuteRun:
         }
         mock_repos["agent_bio_repo"].get_latest_bios_by_agent_ids.side_effect = None
         mock_repos["agent_bio_repo"].get_latest_bios_by_agent_ids.return_value = {
-            "did:plc:agent1": AgentBioFactory.create(
-                agent_id="did:plc:agent1",
+            _AGENT1: AgentBioFactory.create(
+                agent_id=_AGENT1,
                 persona_bio="Persona one",
                 created_at="2026-03-13T00:00:00Z",
                 updated_at="2026-03-13T00:00:00Z",
             ),
-            "did:plc:agent2": AgentBioFactory.create(
-                agent_id="did:plc:agent2",
+            _AGENT2: AgentBioFactory.create(
+                agent_id=_AGENT2,
                 persona_bio="Persona two",
                 created_at="2026-03-13T00:00:01Z",
                 updated_at="2026-03-13T00:00:01Z",
@@ -424,16 +428,16 @@ class TestSimulationCommandServiceExecuteRun:
         mock_repos[
             "user_agent_profile_metadata_repo"
         ].get_metadata_by_agent_ids.return_value = {
-            "did:plc:agent1": UserAgentProfileMetadataFactory.create(
-                agent_id="did:plc:agent1",
+            _AGENT1: UserAgentProfileMetadataFactory.create(
+                agent_id=_AGENT1,
                 followers_count=10,
                 follows_count=11,
                 posts_count=12,
                 created_at="2026-03-13T00:00:00Z",
                 updated_at="2026-03-13T00:00:00Z",
             ),
-            "did:plc:agent2": UserAgentProfileMetadataFactory.create(
-                agent_id="did:plc:agent2",
+            _AGENT2: UserAgentProfileMetadataFactory.create(
+                agent_id=_AGENT2,
                 followers_count=20,
                 follows_count=21,
                 posts_count=22,
@@ -456,8 +460,8 @@ class TestSimulationCommandServiceExecuteRun:
         snapshots = call_args[0][1]
         assert [snapshot.selection_order for snapshot in snapshots] == [0, 1]
         assert [snapshot.agent_id for snapshot in snapshots] == [
-            "did:plc:agent1",
-            "did:plc:agent2",
+            _AGENT1,
+            _AGENT2,
         ]
         assert [snapshot.handle_at_start for snapshot in snapshots] == [
             "agent1.bsky.social",


### PR DESCRIPTION
### Overview

Close the remaining agent_id migration work by adding the missing head-state verifier, removing leftover ordinary legacy-ID fixtures, proving the API-created agent path at the persistence boundary, and recording the final milestone verification sweep so the proposal can be marked complete.

### Problem / motivation

Phase 7 needed explicit proof that every proposal-listed agent-key column at `head` is canonical with no legacy-shaped values, that ordinary tests default to canonical 16-char IDs, and that `POST /v1/simulations/agents` persists one ID across `agent`, `agent_persona_bios`, and `user_agent_profile_metadata`.

### Solution

Add a shared inventory module and pytest head-state audits on real migrated SQLite, switch legacy `did:plc:*` agent_id test fixtures and factory defaults to canonical IDs, add an API integration test that queries SQLite after POST, and capture milestone command results in `docs/plans/2026-03-22_agent_id_phase7_closeout/verification.md` with a Phase 7 note in the strategy proposal.

### Happy Flow

1. A migration-head integration test upgrades an isolated SQLite database to `head`, then walks the full proposal inventory of agent-key columns using `is_canonical_agent_id()` from `lib/agent_id.py`; any non-`^[0-9a-f]{16}$` value fails the test immediately.
2. The same verifier performs a negative pass over those columns and proves no legacy forms remain: `did:*`, `agent_*`, UUID-like values, or handle-shaped values, via `tests/db/agent_id_inventory.py`.
3. Ordinary runtime/API/feed fixtures in `tests/simulation/core/test_command_service.py`, `tests/db/repositories/conftest.py`, `tests/feeds/test_feed_generator.py`, and factory defaults use canonical 16-character IDs.
4. `tests/api/test_simulation_agents.py` asserts `POST /v1/simulations/agents` persists one canonical `agent_id` in `agent`, `agent_persona_bios`, and `user_agent_profile_metadata`.
5. Final verification commands are recorded in the plan asset folder.

### Data Flow

Proposal column inventory → head-state verifier → migrated SQLite at `head`; fixture cleanup → runtime/feed tests; API POST → DB rows in three tables → `verification.md`.

### Changes

- `tests/db/agent_id_inventory.py`: full proposal `AGENT_KEY_COLUMNS`, non-canonical and legacy-shape collection helpers
- `tests/db/test_agent_id_pk_migration.py`: head-state tests (empty DB + post-migration audit)
- `tests/api/test_simulation_agents.py`: canonical seed IDs via `_aid()`, new persistence test
- `tests/simulation/core/test_command_service.py`: `_AGENT1/2/3` canonical constants replace `did:plc:*` for agent-key fields
- `tests/factories/records.py`, `run_agents.py`, `run_posts.py`, `run_follow_edges.py`: default agent IDs use `canonical_agent_id()`
- `tests/db/repositories/conftest.py`, `tests/feeds/test_feed_generator.py`: canonical agent_id in fixtures
- `docs/plans/2026-03-22_agent_id_phase7_closeout/verification.md`: milestone run log
- `strategy_planning/2026-03-20_agent_id_migration/proposal.md`: Phase 7 closeout pointer

### Manual Verification

- `uv run pytest tests/lib/test_agent_id.py tests/scripts/migrations/test_agent_id_migration.py tests/db/test_agent_id_pk_migration.py -q` — exit 0
- `uv run pytest tests/jobs/test_migrate_agents_to_new_schema.py tests/local_dev/test_local_mode_seed.py -q` — exit 0
- `uv run pytest tests/db/repositories/test_action_repositories_integration.py tests/db/repositories/test_generated_feed_repository.py tests/db/repositories/test_generated_feed_repository_integration.py tests/db/repositories/test_feed_post_repository.py tests/db/repositories/test_feed_post_repository_integration.py -q` — exit 0
- `uv run pytest tests/simulation/core/test_command_service.py tests/simulation/core/test_query_service.py tests/feeds/test_feed_generator.py -q` — exit 0, 44 passed
- `uv run pytest tests/api/test_simulation_agents.py tests/api/test_run_query_service.py tests/api/test_simulation_run.py -q` — exit 0, 35 passed
- `uv run pre-commit run --files` (changed files) — passed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to validate agent identifier canonicalization across database tables during system migrations.
  * Updated test factories and fixtures to use standardized agent identifier generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->