### PR TITLE
Add turns parent and turn_* schema spine

### DIFF
--- a/db/adapters/base.py
+++ b/db/adapters/base.py
@@ -239,7 +239,7 @@ class RunDatabaseAdapter(ABC):
     ) -> None:
         """Write turn metadata to the database.
 
-        Writes to the `turn_metadata` table. Uses INSERT.
+        Writes to the ``turns`` table (insert or replace placeholder from feed writes).
 
         Args:
             turn_metadata: TurnMetadata model to write

--- a/db/adapters/sqlite/comment_adapter.py
+++ b/db/adapters/sqlite/comment_adapter.py
@@ -34,7 +34,7 @@ class SQLiteCommentAdapter(CommentDatabaseAdapter):
             actor_id = validate_canonical_agent_id(g.comment.agent_id)
             conn.execute(
                 """
-                INSERT INTO comments (
+                INSERT INTO turn_comments (
                     comment_id, run_id, turn_number, agent_id, post_id, text,
                     created_at, explanation, model_used, generation_metadata_json,
                     generation_created_at
@@ -65,7 +65,7 @@ class SQLiteCommentAdapter(CommentDatabaseAdapter):
             SELECT comment_id, run_id, turn_number, agent_id, post_id, text,
                    created_at, explanation, model_used, generation_metadata_json,
                    generation_created_at
-            FROM comments
+            FROM turn_comments
             WHERE run_id = ? AND turn_number = ?
             ORDER BY agent_id, post_id, comment_id
             """,

--- a/db/adapters/sqlite/follow_adapter.py
+++ b/db/adapters/sqlite/follow_adapter.py
@@ -35,7 +35,7 @@ class SQLiteFollowAdapter(FollowDatabaseAdapter):
             target_id = validate_canonical_agent_id(g.follow.target_agent_id)
             conn.execute(
                 """
-                INSERT INTO follows (
+                INSERT INTO turn_follows (
                     follow_id, run_id, turn_number, agent_id, target_agent_id,
                     created_at, explanation, model_used, generation_metadata_json,
                     generation_created_at
@@ -64,7 +64,7 @@ class SQLiteFollowAdapter(FollowDatabaseAdapter):
             """
             SELECT follow_id, run_id, turn_number, agent_id, target_agent_id, created_at,
                    explanation, model_used, generation_metadata_json, generation_created_at
-            FROM follows
+            FROM turn_follows
             WHERE run_id = ? AND turn_number = ?
             ORDER BY agent_id, target_agent_id, follow_id
             """,

--- a/db/adapters/sqlite/generated_feed_adapter.py
+++ b/db/adapters/sqlite/generated_feed_adapter.py
@@ -6,7 +6,8 @@ import sqlite3
 from db.adapters.base import GeneratedFeedDatabaseAdapter
 from db.adapters.sqlite.schema_utils import ordered_column_names, required_column_names
 from db.adapters.sqlite.sqlite import validate_required_fields
-from db.schema import generated_feeds
+from db.adapters.sqlite.turn_parent import ensure_turn_parent_stub_for_feed_write
+from db.schema import turn_generated_feeds
 from lib.validation_decorators import validate_inputs
 from simulation.core.models.feeds import GeneratedFeed
 from simulation.core.utils.validators import (
@@ -15,10 +16,10 @@ from simulation.core.utils.validators import (
     validate_turn_number,
 )
 
-GENERATED_FEED_COLUMNS = ordered_column_names(generated_feeds)
-GENERATED_FEED_REQUIRED_FIELDS = required_column_names(generated_feeds)
+GENERATED_FEED_COLUMNS = ordered_column_names(turn_generated_feeds)
+GENERATED_FEED_REQUIRED_FIELDS = required_column_names(turn_generated_feeds)
 _INSERT_GENERATED_FEED_SQL = (
-    f"INSERT OR REPLACE INTO generated_feeds ({', '.join(GENERATED_FEED_COLUMNS)}) "
+    f"INSERT OR REPLACE INTO turn_generated_feeds ({', '.join(GENERATED_FEED_COLUMNS)}) "
     f"VALUES ({', '.join('?' for _ in GENERATED_FEED_COLUMNS)})"
 )
 
@@ -63,6 +64,9 @@ class SQLiteGeneratedFeedAdapter(GeneratedFeedDatabaseAdapter):
             sqlite3.IntegrityError: If composite key violates constraints
             sqlite3.OperationalError: If database operation fails
         """
+        ensure_turn_parent_stub_for_feed_write(
+            conn, run_id=feed.run_id, turn_number=feed.turn_number
+        )
         row_values = tuple(
             json.dumps(feed.post_ids) if col == "post_ids" else getattr(feed, col)
             for col in GENERATED_FEED_COLUMNS
@@ -103,7 +107,7 @@ class SQLiteGeneratedFeedAdapter(GeneratedFeedDatabaseAdapter):
             KeyError: If required columns are missing from the database row
         """
         row = conn.execute(
-            "SELECT * FROM generated_feeds WHERE agent_id = ? AND run_id = ? AND turn_number = ?",
+            "SELECT * FROM turn_generated_feeds WHERE agent_id = ? AND run_id = ? AND turn_number = ?",
             (agent_id, run_id, turn_number),
         ).fetchone()
 
@@ -129,7 +133,7 @@ class SQLiteGeneratedFeedAdapter(GeneratedFeedDatabaseAdapter):
         ).fetchone()
         if r2 is None:
             raise ValueError(
-                f"generated_feeds row missing agent_handle and agent {row['agent_id']!r} not found"
+                f"turn_generated_feeds row missing agent_handle and agent {row['agent_id']!r} not found"
             )
         return str(r2[0])
 
@@ -171,7 +175,7 @@ class SQLiteGeneratedFeedAdapter(GeneratedFeedDatabaseAdapter):
             sqlite3.OperationalError: If database operation fails
             KeyError: If required columns are missing from any database row
         """
-        rows = conn.execute("SELECT * FROM generated_feeds").fetchall()
+        rows = conn.execute("SELECT * FROM turn_generated_feeds").fetchall()
         feeds = []
         for row in rows:
             self._validate_generated_feed_row(
@@ -207,7 +211,7 @@ class SQLiteGeneratedFeedAdapter(GeneratedFeedDatabaseAdapter):
         rows = conn.execute(
             """
             SELECT post_ids
-            FROM generated_feeds
+            FROM turn_generated_feeds
             WHERE agent_id = ? AND run_id = ?
         """,
             (agent_id, run_id),
@@ -236,7 +240,7 @@ class SQLiteGeneratedFeedAdapter(GeneratedFeedDatabaseAdapter):
             sqlite3.OperationalError: If database operation fails
         """
         rows = conn.execute(
-            "SELECT * FROM generated_feeds WHERE run_id = ? AND turn_number = ?",
+            "SELECT * FROM turn_generated_feeds WHERE run_id = ? AND turn_number = ?",
             (run_id, turn_number),
         ).fetchall()
 

--- a/db/adapters/sqlite/like_adapter.py
+++ b/db/adapters/sqlite/like_adapter.py
@@ -34,7 +34,7 @@ class SQLiteLikeAdapter(LikeDatabaseAdapter):
             actor_id = validate_canonical_agent_id(g.like.agent_id)
             conn.execute(
                 """
-                INSERT INTO likes (
+                INSERT INTO turn_likes (
                     like_id, run_id, turn_number, agent_id, post_id,
                     created_at, explanation, model_used, generation_metadata_json,
                     generation_created_at
@@ -63,7 +63,7 @@ class SQLiteLikeAdapter(LikeDatabaseAdapter):
             """
             SELECT like_id, run_id, turn_number, agent_id, post_id, created_at,
                    explanation, model_used, generation_metadata_json, generation_created_at
-            FROM likes
+            FROM turn_likes
             WHERE run_id = ? AND turn_number = ?
             ORDER BY agent_id, post_id, like_id
             """,

--- a/db/adapters/sqlite/run_adapter.py
+++ b/db/adapters/sqlite/run_adapter.py
@@ -8,6 +8,7 @@ import sqlite3
 from db.adapters.base import RunDatabaseAdapter
 from db.adapters.sqlite.schema_utils import required_column_names
 from db.adapters.sqlite.sqlite import validate_required_fields
+from db.adapters.sqlite.turn_parent import TURN_PARENT_PLACEHOLDER_CREATED_AT
 from db.schema import runs
 from lib.validation_decorators import validate_inputs
 from simulation.core.metrics.defaults import get_default_metric_keys
@@ -28,7 +29,7 @@ def _validate_turn_metadata_row(row: sqlite3.Row) -> None:
     available_columns = set(row.keys())
     for col in TURN_METADATA_REQUIRED_COLS:
         if col not in available_columns:
-            raise KeyError(f"Missing required column '{col}' in turn_metadata row")
+            raise KeyError(f"Missing required column '{col}' in turns row")
     for col in TURN_METADATA_REQUIRED_COLS:
         if row[col] is None:
             raise ValueError(f"Turn metadata has NULL fields: {col}={row[col]}")
@@ -40,14 +41,14 @@ def _parse_total_actions_from_row(row: sqlite3.Row) -> dict[TurnAction, int]:
         total_actions_dict = json.loads(row["total_actions"])
     except json.JSONDecodeError as e:
         raise ValueError(
-            f"Could not parse total_actions as JSON for turn_metadata: {e}"
+            f"Could not parse total_actions as JSON for turns row: {e}"
         ) from e
     try:
         return {TurnAction(k): v for k, v in total_actions_dict.items()}
     except (ValueError, KeyError) as e:
         valid_keys = [action.value for action in TurnAction]
         raise ValueError(
-            f"Invalid action type in total_actions for turn_metadata: {e}. "
+            f"Invalid action type in total_actions for turns row: {e}. "
             f"Expected keys: {valid_keys}, got: {list(total_actions_dict.keys())}"
         ) from e
 
@@ -229,7 +230,7 @@ class SQLiteRunAdapter(RunDatabaseAdapter):
             KeyError: If required columns are missing from the database row
         """
         row = conn.execute(
-            "SELECT * FROM turn_metadata WHERE run_id = ? AND turn_number = ?",
+            "SELECT * FROM turns WHERE run_id = ? AND turn_number = ?",
             (run_id, turn_number),
         ).fetchone()
 
@@ -272,7 +273,7 @@ class SQLiteRunAdapter(RunDatabaseAdapter):
             KeyError: If required columns are missing from a database row
         """
         rows = conn.execute(
-            "SELECT * FROM turn_metadata WHERE run_id = ? ORDER BY turn_number ASC",
+            "SELECT * FROM turns WHERE run_id = ? ORDER BY turn_number ASC",
             (run_id,),
         ).fetchall()
 
@@ -306,7 +307,8 @@ class SQLiteRunAdapter(RunDatabaseAdapter):
     ) -> None:
         """Write turn metadata to SQLite.
 
-        Writes to the `turn_metadata` table. Uses INSERT.
+        Writes to the ``turns`` table. Inserts a new row, or replaces a placeholder
+        row created by ``ensure_turn_parent_stub_for_feed_write``.
 
         Args:
             turn_metadata: TurnMetadata model to write
@@ -322,7 +324,10 @@ class SQLiteRunAdapter(RunDatabaseAdapter):
             conn=conn,
         )
 
-        if existing_turn_metadata is not None:
+        if (
+            existing_turn_metadata is not None
+            and existing_turn_metadata.created_at != TURN_PARENT_PLACEHOLDER_CREATED_AT
+        ):
             raise DuplicateTurnMetadataError(
                 turn_metadata.run_id, turn_metadata.turn_number
             )
@@ -331,9 +336,31 @@ class SQLiteRunAdapter(RunDatabaseAdapter):
             {k.value: v for k, v in turn_metadata.total_actions.items()}
         )
 
+        if (
+            existing_turn_metadata is not None
+            and existing_turn_metadata.created_at == TURN_PARENT_PLACEHOLDER_CREATED_AT
+        ):
+            conn.execute(
+                """
+                UPDATE turns
+                SET total_actions = ?, created_at = ?
+                WHERE run_id = ? AND turn_number = ?
+                """,
+                (
+                    total_actions_json,
+                    turn_metadata.created_at,
+                    turn_metadata.run_id,
+                    turn_metadata.turn_number,
+                ),
+            )
+            return
+
         try:
             conn.execute(
-                "INSERT INTO turn_metadata (run_id, turn_number, total_actions, created_at) VALUES (?, ?, ?, ?)",
+                """
+                INSERT INTO turns (run_id, turn_number, total_actions, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
                 (
                     turn_metadata.run_id,
                     turn_metadata.turn_number,

--- a/db/adapters/sqlite/sqlite.py
+++ b/db/adapters/sqlite/sqlite.py
@@ -115,11 +115,11 @@ def _has_alembic_version(conn: sqlite3.Connection) -> bool:
 
 
 def _has_any_app_tables(conn: sqlite3.Connection) -> bool:
-    """Return True if any core app table exists (runs, generated_feeds, turn_metadata)."""
+    """Return True if any core app table exists (runs, turns, turn_generated_feeds)."""
     for name in (
         "runs",
-        "generated_feeds",
-        "turn_metadata",
+        "turn_generated_feeds",
+        "turns",
         "turn_metrics",
         "run_metrics",
     ):

--- a/db/adapters/sqlite/turn_parent.py
+++ b/db/adapters/sqlite/turn_parent.py
@@ -1,0 +1,39 @@
+"""Helpers for the canonical ``turns`` parent row.
+
+``generate_feeds`` persists ``turn_generated_feeds`` before ``write_turn`` inserts the
+final ``turns`` row. A placeholder ``turns`` row (see ``TURN_PARENT_PLACEHOLDER_CREATED_AT``)
+satisfies composite foreign keys until ``SQLiteRunAdapter.write_turn_metadata`` replaces
+it with real turn metadata in the same transaction order as before.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from simulation.core.models.actions import TurnAction
+
+# Matches ``lib.timestamp_utils.CREATED_AT_FORMAT`` shape; never used as a real timestamp.
+TURN_PARENT_PLACEHOLDER_CREATED_AT = "1970_01_01-00:00:00"
+
+
+def turn_parent_stub_total_actions_json() -> str:
+    return json.dumps({k.value: 0 for k in TurnAction})
+
+
+def ensure_turn_parent_stub_for_feed_write(
+    conn: sqlite3.Connection, *, run_id: str, turn_number: int
+) -> None:
+    """Insert a placeholder ``turns`` row so ``turn_generated_feeds`` FK checks pass."""
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO turns (run_id, turn_number, total_actions, created_at)
+        VALUES (?, ?, ?, ?)
+        """,
+        (
+            run_id,
+            turn_number,
+            turn_parent_stub_total_actions_json(),
+            TURN_PARENT_PLACEHOLDER_CREATED_AT,
+        ),
+    )

--- a/db/migrations/versions/f3c9a1e7b2d4_turn_table_v2_schema_spine.py
+++ b/db/migrations/versions/f3c9a1e7b2d4_turn_table_v2_schema_spine.py
@@ -1,0 +1,270 @@
+"""Turn table v2 schema spine: turns parent, turn_* tables, migrate legacy rows.
+
+Revision ID: f3c9a1e7b2d4
+Revises: e7f3a9c2d1b4
+Create Date: 2026-03-22 12:00:00.000000
+
+Introduces ``turns`` as the canonical parent for per-turn history, renames
+``turn_metadata`` -> ``turns``, renames ``generated_feeds`` / ``likes`` /
+``comments`` / ``follows`` to ``turn_*`` tables, reparents ``turn_metrics`` onto
+``turns(run_id, turn_number)``, and adds empty ``turn_posts`` (foundation only).
+
+Legacy rows are copied forward with create/copy/drop so composite foreign keys and
+index names are intentional.
+
+Downgrade is intentionally unsupported (restore from backup).
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+# Placeholder parent row for legacy DBs that have per-turn rows without turn_metadata.
+_ORPHAN_TURNS_ACTIONS_JSON = '{"like": 0, "comment": 0, "follow": 0}'
+_ORPHAN_TURNS_CREATED_AT = "1970_01_01-00:00:00"
+
+revision: str = "f3c9a1e7b2d4"
+down_revision: Union[str, Sequence[str], None] = "e7f3a9c2d1b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # SQLite: batch DDL with FK enforcement temporarily disabled.
+    conn.exec_driver_sql("PRAGMA foreign_keys=OFF")
+    try:
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE turns (
+                run_id TEXT NOT NULL,
+                turn_number INTEGER NOT NULL,
+                total_actions TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (run_id, turn_number),
+                FOREIGN KEY (run_id) REFERENCES runs (run_id),
+                CHECK (turn_number >= 0)
+            )
+            """
+        )
+        conn.exec_driver_sql("CREATE INDEX idx_turns_run_id ON turns (run_id)")
+        conn.exec_driver_sql(
+            "INSERT INTO turns SELECT * FROM turn_metadata",
+        )
+        conn.execute(
+            text(
+                """
+                INSERT OR IGNORE INTO turns (run_id, turn_number, total_actions, created_at)
+                SELECT u.run_id, u.turn_number, :actions, :created
+                FROM (
+                    SELECT run_id, turn_number FROM generated_feeds
+                    UNION SELECT run_id, turn_number FROM likes
+                    UNION SELECT run_id, turn_number FROM comments
+                    UNION SELECT run_id, turn_number FROM follows
+                    UNION SELECT run_id, turn_number FROM turn_metrics
+                ) AS u
+                """
+            ),
+            {
+                "actions": _ORPHAN_TURNS_ACTIONS_JSON,
+                "created": _ORPHAN_TURNS_CREATED_AT,
+            },
+        )
+
+        conn.exec_driver_sql("DROP INDEX IF EXISTS idx_turn_metadata_run_id")
+        conn.exec_driver_sql("DROP TABLE turn_metadata")
+
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE turn_metrics_new (
+                run_id TEXT NOT NULL,
+                turn_number INTEGER NOT NULL,
+                metrics TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (run_id, turn_number),
+                FOREIGN KEY (run_id, turn_number) REFERENCES turns (run_id, turn_number),
+                CHECK (turn_number >= 0)
+            )
+            """
+        )
+        conn.exec_driver_sql(
+            "INSERT INTO turn_metrics_new SELECT * FROM turn_metrics",
+        )
+        conn.exec_driver_sql("DROP TABLE turn_metrics")
+        conn.exec_driver_sql("ALTER TABLE turn_metrics_new RENAME TO turn_metrics")
+        conn.exec_driver_sql(
+            "CREATE INDEX IF NOT EXISTS idx_turn_metrics_run_id ON turn_metrics (run_id)"
+        )
+
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE turn_generated_feeds (
+                feed_id TEXT NOT NULL,
+                run_id TEXT NOT NULL,
+                turn_number INTEGER NOT NULL,
+                agent_id TEXT NOT NULL,
+                agent_handle TEXT,
+                post_ids TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (agent_id, run_id, turn_number),
+                FOREIGN KEY (run_id) REFERENCES runs (run_id),
+                FOREIGN KEY (agent_id) REFERENCES agent (agent_id),
+                FOREIGN KEY (run_id, turn_number) REFERENCES turns (run_id, turn_number)
+            )
+            """
+        )
+        conn.exec_driver_sql(
+            "INSERT INTO turn_generated_feeds SELECT * FROM generated_feeds",
+        )
+        conn.exec_driver_sql("DROP TABLE generated_feeds")
+
+        conn.exec_driver_sql("DROP INDEX IF EXISTS idx_likes_run_turn_agent")
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE turn_likes (
+                like_id TEXT NOT NULL PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                turn_number INTEGER NOT NULL,
+                agent_id TEXT NOT NULL,
+                post_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                explanation TEXT,
+                model_used TEXT,
+                generation_metadata_json TEXT,
+                generation_created_at TEXT,
+                FOREIGN KEY (run_id) REFERENCES runs (run_id),
+                FOREIGN KEY (agent_id) REFERENCES agent (agent_id),
+                FOREIGN KEY (run_id, turn_number) REFERENCES turns (run_id, turn_number),
+                CHECK (turn_number >= 0),
+                CONSTRAINT uq_turn_likes_run_turn_agent_post UNIQUE (run_id, turn_number, agent_id, post_id)
+            )
+            """
+        )
+        conn.exec_driver_sql(
+            """
+            INSERT INTO turn_likes SELECT
+                like_id, run_id, turn_number, agent_id, post_id,
+                created_at, explanation, model_used,
+                generation_metadata_json, generation_created_at
+            FROM likes
+            """
+        )
+        conn.exec_driver_sql("DROP TABLE likes")
+        conn.exec_driver_sql(
+            "CREATE INDEX idx_turn_likes_run_turn_agent "
+            "ON turn_likes (run_id, turn_number, agent_id)"
+        )
+
+        conn.exec_driver_sql("DROP INDEX IF EXISTS idx_comments_run_turn_agent")
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE turn_comments (
+                comment_id TEXT NOT NULL PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                turn_number INTEGER NOT NULL,
+                agent_id TEXT NOT NULL,
+                post_id TEXT NOT NULL,
+                text TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                explanation TEXT,
+                model_used TEXT,
+                generation_metadata_json TEXT,
+                generation_created_at TEXT,
+                FOREIGN KEY (run_id) REFERENCES runs (run_id),
+                FOREIGN KEY (agent_id) REFERENCES agent (agent_id),
+                FOREIGN KEY (run_id, turn_number) REFERENCES turns (run_id, turn_number),
+                CHECK (turn_number >= 0),
+                CONSTRAINT uq_turn_comments_run_turn_agent_post UNIQUE (run_id, turn_number, agent_id, post_id)
+            )
+            """
+        )
+        conn.exec_driver_sql(
+            """
+            INSERT INTO turn_comments SELECT
+                comment_id, run_id, turn_number, agent_id, post_id, text,
+                created_at, explanation, model_used,
+                generation_metadata_json, generation_created_at
+            FROM comments
+            """
+        )
+        conn.exec_driver_sql("DROP TABLE comments")
+        conn.exec_driver_sql(
+            "CREATE INDEX idx_turn_comments_run_turn_agent "
+            "ON turn_comments (run_id, turn_number, agent_id)"
+        )
+
+        conn.exec_driver_sql("DROP INDEX IF EXISTS idx_follows_run_turn_agent")
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE turn_follows (
+                follow_id TEXT NOT NULL PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                turn_number INTEGER NOT NULL,
+                agent_id TEXT NOT NULL,
+                target_agent_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                explanation TEXT,
+                model_used TEXT,
+                generation_metadata_json TEXT,
+                generation_created_at TEXT,
+                FOREIGN KEY (run_id) REFERENCES runs (run_id),
+                FOREIGN KEY (agent_id) REFERENCES agent (agent_id),
+                FOREIGN KEY (target_agent_id) REFERENCES agent (agent_id),
+                FOREIGN KEY (run_id, turn_number) REFERENCES turns (run_id, turn_number),
+                CHECK (turn_number >= 0),
+                CONSTRAINT ck_turn_follows_no_self_follow CHECK (agent_id != target_agent_id),
+                CONSTRAINT uq_turn_follows_run_turn_agent_target UNIQUE (run_id, turn_number, agent_id, target_agent_id)
+            )
+            """
+        )
+        conn.exec_driver_sql(
+            """
+            INSERT INTO turn_follows SELECT
+                follow_id, run_id, turn_number, agent_id, target_agent_id,
+                created_at, explanation, model_used,
+                generation_metadata_json, generation_created_at
+            FROM follows
+            """
+        )
+        conn.exec_driver_sql("DROP TABLE follows")
+        conn.exec_driver_sql(
+            "CREATE INDEX idx_turn_follows_run_turn_agent "
+            "ON turn_follows (run_id, turn_number, agent_id)"
+        )
+
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE turn_posts (
+                turn_post_id TEXT NOT NULL,
+                run_id TEXT NOT NULL,
+                turn_number INTEGER NOT NULL,
+                author_agent_id TEXT NOT NULL,
+                author_handle_at_time TEXT NOT NULL,
+                author_display_name_at_time TEXT NOT NULL,
+                body_text TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                explanation TEXT,
+                model_used TEXT,
+                generation_metadata_json TEXT,
+                generation_created_at TEXT,
+                PRIMARY KEY (turn_post_id),
+                FOREIGN KEY (run_id, turn_number) REFERENCES turns (run_id, turn_number),
+                FOREIGN KEY (run_id, author_agent_id) REFERENCES run_agents (run_id, agent_id),
+                CHECK (turn_number >= 0)
+            )
+            """
+        )
+        conn.exec_driver_sql(
+            "CREATE INDEX idx_turn_posts_run_turn_author "
+            "ON turn_posts (run_id, turn_number, author_agent_id)"
+        )
+    finally:
+        conn.exec_driver_sql("PRAGMA foreign_keys=ON")
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Downgrade unsupported; restore from backup.")

--- a/db/schema.py
+++ b/db/schema.py
@@ -7,7 +7,7 @@ source-of-truth for migrations.
 Important:
 - Keep this schema aligned with what migrations produce at HEAD.
 - The initial migration in this repo intentionally omits the
-  `generated_feeds.run_id -> runs.run_id` foreign key; a later migration adds it.
+  `turn_generated_feeds.run_id -> runs.run_id` foreign key; a later migration adds it.
 """
 
 from __future__ import annotations
@@ -64,18 +64,16 @@ runs = sa.Table(
     ),
 )
 
