### PR TITLE
Freeze turn-table v2 contracts in documentation

### DIFF
--- a/docs/architecture/agents-turns-runs-data-model.md
+++ b/docs/architecture/agents-turns-runs-data-model.md
@@ -1,6 +1,13 @@
+---
+description: Taxonomy of Agent*, Run*, and Turn* simulation persistence scopes, lifecycle rules, and the target turn-table parent model.
+tags: [architecture, data-model, simulation, turns, runs]
+---
+
 # Agents, Turns, and Runs
 
 We have mental models around the concepts of `Agent*`, `Turn*`, and `Run*`. This doc helps differentiate these concepts.
+
+**Turn-table v2:** The normative cutover story (parent `turns`, `turn_*` table names, atomic writes, post-ID namespace) is frozen in [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](../../strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md). **`TurnAction.POST` / authored-post generation is deferred** to a later slice; see that proposal’s **Frozen contract (v2 milestone)** section.
 
 ## What are these concepts?
 
@@ -22,7 +29,7 @@ The tables here include:
 
 `Turn*` refers to the per-turn history of what happened during a simulation run.
 
-This is a **conceptual scope**, not only a naming convention. Some tables in this scope are literally prefixed `turn_*`, while others are legacy-named event tables that still belong to the same lifecycle.
+This is a **conceptual scope**, not only a naming convention. **At HEAD**, several tables still use legacy names (`turn_metadata`, `generated_feeds`, `likes`, `comments`, `follows`) while others already use the `turn_*` prefix (`turn_metrics`). The **target steady state** is that every per-turn table is named under the `turn_*` family and is a **child of** `turns(run_id, turn_number)` (replacing `turn_metadata` as the canonical parent). That hard cutover is specified in [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](../../strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md); runtime and `db/schema.py` have not fully moved yet—treat **current schema names vs target names** as a migration in progress.
 
 The key question answered by `Turn*` data is:
 
@@ -32,6 +39,7 @@ This scope includes a few kinds of per-turn data:
 - per-turn metrics
 - per-turn generated outputs, such as feeds shown to agents during that turn
 - per-turn action logs, such as likes, comments, and follows produced during that turn
+- eventually, posts authored during a turn (`turn_posts`), once implemented
 
 The important invariant is lifecycle:
 
@@ -39,7 +47,7 @@ The important invariant is lifecycle:
 - if the row should exist before a run starts, it does **not** belong to `Turn*`
 - if the row describes what was true at the start of a run, it belongs to `Run*Snapshot`, not `Turn*`
 
-TODO: migrate all Turn tables to use the `turn_*` nomenclature.
+**Target naming (v2):** `turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, with `turn_metrics` parented on `turns` via `(run_id, turn_number)`, and `turn_posts` for authored posts. **`TurnAction.POST` generation is deferred**; see the strategy proposal’s frozen contract section.
 
 ### What is `Run*`?
 
@@ -123,7 +131,9 @@ Structural expectations:
 
 - `agent_*` tables should not carry run_id/turn_number
 - `run_*` tables should include run_id
-- `turn_* / turn-event` tables should include both run_id and non-null turn_number.
+- `turn_*` / legacy turn-event tables should include both `run_id` and non-null `turn_number`, and (in the target model) reference `turns(run_id, turn_number)`.
+
+Feed-visible post IDs in turn feeds and actions share one namespace; resolution distinguishes `run_post_id` vs `turn_post_id` in application logic—see [turn-feed-post-id-contract.md](turn-feed-post-id-contract.md).
 
 ## Supporting data outside this taxonomy
 

--- a/docs/architecture/seed-state-run-snapshot-turn-events.md
+++ b/docs/architecture/seed-state-run-snapshot-turn-events.md
@@ -1,6 +1,13 @@
+---
+description: Persistence scopes for seed state, run snapshots, and turn events—naming, lifecycle, and target turn-table parent model versus current schema.
+tags: [architecture, data-model, simulation, turns, runs]
+---
+
 # Seed state vs run snapshots vs turn events
 
 This document defines the **persistence scopes** used by the simulation platform. It exists to prevent a recurring failure mode: mixing editable “current state” data with immutable run history in one table family.
+
+**Turn-table v2:** Target table names and the `turns` parent story are frozen in [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](../../strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md). Post-ID rules (`run_post_id` vs `turn_post_id`) are summarized in [turn-feed-post-id-contract.md](turn-feed-post-id-contract.md). **`TurnAction.POST` / authored-post generation is deferred** to a later slice.
 
 ## Canonical scopes
 
@@ -27,24 +34,24 @@ A run snapshot is the frozen copy of the relevant seed state captured **at run c
 
 Turn events are immutable per-turn outputs produced during a run. They represent “what happened during this run” and should never be edited to represent baseline state.
 
-- **Naming**: new per-turn tables use the `turn_*` prefix.
-- **Lifecycle**: append-only; writes are run-scoped; rows include non-null `run_id` and non-null `turn_number`.
-- **Legacy-named turn-event tables (current schema)**:
-  - `generated_feeds`
-  - `likes`
-  - `comments`
-  - `follows`
-  - `turn_metadata`
-  - `turn_metrics`
+- **Naming (target steady state):** per-turn tables use the `turn_*` prefix (`turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, `turn_metrics`, `turn_posts`). The canonical parent row is **`turns(run_id, turn_number)`** (replacing today’s `turn_metadata` convention).
+- **Lifecycle**: append-only; writes are run-scoped; rows include non-null `run_id` and non-null `turn_number`; target model parents all of these on `turns` via composite FK.
+- **Legacy-named turn-event tables (current `db/schema.py`, pre-cutover)**:
+  - `generated_feeds` → target `turn_generated_feeds`
+  - `likes` → target `turn_likes`
+  - `comments` → target `turn_comments`
+  - `follows` → target `turn_follows`
+  - `turn_metadata` → target `turns` (parent)
+  - `turn_metrics` → remains `turn_metrics`, but gains direct parentage on `turns` in the target model
 
 ## How the current schema maps to scopes
 
-This document describes intended semantics, not table renames. The current table set in `db/schema.py` already spans multiple scopes:
+This document describes intended semantics. The **target** rename/parent story is the v2 hard cutover in [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](../../strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md). The current table set in `db/schema.py` still uses legacy names in several places; scopes are unchanged—only naming and FK parentage move toward `turns` + `turn_*`.
 
 - **Run identity and run-level summaries**:
   - `runs` (run identity/config/status)
   - `run_metrics` (run-level derived outputs)
-- **Turn events**:
+- **Turn events (current names; see target list above)**:
   - `turn_metadata`, `turn_metrics`
   - `generated_feeds`, `likes`, `comments`, `follows`
 - **Seed state**:

--- a/docs/architecture/turn-feed-post-id-contract.md
+++ b/docs/architecture/turn-feed-post-id-contract.md
@@ -1,0 +1,34 @@
+---
+description: Feed-visible post ID namespace for turn feeds and actions—run_post_id vs turn_post_id and application-level resolution (no polymorphic FK).
+tags: [architecture, data-model, simulation, turns, feeds]
+---
+
+# Turn feed and post ID contract
+
+This document freezes how **feed-visible post identifiers** work for turn-scoped feeds and actions. Normative detail and sequencing live in [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](../../strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md) (**Architectural Calls To Freeze**, **Frozen contract**).
+
+## Shared namespace
+
+These fields refer to the **same** feed-visible ID vocabulary (ordering and action targets must agree):
+
+- `turn_generated_feeds.post_ids` (ordered list)
+- `turn_likes.post_id`
+- `turn_comments.post_id`
+
+There is **no** polymorphic foreign key from those columns to mixed tables. Instead, the application resolves each ID to a hydrated post using the split below.
+
+## Resolution: `run_post_id` vs `turn_post_id`
+
+- **`run_post_id`:** Identifies a post that comes from the **run-start snapshot** (`run_posts` and the frozen baseline copied at run creation). These IDs point at immutable run-scoped post rows.
+- **`turn_post_id`:** Identifies a post **authored during a turn** and stored in **`turn_posts`** once that table exists. Same conceptual ID shape as other feed-visible IDs, but resolved against `turn_posts` rather than `run_posts`.
+
+Readers (feed hydration, action display, replay) implement **one resolver** that accepts feed-visible IDs and loads from `run_posts`, `turn_posts`, or both as needed. Mixed `run_posts` + `turn_posts` hydration is required for the system to interpret feeds and actions once `turn_posts` exists; see the strategy proposal’s milestones on mixed post resolution.
+
+## Non-goals
+
+- Persisting authored posts during turns (`TurnAction.POST` **generation**) is **deferred** to a later implementation slice; this contract defines IDs and resolution only.
+
+## Related docs
+
+- [agents-turns-runs-data-model.md](agents-turns-runs-data-model.md) — `Agent*`, `Run*`, and `Turn*` taxonomy
+- [seed-state-run-snapshot-turn-events.md](seed-state-run-snapshot-turn-events.md) — scope boundaries and legacy vs target table names