-turn_metadata = sa.Table(
-    "turn_metadata",
+turns = sa.Table(
+    "turns",
     metadata,
     sa.Column("run_id", sa.Text(), nullable=False),
     sa.Column("turn_number", sa.Integer(), nullable=False),
     sa.Column("total_actions", sa.Text(), nullable=False),
     sa.Column("created_at", sa.Text(), nullable=False),
-    sa.ForeignKeyConstraint(
-        ["run_id"], ["runs.run_id"], name="fk_turn_metadata_run_id"
-    ),
-    sa.CheckConstraint("turn_number >= 0", name="ck_turn_metadata_turn_number_gte_0"),
-    sa.PrimaryKeyConstraint("run_id", "turn_number", name="pk_turn_metadata"),
+    sa.ForeignKeyConstraint(["run_id"], ["runs.run_id"], name="fk_turns_run_id"),
+    sa.CheckConstraint("turn_number >= 0", name="ck_turns_turn_number_gte_0"),
+    sa.PrimaryKeyConstraint("run_id", "turn_number", name="pk_turns"),
 )
 
 turn_metrics = sa.Table(
@@ -85,7 +83,11 @@ turn_metrics = sa.Table(
     sa.Column("turn_number", sa.Integer(), nullable=False),
     sa.Column("metrics", sa.Text(), nullable=False),
     sa.Column("created_at", sa.Text(), nullable=False),
-    sa.ForeignKeyConstraint(["run_id"], ["runs.run_id"], name="fk_turn_metrics_run_id"),
+    sa.ForeignKeyConstraint(
+        ["run_id", "turn_number"],
+        ["turns.run_id", "turns.turn_number"],
+        name="fk_turn_metrics_turn_parent",
+    ),
     sa.CheckConstraint("turn_number >= 0", name="ck_turn_metrics_turn_number_gte_0"),
     sa.PrimaryKeyConstraint("run_id", "turn_number", name="pk_turn_metrics"),
 )
@@ -271,8 +273,8 @@ run_follow_edges = sa.Table(
     ),
 )
 
-generated_feeds = sa.Table(
-    "generated_feeds",
+turn_generated_feeds = sa.Table(
+    "turn_generated_feeds",
     metadata,
     sa.Column("feed_id", sa.Text(), nullable=False),
     sa.Column("run_id", sa.Text(), nullable=False),
@@ -284,15 +286,20 @@ generated_feeds = sa.Table(
     sa.ForeignKeyConstraint(
         ["run_id"],
         ["runs.run_id"],
-        name="fk_generated_feeds_run_id",
+        name="fk_turn_generated_feeds_run_id",
     ),
     sa.ForeignKeyConstraint(
         ["agent_id"],
         ["agent.agent_id"],
-        name="fk_generated_feeds_agent_id",
+        name="fk_turn_generated_feeds_agent_id",
+    ),
+    sa.ForeignKeyConstraint(
+        ["run_id", "turn_number"],
+        ["turns.run_id", "turns.turn_number"],
+        name="fk_turn_generated_feeds_turn_parent",
     ),
     sa.PrimaryKeyConstraint(
-        "agent_id", "run_id", "turn_number", name="pk_generated_feeds"
+        "agent_id", "run_id", "turn_number", name="pk_turn_generated_feeds"
     ),
 )
 
@@ -499,10 +506,10 @@ agent_post_comments = sa.Table(
 )
 
 
-# --- Run-scoped action tables (likes, comments, follows) ---
+# --- Run-scoped turn action tables (turn_likes, turn_comments, turn_follows) ---
 
-likes = sa.Table(
-    "likes",
+turn_likes = sa.Table(
+    "turn_likes",
     metadata,
     sa.Column("like_id", sa.Text(), primary_key=True),
     sa.Column("run_id", sa.Text(), nullable=False),
@@ -514,23 +521,27 @@ likes = sa.Table(
     sa.Column("model_used", sa.Text(), nullable=True),
     sa.Column("generation_metadata_json", sa.Text(), nullable=True),
     sa.Column("generation_created_at", sa.Text(), nullable=True),
-    sa.ForeignKeyConstraint(["run_id"], ["runs.run_id"], name="fk_likes_run_id"),
-    sa.ForeignKeyConstraint(["agent_id"], ["agent.agent_id"], name="fk_likes_agent_id"),
-    sa.CheckConstraint("turn_number >= 0", name="ck_likes_turn_number_gte_0"),
-    # Within a single run+turn, an agent can like a given post at most once.
-    # The domain validator tries to prevent duplicates, but this is the persistence
-    # backstop that guarantees we never store duplicate likes for the same target.
+    sa.ForeignKeyConstraint(["run_id"], ["runs.run_id"], name="fk_turn_likes_run_id"),
+    sa.ForeignKeyConstraint(
+        ["agent_id"], ["agent.agent_id"], name="fk_turn_likes_agent_id"
+    ),
+    sa.ForeignKeyConstraint(
+        ["run_id", "turn_number"],
+        ["turns.run_id", "turns.turn_number"],
+        name="fk_turn_likes_turn_parent",
+    ),
+    sa.CheckConstraint("turn_number >= 0", name="ck_turn_likes_turn_number_gte_0"),
     sa.UniqueConstraint(
         "run_id",
         "turn_number",
         "agent_id",
         "post_id",
-        name="uq_likes_run_turn_agent_post",
+        name="uq_turn_likes_run_turn_agent_post",
     ),
 )
 
-comments = sa.Table(
-    "comments",
+turn_comments = sa.Table(
+    "turn_comments",
     metadata,
     sa.Column("comment_id", sa.Text(), primary_key=True),
     sa.Column("run_id", sa.Text(), nullable=False),
@@ -543,25 +554,29 @@ comments = sa.Table(
     sa.Column("model_used", sa.Text(), nullable=True),
     sa.Column("generation_metadata_json", sa.Text(), nullable=True),
     sa.Column("generation_created_at", sa.Text(), nullable=True),
-    sa.ForeignKeyConstraint(["run_id"], ["runs.run_id"], name="fk_comments_run_id"),
     sa.ForeignKeyConstraint(
-        ["agent_id"], ["agent.agent_id"], name="fk_comments_agent_id"
+        ["run_id"], ["runs.run_id"], name="fk_turn_comments_run_id"
     ),
-    sa.CheckConstraint("turn_number >= 0", name="ck_comments_turn_number_gte_0"),
-    # Within a single run+turn, an agent can comment on a given post at most once.
-    # This matches the current action rules validator (duplicates rejected) and ensures the
-    # DB cannot accumulate duplicate per-target comments for the same turn.
+    sa.ForeignKeyConstraint(
+        ["agent_id"], ["agent.agent_id"], name="fk_turn_comments_agent_id"
+    ),
+    sa.ForeignKeyConstraint(
+        ["run_id", "turn_number"],
+        ["turns.run_id", "turns.turn_number"],
+        name="fk_turn_comments_turn_parent",
+    ),
+    sa.CheckConstraint("turn_number >= 0", name="ck_turn_comments_turn_number_gte_0"),
     sa.UniqueConstraint(
         "run_id",
         "turn_number",
         "agent_id",
         "post_id",
-        name="uq_comments_run_turn_agent_post",
+        name="uq_turn_comments_run_turn_agent_post",
     ),
 )
 
-follows = sa.Table(
-    "follows",
+turn_follows = sa.Table(
+    "turn_follows",
     metadata,
     sa.Column("follow_id", sa.Text(), primary_key=True),
     sa.Column("run_id", sa.Text(), nullable=False),
@@ -573,26 +588,61 @@ follows = sa.Table(
     sa.Column("model_used", sa.Text(), nullable=True),
     sa.Column("generation_metadata_json", sa.Text(), nullable=True),
     sa.Column("generation_created_at", sa.Text(), nullable=True),
-    sa.ForeignKeyConstraint(["run_id"], ["runs.run_id"], name="fk_follows_run_id"),
+    sa.ForeignKeyConstraint(["run_id"], ["runs.run_id"], name="fk_turn_follows_run_id"),
     sa.ForeignKeyConstraint(
-        ["agent_id"], ["agent.agent_id"], name="fk_follows_agent_id"
+        ["agent_id"], ["agent.agent_id"], name="fk_turn_follows_agent_id"
     ),
     sa.ForeignKeyConstraint(
         ["target_agent_id"],
         ["agent.agent_id"],
-        name="fk_follows_target_agent_id",
+        name="fk_turn_follows_target_agent_id",
     ),
-    sa.CheckConstraint("turn_number >= 0", name="ck_follows_turn_number_gte_0"),
-    # Within a single run+turn, an agent can follow a given user at most once.
-    # This prevents duplicate follow actions for the same target and keeps persistence aligned with
-    # the validator/history checks that treat "followed" as a boolean relationship.
+    sa.ForeignKeyConstraint(
+        ["run_id", "turn_number"],
+        ["turns.run_id", "turns.turn_number"],
+        name="fk_turn_follows_turn_parent",
+    ),
+    sa.CheckConstraint("turn_number >= 0", name="ck_turn_follows_turn_number_gte_0"),
+    sa.CheckConstraint(
+        "agent_id != target_agent_id",
+        name="ck_turn_follows_no_self_follow",
+    ),
     sa.UniqueConstraint(
         "run_id",
         "turn_number",
         "agent_id",
         "target_agent_id",
-        name="uq_follows_run_turn_agent_target",
+        name="uq_turn_follows_run_turn_agent_target",
     ),
+)
+
+turn_posts = sa.Table(
+    "turn_posts",
+    metadata,
+    sa.Column("turn_post_id", sa.Text(), nullable=False),
+    sa.Column("run_id", sa.Text(), nullable=False),
+    sa.Column("turn_number", sa.Integer(), nullable=False),
+    sa.Column("author_agent_id", sa.Text(), nullable=False),
+    sa.Column("author_handle_at_time", sa.Text(), nullable=False),
+    sa.Column("author_display_name_at_time", sa.Text(), nullable=False),
+    sa.Column("body_text", sa.Text(), nullable=False),
+    sa.Column("created_at", sa.Text(), nullable=False),
+    sa.Column("explanation", sa.Text(), nullable=True),
+    sa.Column("model_used", sa.Text(), nullable=True),
+    sa.Column("generation_metadata_json", sa.Text(), nullable=True),
+    sa.Column("generation_created_at", sa.Text(), nullable=True),
+    sa.ForeignKeyConstraint(
+        ["run_id", "turn_number"],
+        ["turns.run_id", "turns.turn_number"],
+        name="fk_turn_posts_turn_parent",
+    ),
+    sa.ForeignKeyConstraint(
+        ["run_id", "author_agent_id"],
+        ["run_agents.run_id", "run_agents.agent_id"],
+        name="fk_turn_posts_run_author",
+    ),
+    sa.CheckConstraint("turn_number >= 0", name="ck_turn_posts_turn_number_gte_0"),
+    sa.PrimaryKeyConstraint("turn_post_id", name="pk_turn_posts"),
 )
 
 
@@ -603,7 +653,7 @@ sa.Index("idx_runs_created_at", runs.c.created_at.desc())
 sa.Index("idx_runs_app_user_id", runs.c.app_user_id)
 sa.Index("idx_feed_posts_author_handle", feed_posts.c.author_handle)
 sa.Index("idx_feed_posts_author_agent_id", feed_posts.c.author_agent_id)
-sa.Index("idx_turn_metadata_run_id", turn_metadata.c.run_id)
+sa.Index("idx_turns_run_id", turns.c.run_id)
 sa.Index("idx_turn_metrics_run_id", turn_metrics.c.run_id)
 sa.Index("idx_run_agents_run_id", run_agents.c.run_id)
 sa.Index(
@@ -676,20 +726,26 @@ sa.Index(
     agent_post_comments.c.published_at,
 )
 sa.Index(
-    "idx_likes_run_turn_agent",
-    likes.c.run_id,
-    likes.c.turn_number,
-    likes.c.agent_id,
+    "idx_turn_likes_run_turn_agent",
+    turn_likes.c.run_id,
+    turn_likes.c.turn_number,
+    turn_likes.c.agent_id,
 )
 sa.Index(
-    "idx_comments_run_turn_agent",
-    comments.c.run_id,
-    comments.c.turn_number,
-    comments.c.agent_id,
+    "idx_turn_comments_run_turn_agent",
+    turn_comments.c.run_id,
+    turn_comments.c.turn_number,
+    turn_comments.c.agent_id,
 )
 sa.Index(
-    "idx_follows_run_turn_agent",
-    follows.c.run_id,
-    follows.c.turn_number,
-    follows.c.agent_id,
+    "idx_turn_follows_run_turn_agent",
+    turn_follows.c.run_id,
+    turn_follows.c.turn_number,
+    turn_follows.c.agent_id,
+)
+sa.Index(
+    "idx_turn_posts_run_turn_author",
+    turn_posts.c.run_id,
+    turn_posts.c.turn_number,
+    turn_posts.c.author_agent_id,
 )

--- a/docs/db/2026_03_22-192628-feat__turn-table-v2-schema-spine/schema.md
+++ b/docs/db/2026_03_22-192628-feat__turn-table-v2-schema-spine/schema.md
@@ -77,19 +77,6 @@ erDiagram
     INTEGER follows_count
     INTEGER posts_count
   }
-  comments {
-    TEXT comment_id PK
-    TEXT run_id FK
-    INTEGER turn_number
-    TEXT agent_id FK
-    TEXT post_id
-    TEXT text
-    TEXT created_at
-    TEXT explanation
-    TEXT model_used
-    TEXT generation_metadata_json
-    TEXT generation_created_at
-  }
   feed_posts {
     TEXT post_id PK
     TEXT source
@@ -104,39 +91,6 @@ erDiagram
     INTEGER repost_count
     TEXT created_at
     TEXT author_agent_id FK
-  }
-  follows {
-    TEXT follow_id PK
-    TEXT run_id FK
-    INTEGER turn_number
-    TEXT agent_id FK
-    TEXT target_agent_id FK
-    TEXT created_at
-    TEXT explanation
-    TEXT model_used
-    TEXT generation_metadata_json
-    TEXT generation_created_at
-  }
-  generated_feeds {
-    TEXT feed_id
-    TEXT run_id PK, FK
-    INTEGER turn_number PK
-    TEXT agent_id PK, FK
-    TEXT agent_handle
-    TEXT post_ids
-    TEXT created_at
-  }
-  likes {
-    TEXT like_id PK
-    TEXT run_id FK
-    INTEGER turn_number
-    TEXT agent_id FK
-    TEXT post_id
-    TEXT created_at
-    TEXT explanation
-    TEXT model_used
-    TEXT generation_metadata_json
-    TEXT generation_created_at
   }
   run_agents {
     TEXT run_id PK, FK
@@ -207,16 +161,76 @@ erDiagram
     TEXT metric_keys
     TEXT app_user_id
   }
-  turn_metadata {
-    TEXT run_id PK, FK
-    INTEGER turn_number PK
-    TEXT total_actions
+  turn_comments {
+    TEXT comment_id PK
+    TEXT run_id FK
+    INTEGER turn_number FK
+    TEXT agent_id FK
+    TEXT post_id
+    TEXT text
     TEXT created_at
+    TEXT explanation
+    TEXT model_used
+    TEXT generation_metadata_json
+    TEXT generation_created_at
+  }
+  turn_follows {
+    TEXT follow_id PK
+    TEXT run_id FK
+    INTEGER turn_number FK
+    TEXT agent_id FK
+    TEXT target_agent_id FK
+    TEXT created_at
+    TEXT explanation
+    TEXT model_used
+    TEXT generation_metadata_json
+    TEXT generation_created_at
+  }
+  turn_generated_feeds {
+    TEXT feed_id
+    TEXT run_id PK, FK
+    INTEGER turn_number PK, FK
+    TEXT agent_id PK, FK
+    TEXT agent_handle
+    TEXT post_ids
+    TEXT created_at
+  }
+  turn_likes {
+    TEXT like_id PK
+    TEXT run_id FK
+    INTEGER turn_number FK
+    TEXT agent_id FK
+    TEXT post_id
+    TEXT created_at
+    TEXT explanation
+    TEXT model_used
+    TEXT generation_metadata_json
+    TEXT generation_created_at
   }
   turn_metrics {
     TEXT run_id PK, FK
-    INTEGER turn_number PK
+    INTEGER turn_number PK, FK
     TEXT metrics
+    TEXT created_at
+  }
+  turn_posts {
+    TEXT turn_post_id PK
+    TEXT run_id FK
+    INTEGER turn_number FK
+    TEXT author_agent_id FK
+    TEXT author_handle_at_time
+    TEXT author_display_name_at_time
+    TEXT body_text
+    TEXT created_at
+    TEXT explanation
+    TEXT model_used
+    TEXT generation_metadata_json
+    TEXT generation_created_at
+  }
+  turns {
+    TEXT run_id PK, FK
+    INTEGER turn_number PK
+    TEXT total_actions
     TEXT created_at
   }
   user_agent_profile_metadata {
@@ -234,13 +248,13 @@ erDiagram
   agent ||--o{ agent_post_comments : "fk_agent_post_comments_author_agent_id (author_agent_id)"
   agent ||--o{ agent_post_likes : "fk_agent_post_likes_liker_agent_id (liker_agent_id)"
   agent ||--o{ agent_posts : "fk_agent_posts_agent_id (agent_id)"
-  agent ||--o{ comments : "fk_comments_agent_id (agent_id)"
   agent ||--o{ feed_posts : "fk_feed_posts_author_agent_id (author_agent_id)"
-  agent ||--o{ follows : "fk_follows_agent_id (agent_id)"
-  agent ||--o{ follows : "fk_follows_target_agent_id (target_agent_id)"
-  agent ||--o{ generated_feeds : "fk (agent_id)"
-  agent ||--o{ likes : "fk_likes_agent_id (agent_id)"
   agent ||--o{ run_agents : "fk_run_agents_agent_id (agent_id)"
+  agent ||--o{ turn_comments : "fk (agent_id)"
+  agent ||--o{ turn_follows : "fk (agent_id)"
+  agent ||--o{ turn_follows : "fk (target_agent_id)"
+  agent ||--o{ turn_generated_feeds : "fk (agent_id)"
+  agent ||--o{ turn_likes : "fk (agent_id)"
   agent ||--o{ user_agent_profile_metadata : "fk_user_agent_profile_metadata_agent_id (agent_id)"
   agent_posts ||--o{ agent_post_comments : "fk_agent_post_comments_agent_post_id (agent_post_id)"
   agent_posts ||--o{ agent_post_likes : "fk_agent_post_likes_agent_post_id (agent_post_id)"
@@ -249,21 +263,27 @@ erDiagram
   run_agents ||--o{ run_post_comments : "fk_run_post_comments_run_author (run_id, author_agent_id)"
   run_agents ||--o{ run_post_likes : "fk_run_post_likes_run_liker (run_id, liker_agent_id)"
   run_agents ||--o{ run_posts : "fk_run_posts_run_author (run_id, author_agent_id)"
+  run_agents ||--o{ turn_posts : "fk (run_id, author_agent_id)"
   run_posts ||--o{ run_post_comments : "fk_run_post_comments_run_post (run_id, run_post_id)"
   run_posts ||--o{ run_post_comments : "fk_run_post_comments_run_post_id (run_post_id)"
   run_posts ||--o{ run_post_likes : "fk_run_post_likes_run_post_id (run_post_id)"
-  runs ||--o{ comments : "fk_comments_run_id (run_id)"
-  runs ||--o{ follows : "fk_follows_run_id (run_id)"
-  runs ||--o{ generated_feeds : "fk (run_id)"
-  runs ||--o{ likes : "fk_likes_run_id (run_id)"
   runs ||--o{ run_agents : "fk_run_agents_run_id (run_id)"
   runs ||--o{ run_follow_edges : "fk_run_follow_edges_run_id (run_id)"
   runs ||--o{ run_metrics : "fk_run_metrics_run_id (run_id)"
   runs ||--o{ run_post_comments : "fk_run_post_comments_run_id (run_id)"
   runs ||--o{ run_post_likes : "fk_run_post_likes_run_id (run_id)"
   runs ||--o{ run_posts : "fk_run_posts_run_id (run_id)"
-  runs ||--o{ turn_metadata : "fk_turn_metadata_run_id (run_id)"
-  runs ||--o{ turn_metrics : "fk_turn_metrics_run_id (run_id)"
+  runs ||--o{ turn_comments : "fk (run_id)"
+  runs ||--o{ turn_follows : "fk (run_id)"
+  runs ||--o{ turn_generated_feeds : "fk (run_id)"
+  runs ||--o{ turn_likes : "fk (run_id)"
+  runs ||--o{ turns : "fk (run_id)"
+  turns ||--o{ turn_comments : "fk (run_id, turn_number)"
+  turns ||--o{ turn_follows : "fk (run_id, turn_number)"
+  turns ||--o{ turn_generated_feeds : "fk (run_id, turn_number)"
+  turns ||--o{ turn_likes : "fk (run_id, turn_number)"
+  turns ||--o{ turn_metrics : "fk (run_id, turn_number)"
+  turns ||--o{ turn_posts : "fk (run_id, turn_number)"
 ```
 
 This documentation is generated from a fresh SQLite database after applying Alembic migrations to `head`.
@@ -298,13 +318,13 @@ This documentation is generated from a fresh SQLite database after applying Alem
 - `agent_post_comments` `fk_agent_post_comments_author_agent_id`: `author_agent_id` → `agent_id`
 - `agent_post_likes` `fk_agent_post_likes_liker_agent_id`: `liker_agent_id` → `agent_id`
 - `agent_posts` `fk_agent_posts_agent_id`: `agent_id` → `agent_id`
-- `comments` `fk_comments_agent_id`: `agent_id` → `agent_id`
 - `feed_posts` `fk_feed_posts_author_agent_id`: `author_agent_id` → `agent_id`
-- `follows` `fk_follows_agent_id`: `agent_id` → `agent_id`
-- `follows` `fk_follows_target_agent_id`: `target_agent_id` → `agent_id`
-- `generated_feeds` `(unnamed)`: `agent_id` → `agent_id`
-- `likes` `fk_likes_agent_id`: `agent_id` → `agent_id`
 - `run_agents` `fk_run_agents_agent_id`: `agent_id` → `agent_id`
+- `turn_comments` `(unnamed)`: `agent_id` → `agent_id`
+- `turn_follows` `(unnamed)`: `agent_id` → `agent_id`
+- `turn_follows` `(unnamed)`: `target_agent_id` → `agent_id`
+- `turn_generated_feeds` `(unnamed)`: `agent_id` → `agent_id`
+- `turn_likes` `(unnamed)`: `agent_id` → `agent_id`
 - `user_agent_profile_metadata` `fk_user_agent_profile_metadata_agent_id`: `agent_id` → `agent_id`
 
 ## `agent_bios`
@@ -526,46 +546,6 @@ This documentation is generated from a fresh SQLite database after applying Alem
 - Name: (none)
 - Columns: `handle`
 
-## `comments`
-
-### Columns (`comments`)
-
-| name | type | nullable | default | pk |
-| --- | --- | --- | --- | --- |
-| `comment_id` | `TEXT` | no | `` | `1` |
-| `run_id` | `TEXT` | no | `` | `` |
-| `turn_number` | `INTEGER` | no | `` | `` |
-| `agent_id` | `TEXT` | no | `` | `` |
-| `post_id` | `TEXT` | no | `` | `` |
-| `text` | `TEXT` | no | `` | `` |
-| `created_at` | `TEXT` | no | `` | `` |
-| `explanation` | `TEXT` | yes | `` | `` |
-| `model_used` | `TEXT` | yes | `` | `` |
-| `generation_metadata_json` | `TEXT` | yes | `` | `` |
-| `generation_created_at` | `TEXT` | yes | `` | `` |
-
-### Primary key (`comments`)
-
-- Name: `pk_comments`
-- Columns: `comment_id`
-
-### Foreign keys (`comments`)
-
-- `fk_comments_agent_id`: `agent_id` → `agent(agent_id)`
-- `fk_comments_run_id`: `run_id` → `runs(run_id)`
-
-### Unique constraints (`comments`)
-
-- `uq_comments_run_turn_agent_post`: `run_id`, `turn_number`, `agent_id`, `post_id`
-
-### Indexes (`comments`)
-
-- `idx_comments_run_turn_agent`: `run_id`, `turn_number`, `agent_id`
-
-### Check constraints (`comments`)
-
-- `ck_comments_turn_number_gte_0`: `turn_number >= 0`
-
 ## `feed_posts`
 
 ### Columns (`feed_posts`)
@@ -599,109 +579,6 @@ This documentation is generated from a fresh SQLite database after applying Alem
 
 - `idx_feed_posts_author_agent_id`: `author_agent_id`
 - `idx_feed_posts_author_handle`: `author_handle`
-
-## `follows`
-
-### Columns (`follows`)
-
-| name | type | nullable | default | pk |
-| --- | --- | --- | --- | --- |
-| `follow_id` | `TEXT` | no | `` | `1` |
-| `run_id` | `TEXT` | no | `` | `` |
-| `turn_number` | `INTEGER` | no | `` | `` |
-| `agent_id` | `TEXT` | no | `` | `` |
-| `target_agent_id` | `TEXT` | no | `` | `` |
-| `created_at` | `TEXT` | no | `` | `` |
-| `explanation` | `TEXT` | yes | `` | `` |
-| `model_used` | `TEXT` | yes | `` | `` |
-| `generation_metadata_json` | `TEXT` | yes | `` | `` |
-| `generation_created_at` | `TEXT` | yes | `` | `` |
-
-### Primary key (`follows`)
-
-- Name: `pk_follows`
-- Columns: `follow_id`
-
-### Foreign keys (`follows`)
-
-- `fk_follows_agent_id`: `agent_id` → `agent(agent_id)`
-- `fk_follows_target_agent_id`: `target_agent_id` → `agent(agent_id)`
-- `fk_follows_run_id`: `run_id` → `runs(run_id)`
-
-### Unique constraints (`follows`)
-
-- `uq_follows_run_turn_agent_target`: `run_id`, `turn_number`, `agent_id`, `target_agent_id`
-
-### Indexes (`follows`)
-
-- `idx_follows_run_turn_agent`: `run_id`, `turn_number`, `agent_id`
-
-### Check constraints (`follows`)
-
-- `ck_follows_turn_number_gte_0`: `turn_number >= 0`
-
-## `generated_feeds`
-
-### Columns (`generated_feeds`)
-
-| name | type | nullable | default | pk |
-| --- | --- | --- | --- | --- |
-| `feed_id` | `TEXT` | no | `` | `` |
-| `run_id` | `TEXT` | no | `` | `2` |
-| `turn_number` | `INTEGER` | no | `` | `3` |
-| `agent_id` | `TEXT` | no | `` | `1` |
-| `agent_handle` | `TEXT` | yes | `` | `` |
-| `post_ids` | `TEXT` | no | `` | `` |
-| `created_at` | `TEXT` | no | `` | `` |
-
-### Primary key (`generated_feeds`)
-
-- Name: (none)
-- Columns: `agent_id`, `run_id`, `turn_number`
-
-### Foreign keys (`generated_feeds`)
-
-- `(unnamed)`: `agent_id` → `agent(agent_id)`
-- `(unnamed)`: `run_id` → `runs(run_id)`
-
-## `likes`
-
-### Columns (`likes`)
-
-| name | type | nullable | default | pk |
-| --- | --- | --- | --- | --- |
-| `like_id` | `TEXT` | no | `` | `1` |
-| `run_id` | `TEXT` | no | `` | `` |
-| `turn_number` | `INTEGER` | no | `` | `` |
-| `agent_id` | `TEXT` | no | `` | `` |
-| `post_id` | `TEXT` | no | `` | `` |
-| `created_at` | `TEXT` | no | `` | `` |
-| `explanation` | `TEXT` | yes | `` | `` |
-| `model_used` | `TEXT` | yes | `` | `` |
-| `generation_metadata_json` | `TEXT` | yes | `` | `` |
-| `generation_created_at` | `TEXT` | yes | `` | `` |
-
-### Primary key (`likes`)
-
-- Name: `pk_likes`
-- Columns: `like_id`
-
-### Foreign keys (`likes`)
-
-- `fk_likes_agent_id`: `agent_id` → `agent(agent_id)`
-- `fk_likes_run_id`: `run_id` → `runs(run_id)`
-
-### Unique constraints (`likes`)
-
-- `uq_likes_run_turn_agent_post`: `run_id`, `turn_number`, `agent_id`, `post_id`
-
-### Indexes (`likes`)
-
-- `idx_likes_run_turn_agent`: `run_id`, `turn_number`, `agent_id`
-
-### Check constraints (`likes`)
-
-- `ck_likes_turn_number_gte_0`: `turn_number >= 0`
 
 ## `run_agents`
 
@@ -745,6 +622,7 @@ This documentation is generated from a fresh SQLite database after applying Alem
 - `run_post_comments` `fk_run_post_comments_run_author`: `run_id`, `author_agent_id` → `run_id`, `agent_id`
 - `run_post_likes` `fk_run_post_likes_run_liker`: `run_id`, `liker_agent_id` → `run_id`, `agent_id`
 - `run_posts` `fk_run_posts_run_author`: `run_id`, `author_agent_id` → `run_id`, `agent_id`
+- `turn_posts` `(unnamed)`: `run_id`, `author_agent_id` → `run_id`, `agent_id`
 
 ## `run_follow_edges`
 
@@ -946,46 +824,165 @@ This documentation is generated from a fresh SQLite database after applying Alem
 
 ### Referenced by (`runs`)
 
-- `comments` `fk_comments_run_id`: `run_id` → `run_id`
-- `follows` `fk_follows_run_id`: `run_id` → `run_id`
-- `generated_feeds` `(unnamed)`: `run_id` → `run_id`
-- `likes` `fk_likes_run_id`: `run_id` → `run_id`
 - `run_agents` `fk_run_agents_run_id`: `run_id` → `run_id`
 - `run_follow_edges` `fk_run_follow_edges_run_id`: `run_id` → `run_id`
 - `run_metrics` `fk_run_metrics_run_id`: `run_id` → `run_id`
 - `run_post_comments` `fk_run_post_comments_run_id`: `run_id` → `run_id`
 - `run_post_likes` `fk_run_post_likes_run_id`: `run_id` → `run_id`
 - `run_posts` `fk_run_posts_run_id`: `run_id` → `run_id`
-- `turn_metadata` `fk_turn_metadata_run_id`: `run_id` → `run_id`
-- `turn_metrics` `fk_turn_metrics_run_id`: `run_id` → `run_id`
+- `turn_comments` `(unnamed)`: `run_id` → `run_id`
+- `turn_follows` `(unnamed)`: `run_id` → `run_id`
+- `turn_generated_feeds` `(unnamed)`: `run_id` → `run_id`
+- `turn_likes` `(unnamed)`: `run_id` → `run_id`
+- `turns` `(unnamed)`: `run_id` → `run_id`
 
-## `turn_metadata`
+## `turn_comments`
 
-### Columns (`turn_metadata`)
+### Columns (`turn_comments`)
 
 | name | type | nullable | default | pk |
 | --- | --- | --- | --- | --- |
-| `run_id` | `TEXT` | no | `` | `1` |
-| `turn_number` | `INTEGER` | no | `` | `2` |
-| `total_actions` | `TEXT` | no | `` | `` |
+| `comment_id` | `TEXT` | no | `` | `1` |
+| `run_id` | `TEXT` | no | `` | `` |
+| `turn_number` | `INTEGER` | no | `` | `` |
+| `agent_id` | `TEXT` | no | `` | `` |
+| `post_id` | `TEXT` | no | `` | `` |
+| `text` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+| `explanation` | `TEXT` | yes | `` | `` |
+| `model_used` | `TEXT` | yes | `` | `` |
+| `generation_metadata_json` | `TEXT` | yes | `` | `` |
+| `generation_created_at` | `TEXT` | yes | `` | `` |
+
+### Primary key (`turn_comments`)
+
+- Name: (none)
+- Columns: `comment_id`
+
+### Foreign keys (`turn_comments`)
+
+- `(unnamed)`: `agent_id` → `agent(agent_id)`
+- `(unnamed)`: `run_id` → `runs(run_id)`
+- `(unnamed)`: `run_id`, `turn_number` → `turns(run_id, turn_number)`
+
+### Unique constraints (`turn_comments`)
+
+- `uq_turn_comments_run_turn_agent_post`: `run_id`, `turn_number`, `agent_id`, `post_id`
+
+### Indexes (`turn_comments`)
+
+- `idx_turn_comments_run_turn_agent`: `run_id`, `turn_number`, `agent_id`
+
+### Check constraints (`turn_comments`)
+
+- `(unnamed)`: `turn_number >= 0`
+
+## `turn_follows`
+
+### Columns (`turn_follows`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `follow_id` | `TEXT` | no | `` | `1` |
+| `run_id` | `TEXT` | no | `` | `` |
+| `turn_number` | `INTEGER` | no | `` | `` |
+| `agent_id` | `TEXT` | no | `` | `` |
+| `target_agent_id` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+| `explanation` | `TEXT` | yes | `` | `` |
+| `model_used` | `TEXT` | yes | `` | `` |
+| `generation_metadata_json` | `TEXT` | yes | `` | `` |
+| `generation_created_at` | `TEXT` | yes | `` | `` |
+
+### Primary key (`turn_follows`)
+
+- Name: (none)
+- Columns: `follow_id`
+
+### Foreign keys (`turn_follows`)
+
+- `(unnamed)`: `agent_id` → `agent(agent_id)`
+- `(unnamed)`: `target_agent_id` → `agent(agent_id)`
+- `(unnamed)`: `run_id` → `runs(run_id)`
+- `(unnamed)`: `run_id`, `turn_number` → `turns(run_id, turn_number)`
+
+### Unique constraints (`turn_follows`)
+
+- `uq_turn_follows_run_turn_agent_target`: `run_id`, `turn_number`, `agent_id`, `target_agent_id`
+
+### Indexes (`turn_follows`)
+
+- `idx_turn_follows_run_turn_agent`: `run_id`, `turn_number`, `agent_id`
+
+### Check constraints (`turn_follows`)
+
+- `(unnamed)`: `turn_number >= 0`
+- `ck_turn_follows_no_self_follow`: `agent_id != target_agent_id`
+
+## `turn_generated_feeds`
+
+### Columns (`turn_generated_feeds`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `feed_id` | `TEXT` | no | `` | `` |
+| `run_id` | `TEXT` | no | `` | `2` |
+| `turn_number` | `INTEGER` | no | `` | `3` |
+| `agent_id` | `TEXT` | no | `` | `1` |
+| `agent_handle` | `TEXT` | yes | `` | `` |
+| `post_ids` | `TEXT` | no | `` | `` |
 | `created_at` | `TEXT` | no | `` | `` |
 
-### Primary key (`turn_metadata`)
+### Primary key (`turn_generated_feeds`)
 
-- Name: `pk_turn_metadata`
-- Columns: `run_id`, `turn_number`
+- Name: (none)
+- Columns: `agent_id`, `run_id`, `turn_number`
 
-### Foreign keys (`turn_metadata`)
+### Foreign keys (`turn_generated_feeds`)
 
-- `fk_turn_metadata_run_id`: `run_id` → `runs(run_id)`
+- `(unnamed)`: `agent_id` → `agent(agent_id)`
+- `(unnamed)`: `run_id` → `runs(run_id)`
+- `(unnamed)`: `run_id`, `turn_number` → `turns(run_id, turn_number)`
 
-### Indexes (`turn_metadata`)
+## `turn_likes`
 
-- `idx_turn_metadata_run_id`: `run_id`
+### Columns (`turn_likes`)
 
-### Check constraints (`turn_metadata`)
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `like_id` | `TEXT` | no | `` | `1` |
+| `run_id` | `TEXT` | no | `` | `` |
+| `turn_number` | `INTEGER` | no | `` | `` |
+| `agent_id` | `TEXT` | no | `` | `` |
+| `post_id` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+| `explanation` | `TEXT` | yes | `` | `` |
+| `model_used` | `TEXT` | yes | `` | `` |
+| `generation_metadata_json` | `TEXT` | yes | `` | `` |
+| `generation_created_at` | `TEXT` | yes | `` | `` |
 
-- `ck_turn_metadata_turn_number_gte_0`: `turn_number >= 0`
+### Primary key (`turn_likes`)
+
+- Name: (none)
+- Columns: `like_id`
+
+### Foreign keys (`turn_likes`)
+
+- `(unnamed)`: `agent_id` → `agent(agent_id)`
+- `(unnamed)`: `run_id` → `runs(run_id)`
+- `(unnamed)`: `run_id`, `turn_number` → `turns(run_id, turn_number)`
+
+### Unique constraints (`turn_likes`)
+
+- `uq_turn_likes_run_turn_agent_post`: `run_id`, `turn_number`, `agent_id`, `post_id`
+
+### Indexes (`turn_likes`)
+
+- `idx_turn_likes_run_turn_agent`: `run_id`, `turn_number`, `agent_id`
+
+### Check constraints (`turn_likes`)
+
+- `(unnamed)`: `turn_number >= 0`
 
 ## `turn_metrics`
 
@@ -1000,12 +997,12 @@ This documentation is generated from a fresh SQLite database after applying Alem
 
 ### Primary key (`turn_metrics`)
 
-- Name: `pk_turn_metrics`
+- Name: (none)
 - Columns: `run_id`, `turn_number`
 
 ### Foreign keys (`turn_metrics`)
 
-- `fk_turn_metrics_run_id`: `run_id` → `runs(run_id)`
+- `(unnamed)`: `run_id`, `turn_number` → `turns(run_id, turn_number)`
 
 ### Indexes (`turn_metrics`)
 
@@ -1013,7 +1010,81 @@ This documentation is generated from a fresh SQLite database after applying Alem
 
 ### Check constraints (`turn_metrics`)
 
-- `ck_turn_metrics_turn_number_gte_0`: `turn_number >= 0`
+- `(unnamed)`: `turn_number >= 0`
+
+## `turn_posts`
+
+### Columns (`turn_posts`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `turn_post_id` | `TEXT` | no | `` | `1` |
+| `run_id` | `TEXT` | no | `` | `` |
+| `turn_number` | `INTEGER` | no | `` | `` |
+| `author_agent_id` | `TEXT` | no | `` | `` |
+| `author_handle_at_time` | `TEXT` | no | `` | `` |
+| `author_display_name_at_time` | `TEXT` | no | `` | `` |
+| `body_text` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+| `explanation` | `TEXT` | yes | `` | `` |
+| `model_used` | `TEXT` | yes | `` | `` |
+| `generation_metadata_json` | `TEXT` | yes | `` | `` |
+| `generation_created_at` | `TEXT` | yes | `` | `` |
+
+### Primary key (`turn_posts`)
+
+- Name: (none)
+- Columns: `turn_post_id`
+
+### Foreign keys (`turn_posts`)
+
+- `(unnamed)`: `run_id`, `author_agent_id` → `run_agents(run_id, agent_id)`
+- `(unnamed)`: `run_id`, `turn_number` → `turns(run_id, turn_number)`
+
+### Indexes (`turn_posts`)
+
+- `idx_turn_posts_run_turn_author`: `run_id`, `turn_number`, `author_agent_id`
+
+### Check constraints (`turn_posts`)
+
+- `(unnamed)`: `turn_number >= 0`
+
+## `turns`
+
+### Columns (`turns`)
+
+| name | type | nullable | default | pk |
+| --- | --- | --- | --- | --- |
+| `run_id` | `TEXT` | no | `` | `1` |
+| `turn_number` | `INTEGER` | no | `` | `2` |
+| `total_actions` | `TEXT` | no | `` | `` |
+| `created_at` | `TEXT` | no | `` | `` |
+
+### Primary key (`turns`)
+
+- Name: (none)
+- Columns: `run_id`, `turn_number`
+
+### Foreign keys (`turns`)
+
+- `(unnamed)`: `run_id` → `runs(run_id)`
+
+### Indexes (`turns`)
+
+- `idx_turns_run_id`: `run_id`
+
+### Check constraints (`turns`)
+
+- `(unnamed)`: `turn_number >= 0`
+
+### Referenced by (`turns`)
+
+- `turn_comments` `(unnamed)`: `run_id`, `turn_number` → `run_id`, `turn_number`
+- `turn_follows` `(unnamed)`: `run_id`, `turn_number` → `run_id`, `turn_number`
+- `turn_generated_feeds` `(unnamed)`: `run_id`, `turn_number` → `run_id`, `turn_number`
+- `turn_likes` `(unnamed)`: `run_id`, `turn_number` → `run_id`, `turn_number`
+- `turn_metrics` `(unnamed)`: `run_id`, `turn_number` → `run_id`, `turn_number`
+- `turn_posts` `(unnamed)`: `run_id`, `turn_number` → `run_id`, `turn_number`
 
 ## `user_agent_profile_metadata`
 

--- a/docs/db/2026_03_22-192628-feat__turn-table-v2-schema-spine/schema.snapshot.json
+++ b/docs/db/2026_03_22-192628-feat__turn-table-v2-schema-spine/schema.snapshot.json
@@ -64,16 +64,6 @@
       },
       {
         "from_columns": [
-          "agent_id"
-        ],
-        "from_table": "comments",
-        "name": "fk_comments_agent_id",
-        "to_columns": [
-          "agent_id"
-        ]
-      },
-      {
-        "from_columns": [
           "author_agent_id"
         ],
         "from_table": "feed_posts",
@@ -86,18 +76,8 @@
         "from_columns": [
           "agent_id"
         ],
-        "from_table": "follows",
-        "name": "fk_follows_agent_id",
-        "to_columns": [
-          "agent_id"
-        ]
-      },
-      {
-        "from_columns": [
-          "target_agent_id"
-        ],
-        "from_table": "follows",
-        "name": "fk_follows_target_agent_id",
+        "from_table": "run_agents",
+        "name": "fk_run_agents_agent_id",
         "to_columns": [
           "agent_id"
         ]
@@ -106,7 +86,7 @@
         "from_columns": [
           "agent_id"
         ],
-        "from_table": "generated_feeds",
+        "from_table": "turn_comments",
         "name": null,
         "to_columns": [
           "agent_id"
@@ -116,8 +96,18 @@
         "from_columns": [
           "agent_id"
         ],
-        "from_table": "likes",
-        "name": "fk_likes_agent_id",
+        "from_table": "turn_follows",
+        "name": null,
+        "to_columns": [
+          "agent_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "target_agent_id"
+        ],
+        "from_table": "turn_follows",
+        "name": null,
         "to_columns": [
           "agent_id"
         ]
@@ -126,8 +116,18 @@
         "from_columns": [
           "agent_id"
         ],
-        "from_table": "run_agents",
-        "name": "fk_run_agents_agent_id",
+        "from_table": "turn_generated_feeds",
+        "name": null,
+        "to_columns": [
+          "agent_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "agent_id"
+        ],
+        "from_table": "turn_likes",
+        "name": null,
         "to_columns": [
           "agent_id"
         ]
@@ -172,11 +172,7 @@
     ],
     "app_users": [],
     "bluesky_profiles": [],
-    "comments": [],
     "feed_posts": [],
-    "follows": [],
-    "generated_feeds": [],
-    "likes": [],
     "run_agents": [
       {
         "from_columns": [
@@ -237,6 +233,18 @@
           "run_id",
           "agent_id"
         ]
+      },
+      {
+        "from_columns": [
+          "run_id",
+          "author_agent_id"
+        ],
+        "from_table": "turn_posts",
+        "name": null,
+        "to_columns": [
+          "run_id",
+          "agent_id"
+        ]
       }
     ],
     "run_follow_edges": [],
@@ -278,46 +286,6 @@
       }
     ],
     "runs": [
-      {
-        "from_columns": [
-          "run_id"
-        ],
-        "from_table": "comments",
-        "name": "fk_comments_run_id",
-        "to_columns": [
-          "run_id"
-        ]
-      },
-      {
-        "from_columns": [
-          "run_id"
-        ],
-        "from_table": "follows",
-        "name": "fk_follows_run_id",
-        "to_columns": [
-          "run_id"
-        ]
-      },
-      {
-        "from_columns": [
-          "run_id"
-        ],
-        "from_table": "generated_feeds",
-        "name": null,
-        "to_columns": [
-          "run_id"
-        ]
-      },
-      {
-        "from_columns": [
-          "run_id"
-        ],
-        "from_table": "likes",
-        "name": "fk_likes_run_id",
-        "to_columns": [
-          "run_id"
-        ]
-      },
       {
         "from_columns": [
           "run_id"
@@ -382,8 +350,8 @@
         "from_columns": [
           "run_id"
         ],
-        "from_table": "turn_metadata",
-        "name": "fk_turn_metadata_run_id",
+        "from_table": "turn_comments",
+        "name": null,
         "to_columns": [
           "run_id"
         ]
@@ -392,15 +360,123 @@
         "from_columns": [
           "run_id"
         ],
-        "from_table": "turn_metrics",
-        "name": "fk_turn_metrics_run_id",
+        "from_table": "turn_follows",
+        "name": null,
+        "to_columns": [
+          "run_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id"
+        ],
+        "from_table": "turn_generated_feeds",
+        "name": null,
+        "to_columns": [
+          "run_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id"
+        ],
+        "from_table": "turn_likes",
+        "name": null,
+        "to_columns": [
+          "run_id"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id"
+        ],
+        "from_table": "turns",
+        "name": null,
         "to_columns": [
           "run_id"
         ]
       }
     ],
-    "turn_metadata": [],
+    "turn_comments": [],
+    "turn_follows": [],
+    "turn_generated_feeds": [],
+    "turn_likes": [],
     "turn_metrics": [],
+    "turn_posts": [],
+    "turns": [
+      {
+        "from_columns": [
+          "run_id",
+          "turn_number"
+        ],
+        "from_table": "turn_comments",
+        "name": null,
+        "to_columns": [
+          "run_id",
+          "turn_number"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id",
+          "turn_number"
+        ],
+        "from_table": "turn_follows",
+        "name": null,
+        "to_columns": [
+          "run_id",
+          "turn_number"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id",
+          "turn_number"
+        ],
+        "from_table": "turn_generated_feeds",
+        "name": null,
+        "to_columns": [
+          "run_id",
+          "turn_number"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id",
+          "turn_number"
+        ],
+        "from_table": "turn_likes",
+        "name": null,
+        "to_columns": [
+          "run_id",
+          "turn_number"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id",
+          "turn_number"
+        ],
+        "from_table": "turn_metrics",
+        "name": null,
+        "to_columns": [
+          "run_id",
+          "turn_number"
+        ]
+      },
+      {
+        "from_columns": [
+          "run_id",
+          "turn_number"
+        ],
+        "from_table": "turn_posts",
+        "name": null,
+        "to_columns": [
+          "run_id",
+          "turn_number"
+        ]
+      }
+    ],
     "user_agent_profile_metadata": []
   },
   "tables": {
@@ -1123,147 +1199,6 @@
       },
       "unique_constraints": []
     },
-    "comments": {
-      "check_constraints": [
-        {
-          "name": "ck_comments_turn_number_gte_0",
-          "sqltext": "turn_number >= 0"
-        }
-      ],
-      "columns": [
-        {
-          "default": null,
-          "name": "comment_id",
-          "nullable": false,
-          "primary_key": 1,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "run_id",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "turn_number",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "INTEGER"
-        },
-        {
-          "default": null,
-          "name": "agent_id",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "post_id",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "text",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "created_at",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "explanation",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "model_used",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "generation_metadata_json",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "generation_created_at",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        }
-      ],
-      "foreign_keys": [
-        {
-          "columns": [
-            "agent_id"
-          ],
-          "name": "fk_comments_agent_id",
-          "ondelete": null,
-          "onupdate": null,
-          "referred_columns": [
-            "agent_id"
-          ],
-          "referred_table": "agent"
-        },
-        {
-          "columns": [
-            "run_id"
-          ],
-          "name": "fk_comments_run_id",
-          "ondelete": null,
-          "onupdate": null,
-          "referred_columns": [
-            "run_id"
-          ],
-          "referred_table": "runs"
-        }
-      ],
-      "indexes": [
-        {
-          "columns": [
-            "run_id",
-            "turn_number",
-            "agent_id"
-          ],
-          "name": "idx_comments_run_turn_agent",
-          "unique": false
-        }
-      ],
-      "primary_key": {
-        "columns": [
-          "comment_id"
-        ],
-        "name": "pk_comments"
-      },
-      "unique_constraints": [
-        {
-          "columns": [
-            "run_id",
-            "turn_number",
-            "agent_id",
-            "post_id"
-          ],
-          "name": "uq_comments_run_turn_agent_post"
-        }
-      ]
-    },
     "feed_posts": {
       "check_constraints": [],
       "columns": [
@@ -1396,376 +1331,6 @@
         "name": null
       },
       "unique_constraints": []
-    },
-    "follows": {
-      "check_constraints": [
-        {
-          "name": "ck_follows_turn_number_gte_0",
-          "sqltext": "turn_number >= 0"
-        }
-      ],
-      "columns": [
-        {
-          "default": null,
-          "name": "follow_id",
-          "nullable": false,
-          "primary_key": 1,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "run_id",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "turn_number",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "INTEGER"
-        },
-        {
-          "default": null,
-          "name": "agent_id",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "target_agent_id",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "created_at",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "explanation",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "model_used",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "generation_metadata_json",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "generation_created_at",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        }
-      ],
-      "foreign_keys": [
-        {
-          "columns": [
-            "agent_id"
-          ],
-          "name": "fk_follows_agent_id",
-          "ondelete": null,
-          "onupdate": null,
-          "referred_columns": [
-            "agent_id"
-          ],
-          "referred_table": "agent"
-        },
-        {
-          "columns": [
-            "target_agent_id"
-          ],
-          "name": "fk_follows_target_agent_id",
-          "ondelete": null,
-          "onupdate": null,
-          "referred_columns": [
-            "agent_id"
-          ],
-          "referred_table": "agent"
-        },
-        {
-          "columns": [
-            "run_id"
-          ],
-          "name": "fk_follows_run_id",
-          "ondelete": null,
-          "onupdate": null,
-          "referred_columns": [
-            "run_id"
-          ],
-          "referred_table": "runs"
-        }
-      ],
-      "indexes": [
-        {
-          "columns": [
-            "run_id",
-            "turn_number",
-            "agent_id"
-          ],
-          "name": "idx_follows_run_turn_agent",
-          "unique": false
-        }
-      ],
-      "primary_key": {
-        "columns": [
-          "follow_id"
-        ],
-        "name": "pk_follows"
-      },
-      "unique_constraints": [
-        {
-          "columns": [
-            "run_id",
-            "turn_number",
-            "agent_id",
-            "target_agent_id"
-          ],
-          "name": "uq_follows_run_turn_agent_target"
-        }
-      ]
-    },
-    "generated_feeds": {
-      "check_constraints": [],
-      "columns": [
-        {
-          "default": null,
-          "name": "feed_id",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "run_id",
-          "nullable": false,
-          "primary_key": 2,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "turn_number",
-          "nullable": false,
-          "primary_key": 3,
-          "type": "INTEGER"
-        },
-        {
-          "default": null,
-          "name": "agent_id",
-          "nullable": false,
-          "primary_key": 1,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "agent_handle",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "post_ids",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "created_at",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        }
-      ],
-      "foreign_keys": [
-        {
-          "columns": [
-            "agent_id"
-          ],
-          "name": null,
-          "ondelete": null,
-          "onupdate": null,
-          "referred_columns": [
-            "agent_id"
-          ],
-          "referred_table": "agent"
-        },
-        {
-          "columns": [
-            "run_id"
-          ],
-          "name": null,
-          "ondelete": null,
-          "onupdate": null,
-          "referred_columns": [
-            "run_id"
-          ],
-          "referred_table": "runs"
-        }
-      ],
-      "indexes": [],
-      "primary_key": {
-        "columns": [
-          "agent_id",
-          "run_id",
-          "turn_number"
-        ],
-        "name": null
-      },
-      "unique_constraints": []
-    },
-    "likes": {
-      "check_constraints": [
-        {
-          "name": "ck_likes_turn_number_gte_0",
-          "sqltext": "turn_number >= 0"
-        }
-      ],
-      "columns": [
-        {
-          "default": null,
-          "name": "like_id",
-          "nullable": false,
-          "primary_key": 1,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "run_id",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "turn_number",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "INTEGER"
-        },
-        {
-          "default": null,
-          "name": "agent_id",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "post_id",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "created_at",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "explanation",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "model_used",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "generation_metadata_json",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "generation_created_at",
-          "nullable": true,
-          "primary_key": 0,
-          "type": "TEXT"
-        }
-      ],
-      "foreign_keys": [
-        {
-          "columns": [
-            "agent_id"
-          ],
-          "name": "fk_likes_agent_id",
-          "ondelete": null,
-          "onupdate": null,
-          "referred_columns": [
-            "agent_id"
-          ],
-          "referred_table": "agent"
-        },
-        {
-          "columns": [
-            "run_id"
-          ],
-          "name": "fk_likes_run_id",
-          "ondelete": null,
-          "onupdate": null,
-          "referred_columns": [
-            "run_id"
-          ],
-          "referred_table": "runs"
-        }
-      ],
-      "indexes": [
-        {
-          "columns": [
-            "run_id",
-            "turn_number",
-            "agent_id"
-          ],
-          "name": "idx_likes_run_turn_agent",
-          "unique": false
-        }
-      ],
-      "primary_key": {
-        "columns": [
-          "like_id"
-        ],
-        "name": "pk_likes"
-      },
-      "unique_constraints": [
-        {
-          "columns": [
-            "run_id",
-            "turn_number",
-            "agent_id",
-            "post_id"
-          ],
-          "name": "uq_likes_run_turn_agent_post"
-        }
-      ]
     },
     "run_agents": {
       "check_constraints": [],
@@ -2612,10 +2177,794 @@
       },
       "unique_constraints": []
     },
-    "turn_metadata": {
+    "turn_comments": {
       "check_constraints": [
         {
-          "name": "ck_turn_metadata_turn_number_gte_0",
+          "name": null,
+          "sqltext": "turn_number >= 0"
+        }
+      ],
+      "columns": [
+        {
+          "default": null,
+          "name": "comment_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "turn_number",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "agent_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "post_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "text",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "explanation",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "model_used",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_metadata_json",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_created_at",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "agent_id"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "agent_id"
+          ],
+          "referred_table": "agent"
+        },
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id"
+          ],
+          "referred_table": "runs"
+        },
+        {
+          "columns": [
+            "run_id",
+            "turn_number"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id",
+            "turn_number"
+          ],
+          "referred_table": "turns"
+        }
+      ],
+      "indexes": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "agent_id"
+          ],
+          "name": "idx_turn_comments_run_turn_agent",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "comment_id"
+        ],
+        "name": null
+      },
+      "unique_constraints": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "agent_id",
+            "post_id"
+          ],
+          "name": "uq_turn_comments_run_turn_agent_post"
+        }
+      ]
+    },
+    "turn_follows": {
+      "check_constraints": [
+        {
+          "name": null,
+          "sqltext": "turn_number >= 0"
+        },
+        {
+          "name": "ck_turn_follows_no_self_follow",
+          "sqltext": "agent_id != target_agent_id"
+        }
+      ],
+      "columns": [
+        {
+          "default": null,
+          "name": "follow_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "turn_number",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "agent_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "target_agent_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "explanation",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "model_used",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_metadata_json",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_created_at",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "agent_id"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "agent_id"
+          ],
+          "referred_table": "agent"
+        },
+        {
+          "columns": [
+            "target_agent_id"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "agent_id"
+          ],
+          "referred_table": "agent"
+        },
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id"
+          ],
+          "referred_table": "runs"
+        },
+        {
+          "columns": [
+            "run_id",
+            "turn_number"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id",
+            "turn_number"
+          ],
+          "referred_table": "turns"
+        }
+      ],
+      "indexes": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "agent_id"
+          ],
+          "name": "idx_turn_follows_run_turn_agent",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "follow_id"
+        ],
+        "name": null
+      },
+      "unique_constraints": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "agent_id",
+            "target_agent_id"
+          ],
+          "name": "uq_turn_follows_run_turn_agent_target"
+        }
+      ]
+    },
+    "turn_generated_feeds": {
+      "check_constraints": [],
+      "columns": [
+        {
+          "default": null,
+          "name": "feed_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 2,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "turn_number",
+          "nullable": false,
+          "primary_key": 3,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "agent_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "agent_handle",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "post_ids",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "agent_id"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "agent_id"
+          ],
+          "referred_table": "agent"
+        },
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id"
+          ],
+          "referred_table": "runs"
+        },
+        {
+          "columns": [
+            "run_id",
+            "turn_number"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id",
+            "turn_number"
+          ],
+          "referred_table": "turns"
+        }
+      ],
+      "indexes": [],
+      "primary_key": {
+        "columns": [
+          "agent_id",
+          "run_id",
+          "turn_number"
+        ],
+        "name": null
+      },
+      "unique_constraints": []
+    },
+    "turn_likes": {
+      "check_constraints": [
+        {
+          "name": null,
+          "sqltext": "turn_number >= 0"
+        }
+      ],
+      "columns": [
+        {
+          "default": null,
+          "name": "like_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "turn_number",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "agent_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "post_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "explanation",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "model_used",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_metadata_json",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_created_at",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "agent_id"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "agent_id"
+          ],
+          "referred_table": "agent"
+        },
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id"
+          ],
+          "referred_table": "runs"
+        },
+        {
+          "columns": [
+            "run_id",
+            "turn_number"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id",
+            "turn_number"
+          ],
+          "referred_table": "turns"
+        }
+      ],
+      "indexes": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "agent_id"
+          ],
+          "name": "idx_turn_likes_run_turn_agent",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "like_id"
+        ],
+        "name": null
+      },
+      "unique_constraints": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "agent_id",
+            "post_id"
+          ],
+          "name": "uq_turn_likes_run_turn_agent_post"
+        }
+      ]
+    },
+    "turn_metrics": {
+      "check_constraints": [
+        {
+          "name": null,
+          "sqltext": "turn_number >= 0"
+        }
+      ],
+      "columns": [
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "turn_number",
+          "nullable": false,
+          "primary_key": 2,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "metrics",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id",
+            "turn_number"
+          ],
+          "referred_table": "turns"
+        }
+      ],
+      "indexes": [
+        {
+          "columns": [
+            "run_id"
+          ],
+          "name": "idx_turn_metrics_run_id",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "run_id",
+          "turn_number"
+        ],
+        "name": null
+      },
+      "unique_constraints": []
+    },
+    "turn_posts": {
+      "check_constraints": [
+        {
+          "name": null,
+          "sqltext": "turn_number >= 0"
+        }
+      ],
+      "columns": [
+        {
+          "default": null,
+          "name": "turn_post_id",
+          "nullable": false,
+          "primary_key": 1,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "run_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "turn_number",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "INTEGER"
+        },
+        {
+          "default": null,
+          "name": "author_agent_id",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "author_handle_at_time",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "author_display_name_at_time",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "body_text",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "created_at",
+          "nullable": false,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "explanation",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "model_used",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_metadata_json",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        },
+        {
+          "default": null,
+          "name": "generation_created_at",
+          "nullable": true,
+          "primary_key": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "run_id",
+            "author_agent_id"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id",
+            "agent_id"
+          ],
+          "referred_table": "run_agents"
+        },
+        {
+          "columns": [
+            "run_id",
+            "turn_number"
+          ],
+          "name": null,
+          "ondelete": null,
+          "onupdate": null,
+          "referred_columns": [
+            "run_id",
+            "turn_number"
+          ],
+          "referred_table": "turns"
+        }
+      ],
+      "indexes": [
+        {
+          "columns": [
+            "run_id",
+            "turn_number",
+            "author_agent_id"
+          ],
+          "name": "idx_turn_posts_run_turn_author",
+          "unique": false
+        }
+      ],
+      "primary_key": {
+        "columns": [
+          "turn_post_id"
+        ],
+        "name": null
+      },
+      "unique_constraints": []
+    },
+    "turns": {
+      "check_constraints": [
+        {
+          "name": null,
           "sqltext": "turn_number >= 0"
         }
       ],
@@ -2654,7 +3003,7 @@
           "columns": [
             "run_id"
           ],
-          "name": "fk_turn_metadata_run_id",
+          "name": null,
           "ondelete": null,
           "onupdate": null,
           "referred_columns": [
@@ -2668,7 +3017,7 @@
           "columns": [
             "run_id"
           ],
-          "name": "idx_turn_metadata_run_id",
+          "name": "idx_turns_run_id",
           "unique": false
         }
       ],
@@ -2677,76 +3026,7 @@
           "run_id",
           "turn_number"
         ],
-        "name": "pk_turn_metadata"
-      },
-      "unique_constraints": []
-    },
-    "turn_metrics": {
-      "check_constraints": [
-        {
-          "name": "ck_turn_metrics_turn_number_gte_0",
-          "sqltext": "turn_number >= 0"
-        }
-      ],
-      "columns": [
-        {
-          "default": null,
-          "name": "run_id",
-          "nullable": false,
-          "primary_key": 1,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "turn_number",
-          "nullable": false,
-          "primary_key": 2,
-          "type": "INTEGER"
-        },
-        {
-          "default": null,
-          "name": "metrics",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        },
-        {
-          "default": null,
-          "name": "created_at",
-          "nullable": false,
-          "primary_key": 0,
-          "type": "TEXT"
-        }
-      ],
-      "foreign_keys": [
-        {
-          "columns": [
-            "run_id"
-          ],
-          "name": "fk_turn_metrics_run_id",
-          "ondelete": null,
-          "onupdate": null,
-          "referred_columns": [
-            "run_id"
-          ],
-          "referred_table": "runs"
-        }
-      ],
-      "indexes": [
-        {
-          "columns": [
-            "run_id"
-          ],
-          "name": "idx_turn_metrics_run_id",
-          "unique": false
-        }
-      ],
-      "primary_key": {
-        "columns": [
-          "run_id",
-          "turn_number"
-        ],
-        "name": "pk_turn_metrics"
+        "name": null
       },
       "unique_constraints": []
     },

--- a/docs/db/LATEST.txt
+++ b/docs/db/LATEST.txt
@@ -1,1 +1,1 @@
-2026_03_21-132257-require-post-author-agent-id
+2026_03_22-192628-feat__turn-table-v2-schema-spine

--- a/docs/plans/2026-03-22_turn_table_schema_spine_847292/verification.md
+++ b/docs/plans/2026-03-22_turn_table_schema_spine_847292/verification.md
@@ -1,0 +1,12 @@
+---
+description: Verification notes for turn-table v2 schema spine slice
+tags: [verification, plan, database, turns]
+---
+
+# Turn schema spine — verification
+
+- `SIM_DB_PATH=/tmp/turn_tables_v2.sqlite uv run python -m alembic -c pyproject.toml upgrade head` — exit 0, single head `f3c9a1e7b2d4`.
+- `uv run pytest tests/db/test_turn_table_v2_schema_migration.py -q` — pass.
+- `uv run pytest tests/db -k "turn or migration" -q` — pass.
+- `uv run pytest tests/lint/test_lint_schema_conventions.py -q` — pass.
+- `uv run python scripts/generate_db_schema_docs.py --check` — pass after updating `docs/db/LATEST.txt` to `2026_03_22-192628-feat__turn-table-v2-schema-spine`.

--- a/scripts/lint_schema_conventions.py
+++ b/scripts/lint_schema_conventions.py
@@ -26,20 +26,6 @@ LEGACY_SEED_STATE_TABLES: frozenset[str] = frozenset(
     }
 )
 
-# TODO: Delete these legacy tables once migration renames/replaces them.
-LEGACY_TURN_EVENT_TABLES: frozenset[str] = frozenset(
-    {
-        # Legacy-named turn event tables (treated like `turn_*`).
-        "generated_feeds",
-        "likes",
-        "comments",
-        "follows",
-        # Already-prefixed turn-event tables.
-        "turn_metadata",
-        "turn_metrics",
-    }
-)
-
 
 @dataclass(frozen=True)
 class Violation:
@@ -122,7 +108,7 @@ def lint_metadata(metadata: sa.MetaData) -> list[Violation]:
             violations.extend(_lint_run_table(table))
             continue
 
-        if name.startswith("turn_") or name in LEGACY_TURN_EVENT_TABLES:
+        if name == "turns" or name.startswith("turn_"):
             violations.extend(_lint_turn_event_table(table))
             continue
 

--- a/tests/db/adapters/sqlite/test_generated_feed_adapter.py
+++ b/tests/db/adapters/sqlite/test_generated_feed_adapter.py
@@ -88,7 +88,7 @@ class TestSQLiteGeneratedFeedAdapterReadFeedsForTurn:
             call_args = mock_conn.execute.call_args
             assert (
                 call_args[0][0]
-                == "SELECT * FROM generated_feeds WHERE run_id = ? AND turn_number = ?"
+                == "SELECT * FROM turn_generated_feeds WHERE run_id = ? AND turn_number = ?"
             )
             assert call_args[0][1] == (run_id, turn_number)
 
@@ -225,6 +225,6 @@ class TestSQLiteGeneratedFeedAdapterReadFeedsForTurn:
             call_args = mock_conn.execute.call_args
             assert (
                 call_args[0][0]
-                == "SELECT * FROM generated_feeds WHERE run_id = ? AND turn_number = ?"
+                == "SELECT * FROM turn_generated_feeds WHERE run_id = ? AND turn_number = ?"
             )
             assert call_args[0][1] == (run_id, turn_number)

--- a/tests/db/adapters/sqlite/test_run_adapter.py
+++ b/tests/db/adapters/sqlite/test_run_adapter.py
@@ -285,9 +285,8 @@ class TestSQLiteRunAdapterReadTurnMetadata:
             # Assert
             mock_conn.execute.assert_called_once()
             call_args = mock_conn.execute.call_args
-            assert (
-                "SELECT * FROM turn_metadata WHERE run_id = ? AND turn_number = ?"
-                in str(call_args[0][0])
+            assert "SELECT * FROM turns WHERE run_id = ? AND turn_number = ?" in str(
+                call_args[0][0]
             )
             assert call_args[0][1] == (run_id, turn_number)
 
@@ -389,7 +388,7 @@ class TestSQLiteRunAdapterReadTurnMetadataForRun:
             mock_conn.execute.assert_called_once()
             call_args = mock_conn.execute.call_args
             assert (
-                "SELECT * FROM turn_metadata WHERE run_id = ? ORDER BY turn_number ASC"
+                "SELECT * FROM turns WHERE run_id = ? ORDER BY turn_number ASC"
                 in str(call_args[0][0])
             )
             assert call_args[0][1] == (run_id,)
@@ -432,7 +431,7 @@ class TestSQLiteRunAdapterWriteTurnMetadata:
             # Verify INSERT was executed (conn provided, no commit)
             mock_conn.execute.assert_called_once()
             call_args = mock_conn.execute.call_args
-            assert "INSERT INTO turn_metadata" in str(call_args[0][0])
+            assert "INSERT INTO turns" in str(call_args[0][0])
             # Verify parameters
             params = call_args[0][1]
             assert params[0] == run_id
@@ -588,7 +587,7 @@ class TestSQLiteRunAdapterWriteTurnMetadata:
             call_args = mock_conn.execute.call_args
             # Verify SQL statement
             sql = str(call_args[0][0])
-            assert "INSERT INTO turn_metadata" in sql
+            assert "INSERT INTO turns" in sql
             assert "run_id" in sql
             assert "turn_number" in sql
             assert "total_actions" in sql
@@ -629,7 +628,7 @@ class TestSQLiteRunAdapterWriteTurnMetadata:
 
         # Simulate PRIMARY KEY constraint violation (duplicate insert)
         integrity_error = sqlite3.IntegrityError(
-            "UNIQUE constraint failed: turn_metadata.run_id, turn_metadata.turn_number"
+            "UNIQUE constraint failed: turns.run_id, turns.turn_number"
         )
         with mock_db_connection() as (mock_conn, mock_cursor):
             mock_conn.execute.side_effect = integrity_error

--- a/tests/db/adapters/sqlite/test_sqlite.py
+++ b/tests/db/adapters/sqlite/test_sqlite.py
@@ -124,9 +124,9 @@ class TestInitializeDatabase:
                 "bluesky_profiles",
                 "feed_posts",
                 "agent_bios",
-                "generated_feeds",
+                "turn_generated_feeds",
                 "runs",
-                "turn_metadata",
+                "turns",
                 "turn_metrics",
                 "run_metrics",
             ]
@@ -152,7 +152,7 @@ class TestInitializeDatabase:
                 "idx_runs_status",
                 "idx_runs_created_at",
                 "idx_feed_posts_author_handle",
-                "idx_turn_metadata_run_id",
+                "idx_turns_run_id",
                 "idx_turn_metrics_run_id",
             ]
 

--- a/tests/db/agent_id_inventory.py
+++ b/tests/db/agent_id_inventory.py
@@ -24,11 +24,11 @@ AGENT_KEY_COLUMNS: tuple[tuple[str, str], ...] = (
     ("run_post_comments", "author_agent_id"),
     ("run_follow_edges", "follower_agent_id"),
     ("run_follow_edges", "target_agent_id"),
-    ("likes", "agent_id"),
-    ("comments", "agent_id"),
-    ("follows", "agent_id"),
-    ("follows", "target_agent_id"),
-    ("generated_feeds", "agent_id"),
+    ("turn_likes", "agent_id"),
+    ("turn_comments", "agent_id"),
+    ("turn_follows", "agent_id"),
+    ("turn_follows", "target_agent_id"),
+    ("turn_generated_feeds", "agent_id"),
 )
 
 _UUID_HYPHENATED = re.compile(

--- a/tests/db/repositories/conftest.py
+++ b/tests/db/repositories/conftest.py
@@ -13,7 +13,7 @@ from simulation.core.models.feeds import GeneratedFeed
 
 
 def ensure_agent_row_for_generated_feed(feed: GeneratedFeed) -> None:
-    """Insert an agent row so ``generated_feeds.agent_id`` FK writes succeed in tests."""
+    """Insert an agent row so ``turn_generated_feeds.agent_id`` FK writes succeed in tests."""
     handle = feed.agent_handle.strip()
     with get_connection() as conn:
         conn.execute(

--- a/tests/db/repositories/test_action_repositories_integration.py
+++ b/tests/db/repositories/test_action_repositories_integration.py
@@ -5,11 +5,14 @@ Uses a real SQLite database. Requires a run to exist for FK (run_id).
 
 from __future__ import annotations
 
+import json
 import sqlite3
 
 import pytest
 
+from db.adapters.sqlite.turn_parent import TURN_PARENT_PLACEHOLDER_CREATED_AT
 from lib.agent_id import canonical_agent_id
+from simulation.core.models.actions import TurnAction
 from tests.factories import (
     CommentFactory,
     FollowFactory,
@@ -55,7 +58,28 @@ def _make_run(run_repo) -> str:
     return run.run_id
 
 
-_ALLOWED_ACTION_TABLES = frozenset({"likes", "comments", "follows"})
+def _seed_turn_parent_row(temp_db: str, run_id: str, turn_number: int) -> None:
+    """Ensure ``turns`` has a parent row so ``turn_*`` action FK checks pass."""
+    conn = sqlite3.connect(temp_db)
+    try:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO turns (run_id, turn_number, total_actions, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                run_id,
+                turn_number,
+                json.dumps({k.value: 0 for k in TurnAction}),
+                TURN_PARENT_PLACEHOLDER_CREATED_AT,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+_ALLOWED_ACTION_TABLES = frozenset({"turn_likes", "turn_comments", "turn_follows"})
 
 
 def _count_rows(temp_db: str, table: str) -> int:
@@ -72,11 +96,12 @@ class TestSQLiteLikeRepositoryIntegration:
     """Integration tests for LikeRepository."""
 
     def test_write_and_read_likes_by_run_turn(
-        self, seed_action_agents, run_repo, like_repo
+        self, seed_action_agents, temp_db, run_repo, like_repo
     ) -> None:
         """write_likes then read_likes_by_run_turn round-trips."""
         run_id = _make_run(run_repo)
         turn_number = 0
+        _seed_turn_parent_row(temp_db, run_id, turn_number)
 
         alice_id = canonical_agent_id("alice.bsky.social")
         likes = [
@@ -116,11 +141,12 @@ class TestSQLiteCommentRepositoryIntegration:
     """Integration tests for CommentRepository."""
 
     def test_write_and_read_comments_by_run_turn(
-        self, seed_action_agents, run_repo, comment_repo
+        self, seed_action_agents, temp_db, run_repo, comment_repo
     ) -> None:
         """write_comments then read_comments_by_run_turn round-trips."""
         run_id = _make_run(run_repo)
         turn_number = 0
+        _seed_turn_parent_row(temp_db, run_id, turn_number)
 
         bob_id = canonical_agent_id("bob.bsky.social")
         comments = [
@@ -156,11 +182,12 @@ class TestSQLiteFollowRepositoryIntegration:
     """Integration tests for FollowRepository."""
 
     def test_write_and_read_follows_by_run_turn(
-        self, seed_action_agents, run_repo, follow_repo
+        self, seed_action_agents, temp_db, run_repo, follow_repo
     ) -> None:
         """write_follows then read_follows_by_run_turn round-trips."""
         run_id = _make_run(run_repo)
         turn_number = 0
+        _seed_turn_parent_row(temp_db, run_id, turn_number)
 
         alice_id = canonical_agent_id("alice.bsky.social")
         charlie_id = canonical_agent_id("charlie.bsky.social")
@@ -198,7 +225,7 @@ class TestSQLiteActionRepositoriesCanonicalOnly:
         self, seed_action_agents, run_repo, like_repo, temp_db
     ) -> None:
         run_id = _make_run(run_repo)
-        before = _count_rows(temp_db, "likes")
+        before = _count_rows(temp_db, "turn_likes")
         bad = GeneratedLikeFactory.create(
             like=LikeFactory.create(
                 like_id="like_bad",
@@ -215,13 +242,13 @@ class TestSQLiteActionRepositoriesCanonicalOnly:
         )
         with pytest.raises(ValueError, match="agent_id must be 16 lowercase hex chars"):
             like_repo.write_likes(run_id, 0, [bad])
-        assert _count_rows(temp_db, "likes") == before
+        assert _count_rows(temp_db, "turn_likes") == before
 
     def test_write_comments_rejects_malformed_agent_id_without_persisting(
         self, seed_action_agents, run_repo, comment_repo, temp_db
     ) -> None:
         run_id = _make_run(run_repo)
-        before = _count_rows(temp_db, "comments")
+        before = _count_rows(temp_db, "turn_comments")
         bad = GeneratedCommentFactory.create(
             comment=CommentFactory.create(
                 comment_id="c_bad",
@@ -239,13 +266,13 @@ class TestSQLiteActionRepositoriesCanonicalOnly:
         )
         with pytest.raises(ValueError, match="agent_id must be 16 lowercase hex chars"):
             comment_repo.write_comments(run_id, 0, [bad])
-        assert _count_rows(temp_db, "comments") == before
+        assert _count_rows(temp_db, "turn_comments") == before
 
     def test_write_follows_rejects_handle_target_without_persisting(
         self, seed_action_agents, run_repo, follow_repo, temp_db
     ) -> None:
         run_id = _make_run(run_repo)
-        before = _count_rows(temp_db, "follows")
+        before = _count_rows(temp_db, "turn_follows")
         alice_id = canonical_agent_id("alice.bsky.social")
         bad = GeneratedFollowFactory.create(
             follow=FollowFactory.create(
@@ -263,4 +290,4 @@ class TestSQLiteActionRepositoriesCanonicalOnly:
         )
         with pytest.raises(ValueError, match="agent_id must be 16 lowercase hex chars"):
             follow_repo.write_follows(run_id, 0, [bad])
-        assert _count_rows(temp_db, "follows") == before
+        assert _count_rows(temp_db, "turn_follows") == before

--- a/tests/db/repositories/test_generated_feed_repository.py
+++ b/tests/db/repositories/test_generated_feed_repository.py
@@ -142,7 +142,7 @@ class TestSQLiteGeneratedFeedRepositoryCreateOrUpdateGeneratedFeed:
 
         mock_adapter = Mock(spec=GeneratedFeedDatabaseAdapter)
         db_error = sqlite3.IntegrityError(
-            "UNIQUE constraint failed: generated_feeds.agent_handle, run_id, turn_number"
+            "UNIQUE constraint failed: turn_generated_feeds.agent_id, run_id, turn_number"
         )
         mock_adapter.write_generated_feed.side_effect = db_error
         repo = SQLiteGeneratedFeedRepository(

--- a/tests/db/repositories/test_generated_feed_repository_integration.py
+++ b/tests/db/repositories/test_generated_feed_repository_integration.py
@@ -237,7 +237,7 @@ class TestSQLiteGeneratedFeedRepositoryIntegration:
             repo.get_generated_feed("", "run_123", 1)
 
     def test_get_post_ids_for_run_rejects_handle_before_db(self, generated_feed_repo):
-        """Handle-shaped ``agent_id`` must not query ``generated_feeds``."""
+        """Handle-shaped ``agent_id`` must not query ``turn_generated_feeds``."""
         repo = generated_feed_repo
         with pytest.raises(ValueError, match="agent_id must be 16 lowercase hex chars"):
             repo.get_post_ids_for_run("test.bsky.social", "run_123")
@@ -262,7 +262,7 @@ class TestSQLiteGeneratedFeedRepositoryIntegration:
         conn = sqlite3.connect(temp_db)
         try:
             conn.execute(
-                "UPDATE generated_feeds SET agent_handle = ? WHERE agent_id = ? AND run_id = ?",
+                "UPDATE turn_generated_feeds SET agent_handle = ? WHERE agent_id = ? AND run_id = ?",
                 ("stale.bsky.social", aid, "run_123"),
             )
             conn.commit()

--- a/tests/db/repositories/test_metrics_repository_integration.py
+++ b/tests/db/repositories/test_metrics_repository_integration.py
@@ -1,19 +1,47 @@
 """Integration tests for db.repositories.metrics_repository module."""
 
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from db.adapters.sqlite.turn_parent import TURN_PARENT_PLACEHOLDER_CREATED_AT
 from lib.timestamp_utils import get_current_timestamp
+from simulation.core.models.actions import TurnAction
 from tests.factories import RunConfigFactory, RunMetricsFactory, TurnMetricsFactory
+
+
+def _seed_turn_parent_row(temp_db: str, run_id: str, turn_number: int) -> None:
+    conn = sqlite3.connect(temp_db)
+    try:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO turns (run_id, turn_number, total_actions, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                run_id,
+                turn_number,
+                json.dumps({k.value: 0 for k in TurnAction}),
+                TURN_PARENT_PLACEHOLDER_CREATED_AT,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 class TestSQLiteMetricsRepositoryIntegration:
     """Integration tests using a real SQLite database."""
 
-    def test_write_and_read_turn_metrics(self, run_repo, metrics_repo):
+    def test_write_and_read_turn_metrics(self, temp_db, run_repo, metrics_repo):
         """write_turn_metrics then get_turn_metrics round-trips."""
         run = run_repo.create_run(
             RunConfigFactory.create(
                 num_agents=2, num_turns=2, feed_algorithm="chronological"
             )
         )
+        _seed_turn_parent_row(temp_db, run.run_id, 0)
 
         created_at = get_current_timestamp()
         turn_metrics = TurnMetricsFactory.create(
@@ -32,13 +60,17 @@ class TestSQLiteMetricsRepositoryIntegration:
         assert result.metrics == {"turn.actions.total": 3}
         assert result.created_at == created_at
 
-    def test_list_turn_metrics_is_ordered_by_turn_number(self, run_repo, metrics_repo):
+    def test_list_turn_metrics_is_ordered_by_turn_number(
+        self, temp_db, run_repo, metrics_repo
+    ):
         """list_turn_metrics returns items ordered by turn_number ascending."""
         run = run_repo.create_run(
             RunConfigFactory.create(
                 num_agents=2, num_turns=3, feed_algorithm="chronological"
             )
         )
+        for tn in (0, 1, 2):
+            _seed_turn_parent_row(temp_db, run.run_id, tn)
 
         metrics_repo.write_turn_metrics(
             TurnMetricsFactory.create(

--- a/tests/db/repositories/test_run_repository_integration.py
+++ b/tests/db/repositories/test_run_repository_integration.py
@@ -558,7 +558,7 @@ class TestTurnMetadataIntegration:
                 )
                 conn.execute(
                     """
-                    INSERT INTO turn_metadata (run_id, turn_number, total_actions, created_at)
+                    INSERT INTO turns (run_id, turn_number, total_actions, created_at)
                     VALUES (?, ?, ?, ?)
                     """,
                     (
@@ -606,7 +606,7 @@ class TestTurnMetadataIntegration:
         with get_connection() as conn:
             conn.execute(
                 """
-                INSERT INTO turn_metadata (run_id, turn_number, total_actions, created_at)
+                INSERT INTO turns (run_id, turn_number, total_actions, created_at)
                 VALUES (?, ?, ?, ?)
                 """,
                 (run.run_id, turn_number, total_actions_json, "2024_01_01-12:00:00"),
@@ -656,7 +656,7 @@ class TestTurnMetadataIntegration:
             )
             conn.execute(
                 """
-                INSERT INTO turn_metadata (run_id, turn_number, total_actions, created_at)
+                INSERT INTO turns (run_id, turn_number, total_actions, created_at)
                 VALUES (?, ?, ?, ?)
                 """,
                 (run1.run_id, 0, total_actions_json_1, "2024_01_01-12:00:00"),
@@ -673,7 +673,7 @@ class TestTurnMetadataIntegration:
             )
             conn.execute(
                 """
-                INSERT INTO turn_metadata (run_id, turn_number, total_actions, created_at)
+                INSERT INTO turns (run_id, turn_number, total_actions, created_at)
                 VALUES (?, ?, ?, ?)
                 """,
                 (run2.run_id, 0, total_actions_json_2, "2024_01_01-12:00:00"),

--- a/tests/db/test_turn_table_v2_schema_migration.py
+++ b/tests/db/test_turn_table_v2_schema_migration.py
@@ -1,0 +1,199 @@
+"""Upgrade tests for the turn-table v2 schema spine (``f3c9a1e7b2d4``)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+from lib.agent_id import canonical_agent_id
+from lib.constants import REPO_ROOT
+
+
+def _cfg(monkeypatch: pytest.MonkeyPatch, db_path: str) -> Config:
+    monkeypatch.setenv("SIM_DB_PATH", db_path)
+    monkeypatch.delenv("SIM_DATABASE_URL", raising=False)
+    return Config(toml_file=str(Path(REPO_ROOT) / "pyproject.toml"))
+
+
+def _fk_violations(conn: sqlite3.Connection) -> list:
+    return conn.execute("PRAGMA foreign_key_check").fetchall()
+
+
+class TestTurnTableV2SchemaMigration:
+    def test_migrates_legacy_turn_rows_to_turn_family(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        db_path = str(tmp_path / "turn_v2.sqlite")
+        cfg = _cfg(monkeypatch, db_path)
+        command.upgrade(cfg, "e7f3a9c2d1b4")
+
+        run_id = "run-turn-v2-test"
+        handle_a = "alice.turnv2.bsky.social"
+        handle_b = "bob.turnv2.bsky.social"
+        agent_a = canonical_agent_id(handle_a)
+        agent_b = canonical_agent_id(handle_b)
+
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                """
+                INSERT INTO runs (
+                  run_id, app_user_id, created_at, total_turns, total_agents, feed_algorithm,
+                  metric_keys, started_at, status, completed_at
+                ) VALUES (?, NULL, '2026-01-01', 1, 2, 'chronological',
+                  NULL, '2026-01-01', 'running', NULL)
+                """,
+                (run_id,),
+            )
+            for aid, h in ((agent_a, handle_a), (agent_b, handle_b)):
+                conn.execute(
+                    """
+                    INSERT INTO agent (
+                      agent_id, handle, persona_source, display_name, created_at, updated_at
+                    ) VALUES (?, ?, 'test', 'Agent', '2026-01-01', '2026-01-01')
+                    """,
+                    (aid, h),
+                )
+            conn.execute(
+                """
+                INSERT INTO turn_metadata (
+                  run_id, turn_number, total_actions, created_at
+                ) VALUES (?, ?, ?, '2026-01-01')
+                """,
+                (
+                    run_id,
+                    0,
+                    json.dumps({"like": 1, "comment": 1, "follow": 1}),
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO turn_metrics (run_id, turn_number, metrics, created_at)
+                VALUES (?, ?, ?, '2026-01-01')
+                """,
+                (run_id, 0, json.dumps({"k": 1})),
+            )
+            conn.execute(
+                """
+                INSERT INTO generated_feeds (
+                  feed_id, run_id, turn_number, agent_id, agent_handle, post_ids, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, '2026-01-01')
+                """,
+                ("feed-1", run_id, 0, agent_a, handle_a, json.dumps(["post-a"])),
+            )
+            conn.execute(
+                """
+                INSERT INTO likes (
+                  like_id, run_id, turn_number, agent_id, post_id, created_at
+                ) VALUES (?, ?, ?, ?, ?, '2026-01-01')
+                """,
+                ("like-1", run_id, 0, agent_a, "run-post-1"),
+            )
+            conn.execute(
+                """
+                INSERT INTO comments (
+                  comment_id, run_id, turn_number, agent_id, post_id, text, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, '2026-01-01')
+                """,
+                ("comment-1", run_id, 0, agent_a, "run-post-1", "hi"),
+            )
+            conn.execute(
+                """
+                INSERT INTO follows (
+                  follow_id, run_id, turn_number, agent_id, target_agent_id, created_at
+                ) VALUES (?, ?, ?, ?, ?, '2026-01-01')
+                """,
+                ("follow-1", run_id, 0, agent_a, agent_b),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        command.upgrade(cfg, "head")
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert _fk_violations(conn) == []
+            assert (
+                conn.execute(
+                    "SELECT COUNT(*) FROM turns WHERE run_id = ?", (run_id,)
+                ).fetchone()[0]
+                == 1
+            )
+            tm = conn.execute(
+                "SELECT total_actions FROM turns WHERE run_id = ? AND turn_number = 0",
+                (run_id,),
+            ).fetchone()
+            assert tm is not None
+            assert json.loads(tm[0]) == {"like": 1, "comment": 1, "follow": 1}
+
+            assert (
+                conn.execute(
+                    "SELECT COUNT(*) FROM turn_generated_feeds WHERE run_id = ?",
+                    (run_id,),
+                ).fetchone()[0]
+                == 1
+            )
+            gf = conn.execute(
+                "SELECT post_ids FROM turn_generated_feeds WHERE feed_id = ?",
+                ("feed-1",),
+            ).fetchone()
+            assert gf is not None
+            assert json.loads(gf[0]) == ["post-a"]
+
+            assert (
+                conn.execute(
+                    "SELECT like_id FROM turn_likes WHERE run_id = ?", (run_id,)
+                ).fetchone()[0]
+                == "like-1"
+            )
+            assert (
+                conn.execute(
+                    "SELECT comment_id FROM turn_comments WHERE run_id = ?", (run_id,)
+                ).fetchone()[0]
+                == "comment-1"
+            )
+            assert (
+                conn.execute(
+                    "SELECT follow_id FROM turn_follows WHERE run_id = ?", (run_id,)
+                ).fetchone()[0]
+                == "follow-1"
+            )
+            assert conn.execute("SELECT COUNT(*) FROM turn_posts").fetchone()[0] == 0
+        finally:
+            conn.close()
+
+    def test_fresh_head_database_exposes_turn_family_not_legacy_names(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        db_path = str(tmp_path / "turn_v2_fresh.sqlite")
+        cfg = _cfg(monkeypatch, db_path)
+        command.upgrade(cfg, "head")
+
+        conn = sqlite3.connect(db_path)
+        try:
+            names = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+                ).fetchall()
+            }
+            assert "turns" in names
+            assert "turn_metrics" in names
+            assert "turn_generated_feeds" in names
+            assert "turn_likes" in names
+            assert "turn_comments" in names
+            assert "turn_follows" in names
+            assert "turn_posts" in names
+            assert "turn_metadata" not in names
+            assert "generated_feeds" not in names
+            assert "likes" not in names
+            assert "comments" not in names
+            assert "follows" not in names
+        finally:
+            conn.close()


### PR DESCRIPTION
## Overview

This slice implements the next step from the v2 turn-table strategy: land the irreversible schema foundation for the turn-table v2 architecture that was already frozen in docs. The work is intentionally limited to DDL, data migration, schema-linter alignment, schema-doc refresh, and migration-focused tests so later runtime/query changes can build on a stable `turns` + `turn_*` head schema without mixing in transaction-boundary or read-path behavior changes.

## Problem / motivation

Legacy `turn_metadata`, `generated_feeds`, `likes`, `comments`, and `follows` needed to be replaced with a canonical `turns` parent and `turn_*` table family with composite FKs to `turns(run_id, turn_number)`, per the frozen contracts, so Alembic head and persistence can converge on one steady-state shape.

## Solution

- Redefine `db/schema.py` at head around `turns`, `turn_metrics`, `turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, and foundation-only `turn_posts`.
- Add migration `f3c9a1e7b2d4` (revises `e7f3a9c2d1b4`): copy legacy rows, add composite FKs and named constraints, create empty `turn_posts`, drop legacy tables.
- Ensure feed writes satisfy composite FKs via a placeholder `turns` row (`db/adapters/sqlite/turn_parent.py`) and upsert in `write_turn_metadata`.
- Update SQLite adapters, schema linter, `docs/db` snapshot, and regression tests.

## Happy Flow

1. `db/schema.py` defines `turns`, `turn_metrics`, `turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, and `turn_posts`, with per-turn tables referencing `turns(run_id, turn_number)`.
2. Alembic `f3c9a1e7b2d4` upgrades SQLite: new tables, copy forward, named constraints/indexes, drop legacy turn-event tables.
3. `turn_posts` exists at head; migration does not backfill rows.
4. `scripts/lint_schema_conventions.py`, `tests/lint/test_lint_schema_conventions.py`, `docs/db/LATEST.txt`, and the latest `docs/db/*` snapshot match head.
5. `tests/db/test_turn_table_v2_schema_migration.py` covers upgrade from pre-spine head and fresh head table names.

## Data Flow

Legacy turn-event tables → new Alembic revision → `turns` parent + `turn_*` children → schema docs + linter; runtime writes use stub `turns` row before `turn_generated_feeds`, then `write_turn_metadata` replaces placeholder counts.

## Changes

- `db/schema.py`, `db/migrations/versions/f3c9a1e7b2d4_turn_table_v2_schema_spine.py`: head DDL + upgrade path (upgrade-only downgrade).
- `db/adapters/sqlite/*`, `db/adapters/sqlite/turn_parent.py`, `db/adapters/base.py`: SQL table renames and turn-parent stub/upsert behavior.
- `scripts/lint_schema_conventions.py`: lint `turns` and `turn_*` only (no legacy turn-event allowlist).
- `docs/db/`: new snapshot folder; `docs/db/LATEST.txt` updated.
- Tests: migration file, integration seeds for `turns` FKs, adapter/repository expectations.

## Manual Verification

- `SIM_DB_PATH=/tmp/turn_tables_v2.sqlite uv run python -m alembic -c pyproject.toml upgrade head` — exit 0
- `uv run pytest tests/db/test_turn_table_v2_schema_migration.py -q` — pass
- `uv run pytest tests/db -k "turn or migration" -q` — pass
- `uv run pytest tests/lint/test_lint_schema_conventions.py -q` — pass
- `uv run python scripts/generate_db_schema_docs.py --check` — pass
- `uv run python scripts/check_db_schema_drift.py` — pass (pre-commit)

Verification notes: `docs/plans/2026-03-22_turn_table_schema_spine_847292/verification.md`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Restructured core database schema to enhance data organization and consistency across turn-based operations. Updated all data persistence layers to align with the new schema structure. Implemented comprehensive migration tooling to seamlessly upgrade existing database instances while ensuring data integrity and preventing orphaned records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->