--- a/docs/plans/2026-03-22_freeze_turn_table_v2_contracts_847291/verification.md
+++ b/docs/plans/2026-03-22_freeze_turn_table_v2_contracts_847291/verification.md
@@ -1,0 +1,26 @@
+---
+description: Working verification record for the turn-table v2 contract-freeze docs milestone (metadata script + touched paths).
+tags: [plan, verification, turns, architecture, documentation]
+---
+
+# Turn-table v2 contract freeze — verification
+
+Executed per the Cursor plan *freeze_turn-table_v2_contracts*. Docs-only scope; no changes under `db/`, `simulation/`, `feeds/`, or `ui/`.
+
+## Commands
+
+```bash
+uv run python scripts/check_docs_metadata.py \
+  docs/architecture/agents-turns-runs-data-model.md \
+  docs/architecture/seed-state-run-snapshot-turn-events.md \
+  docs/architecture/turn-feed-post-id-contract.md \
+  strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md \
+  docs/plans/2026-03-22_freeze_turn_table_v2_contracts_847291/verification.md
+```
+
+**Expected:** `Docs metadata validation succeeded.`
+
+## Spot-check
+
+- Strategy proposal contains **Frozen contract (v2 milestone)** and explicit **defer** of `TurnAction.POST` / authored-post generation.
+- Architecture docs align on `turns` parent, `turn_*` targets, and post-ID namespace; optional `turn-feed-post-id-contract.md` cross-linked.

--- a/strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md
+++ b/strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md
@@ -1,6 +1,8 @@
 ---
 name: Turn tables refactor proposal v2
 overview: Update the March 19 turn-table refactor plan to reflect the now-complete agent_id migration stack, preserve current canonical ID and post-author contracts, and define a staged hard-cutover from legacy turn-event tables to a fully turn-scoped schema centered on turns and turn_posts.
+description: Normative v2 umbrella for the turn-table hard cutover—turns parent, turn_* tables, atomic writes, and post-ID contracts after the completed agent-ID migration.
+tags: [strategy, architecture, turns, schema, simulation]
 ---
 
 # Turn Tables Refactor Proposal V2
@@ -20,6 +22,23 @@ This is a revision of the original [March 19 turn-table proposal](../2026-03-19_
 The core change in v2 is that the turn-table refactor can no longer be planned as a mostly mechanical naming cleanup that preserves handle-shaped action semantics. That assumption was reasonable on March 19, but it is stale now. The merged agent-ID epic completed the identity migration all the way through storage, runtime generation, repository boundaries, query hydration, API payloads, UI consumption, and milestone verification. The turn-table plan must therefore treat canonical `agent_id`, `target_agent_id`, and `author_agent_id` as fixed architectural inputs and must not reopen those decisions.
 
 The other major v2 change is that the proposal now treats the transactional boundary as first-class work. Today, `generated_feeds` is still written before `SimulationPersistenceService.write_turn(...)`, which means a failed turn can leave feed rows behind without corresponding `turn_metadata`, metrics, or actions. The refactor should use this schema-cutover to fix that boundary and make every per-turn artifact a child of a canonical `turns` row persisted atomically.
+
+## Frozen contract (v2 milestone)
+
+This subsection locks meaning for downstream implementation slices. Rationale and sequencing live in [Architectural Calls To Freeze](#architectural-calls-to-freeze); architecture overviews live in [`docs/architecture/agents-turns-runs-data-model.md`](../docs/architecture/agents-turns-runs-data-model.md), [`docs/architecture/seed-state-run-snapshot-turn-events.md`](../docs/architecture/seed-state-run-snapshot-turn-events.md), and optionally [`docs/architecture/turn-feed-post-id-contract.md`](../docs/architecture/turn-feed-post-id-contract.md).
+
+- **Canonical IDs:** `agent_id`, `target_agent_id`, and `author_agent_id` stay **immutable** for this epic on new persistence paths—no handle-shaped keys, consistent with the completed agent-ID migration.
+- **Parent row:** `turns` replaces `turn_metadata` as the **canonical parent**; every per-turn history table references `turns(run_id, turn_number)`.
+- **Renames (hard cutover):** `generated_feeds` → `turn_generated_feeds`; `likes` / `comments` / `follows` → `turn_likes` / `turn_comments` / `turn_follows`.
+- **Atomic turns:** Turn persistence is a **single transaction** for the `turns` row, `turn_metrics`, feeds, actions, and `turn_posts` when present—no partial turn commits.
+- **Feed-visible post IDs:** `turn_generated_feeds.post_ids`, `turn_likes.post_id`, and `turn_comments.post_id` share one feed-visible ID namespace; application code distinguishes **`run_post_id`** vs **`turn_post_id`** (no polymorphic FK). See [turn-feed-post-id-contract.md](../docs/architecture/turn-feed-post-id-contract.md).
+- **`turn_posts` v1:** Columns as listed under [`turn_posts`](#turn_posts) in this document, including mandatory **`author_agent_id`**.
+- **Product decision — `TurnAction.POST` / authored-post generation:** **Deferred** to a later implementation slice (after the feed-visible post-ID contract, mixed resolver, and atomic turn write path are implemented). This docs milestone does **not** commit runtime simulation to emit `TurnAction.POST` or to persist authored posts during turns.
+
+### Non-goals implied by deferring POST generation
+
+- No obligation to ship agent-authored post generation in the same change as bare `turn_posts` schema (see **Non-goals for `turn_posts` v1** later in this document).
+- Later POST work must not re-open canonical ID rules or the shared feed-visible namespace rules above.
 
 ## What Changed Since March 19
 


### PR DESCRIPTION
## Overview

Deliver the first milestone from [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md): lock the v2 turn-table architecture in documentation before any schema or runtime work, with explicit frozen decisions, non-goals, and updated architecture docs—without touching `db/`, `simulation/`, or `ui/`.

## Problem / motivation

Downstream schema and runtime work needs a single normative contract for parent `turns`, `turn_*` table names, atomic turn writes, and the feed-visible post ID namespace. Architecture docs still mixed legacy naming with steady-state intent, and the strategy proposal lacked a compact frozen-contract section plus valid docs metadata.

## Solution

Add a **Frozen contract (v2 milestone)** block to the v2 strategy proposal (with `description` / `tags` front matter), align the two architecture docs on current vs target schema and cross-links, add a dedicated post-ID contract doc, and record verification under `docs/plans/`. **`TurnAction.POST` / authored-post generation is explicitly deferred** to a later slice.

## Happy Flow

1. A reader opens [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md) and finds **Frozen contract (v2 milestone)**: parent `turns`, renamed `turn_*` tables, atomic turn writes, shared feed-visible post ID namespace (`run_post_id` / `turn_post_id`), approved `turn_posts` v1 column expectations, and a clear **defer** for authored-post generation.
2. [docs/architecture/agents-turns-runs-data-model.md](docs/architecture/agents-turns-runs-data-model.md) describes `Turn*` with current vs target naming and points to the strategy doc.
3. [docs/architecture/seed-state-run-snapshot-turn-events.md](docs/architecture/seed-state-run-snapshot-turn-events.md) aligns scopes with the same target naming and `turns` parent story.
4. [docs/architecture/turn-feed-post-id-contract.md](docs/architecture/turn-feed-post-id-contract.md) documents `run_post_id` vs `turn_post_id` resolution expectations.

## Data Flow

Strategy proposal drives terminology; architecture docs and the post-ID contract stay mutually consistent (cross-links). No runtime or schema changes in this PR.

## Changes

- `strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md`: YAML `description`/`tags`; frozen contract + non-goals subsection; POST deferral
- `docs/architecture/agents-turns-runs-data-model.md`: front matter; `Turn*` section refresh; link to post-ID contract
- `docs/architecture/seed-state-run-snapshot-turn-events.md`: front matter; legacy vs target turn-event lists; `turns` parent narrative
- `docs/architecture/turn-feed-post-id-contract.md`: new shared-namespace + resolution doc
- `docs/plans/2026-03-22_freeze_turn_table_v2_contracts_847291/verification.md`: milestone verification record

## Manual Verification

- `uv run python scripts/check_docs_metadata.py docs/architecture/agents-turns-runs-data-model.md docs/architecture/seed-state-run-snapshot-turn-events.md docs/architecture/turn-feed-post-id-contract.md strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md docs/plans/2026-03-22_freeze_turn_table_v2_contracts_847291/verification.md` → **Docs metadata validation succeeded.**
- `uv run pre-commit run docs-metadata --files` (same paths) → passed
- `uv run pre-commit run markdownlint --files` on touched markdown → passed
- Full `git commit` pre-commit suite → passed
- Confirmed no changes under `db/`, `simulation/`, `feeds/`, `ui/`

## State (Before) / State (After)

N/A — documentation-only; no UI.

Made with [Cursor](https://cursor.com)