### PR TITLE
Update turn read-path docs for turns/turn_* tables

### DIFF
--- a/db/adapters/sqlite/run_adapter.py
+++ b/db/adapters/sqlite/run_adapter.py
@@ -56,8 +56,9 @@ def _parse_total_actions_from_row(row: sqlite3.Row) -> dict[TurnAction, int]:
 class SQLiteRunAdapter(RunDatabaseAdapter):
     """SQLite implementation of RunDatabaseAdapter.
 
-    This implementation raises SQLite-specific exceptions. See method docstrings
-    for details on specific exception types.
+    Turn metadata is read and written from the ``turns`` table (see
+    ``read_turn_metadata``, ``write_turn_metadata``). This implementation raises
+    SQLite-specific exceptions; see method docstrings for details.
     """
 
     def _row_to_run(self, row: sqlite3.Row) -> Run:
@@ -210,7 +211,7 @@ class SQLiteRunAdapter(RunDatabaseAdapter):
         *,
         conn: sqlite3.Connection,
     ) -> TurnMetadata | None:
-        """Read turn metadata from SQLite.
+        """Read turn metadata from SQLite (``turns`` table).
 
         The total_actions field is stored as JSON with string keys (e.g., {"like": 5}).
         This method converts those string keys to TurnAction enum keys.
@@ -257,7 +258,7 @@ class SQLiteRunAdapter(RunDatabaseAdapter):
     def read_turn_metadata_for_run(
         self, run_id: str, *, conn: sqlite3.Connection
     ) -> list[TurnMetadata]:
-        """Read all turn metadata rows for a run from SQLite.
+        """Read all turn metadata rows for a run from SQLite (``turns``).
 
         Args:
             run_id: The ID of the run

--- a/db/adapters/sqlite/turn_parent.py
+++ b/db/adapters/sqlite/turn_parent.py
@@ -1,9 +1,9 @@
 """Helpers for the canonical ``turns`` parent row.
 
-``generate_feeds`` persists ``turn_generated_feeds`` before ``write_turn`` inserts the
-final ``turns`` row. A placeholder ``turns`` row (see ``TURN_PARENT_PLACEHOLDER_CREATED_AT``)
-satisfies composite foreign keys until ``SQLiteRunAdapter.write_turn_metadata`` replaces
-it with real turn metadata in the same transaction order as before.
+Some persistence paths insert a placeholder ``turns`` row so child rows in
+``turn_generated_feeds`` (and related ``turn_*`` action tables) satisfy foreign
+keys. ``SQLiteRunAdapter.write_turn_metadata`` replaces that stub or inserts the
+final row as part of the per-turn write flow.
 """
 
 from __future__ import annotations

--- a/db/repositories/comment_repository.py
+++ b/db/repositories/comment_repository.py
@@ -11,7 +11,7 @@ from simulation.core.models.persisted_actions import PersistedComment
 
 
 class SQLiteCommentRepository(CommentRepository):
-    """SQLite implementation of CommentRepository."""
+    """SQLite implementation of CommentRepository (``turn_comments``)."""
 
     def __init__(
         self,
@@ -29,6 +29,7 @@ class SQLiteCommentRepository(CommentRepository):
         comments: Iterable[GeneratedComment],
         conn: object | None = None,
     ) -> None:
+        """Persist generated comments for one turn (runtime history, not seed state)."""
         if conn is not None:
             self._db_adapter.write_comments(run_id, turn_number, comments, conn=conn)
         else:

--- a/db/repositories/follow_repository.py
+++ b/db/repositories/follow_repository.py
@@ -11,7 +11,7 @@ from simulation.core.models.persisted_actions import PersistedFollow
 
 
 class SQLiteFollowRepository(FollowRepository):
-    """SQLite implementation of FollowRepository."""
+    """SQLite implementation of FollowRepository (``turn_follows``)."""
 
     def __init__(
         self,
@@ -29,6 +29,7 @@ class SQLiteFollowRepository(FollowRepository):
         follows: Iterable[GeneratedFollow],
         conn: object | None = None,
     ) -> None:
+        """Persist generated follows for one turn (runtime history, not seed state)."""
         if conn is not None:
             self._db_adapter.write_follows(run_id, turn_number, follows, conn=conn)
         else:

--- a/db/repositories/generated_feed_repository.py
+++ b/db/repositories/generated_feed_repository.py
@@ -15,7 +15,8 @@ class SQLiteGeneratedFeedRepository(GeneratedFeedRepository):
     """SQLite implementation of GeneratedFeedRepository.
 
     Uses dependency injection to accept a database adapter,
-    decoupling it from concrete implementations.
+    decoupling it from concrete implementations. Reads and writes map to
+    ``turn_generated_feeds``.
     """
 
     def __init__(

--- a/db/repositories/interfaces.py
+++ b/db/repositories/interfaces.py
@@ -233,6 +233,9 @@ class RunRepository(ABC):
     def get_turn_metadata(self, run_id: str, turn_number: int) -> TurnMetadata | None:
         """Get turn metadata for a specific run and turn.
 
+        Rows are stored in the ``turns`` table. Method names are historical; the
+        contract is one metadata row per (run_id, turn_number) in ``turns``.
+
         Args:
             run_id: The ID of the run
             turn_number: The turn number (0-indexed)
@@ -248,6 +251,8 @@ class RunRepository(ABC):
     @abstractmethod
     def list_turn_metadata(self, run_id: str) -> list[TurnMetadata]:
         """List all turn metadata for a run in turn order.
+
+        Backed by the ``turns`` table, ordered by ``turn_number``.
 
         Args:
             run_id: The ID of the run
@@ -268,6 +273,8 @@ class RunRepository(ABC):
         conn: object | None = None,
     ) -> None:
         """Write turn metadata to the database.
+
+        Persists to the ``turns`` table (insert or replace placeholder stub rows).
 
         Args:
             turn_metadata: TurnMetadata model to write
@@ -343,7 +350,7 @@ class RunPostRepository(ABC):
 
         Args:
             run_id: The run to scope the lookup.
-            post_ids: Iterable of run_post_ids (from generated_feeds.post_ids).
+            post_ids: Iterable of run_post_ids (from ``turn_generated_feeds.post_ids``).
 
         Returns:
             List of RunPostSnapshot in the same order as post_ids, skipping missing.
@@ -750,7 +757,11 @@ class FeedPostRepository(ABC):
 
 
 class GeneratedFeedRepository(ABC):
-    """Abstract base class defining the interface for generated feed repositories."""
+    """Abstract interface for per-turn generated feeds.
+
+    Runtime persistence is the ``turn_generated_feeds`` table (one logical feed
+    per agent/run/turn composite key).
+    """
 
     @abstractmethod
     def write_generated_feed(
@@ -871,7 +882,7 @@ class GeneratedBioRepository(ABC):
 
 
 class LikeRepository(ABC):
-    """Abstract interface for persisted like actions (run-scoped)."""
+    """Abstract interface for persisted like actions (run-scoped, ``turn_likes``)."""
 
     @abstractmethod
     def write_likes(
@@ -893,7 +904,7 @@ class LikeRepository(ABC):
 
 
 class CommentRepository(ABC):
-    """Abstract interface for persisted comment actions (run-scoped)."""
+    """Abstract interface for persisted comment actions (run-scoped, ``turn_comments``)."""
 
     @abstractmethod
     def write_comments(
@@ -915,7 +926,7 @@ class CommentRepository(ABC):
 
 
 class FollowRepository(ABC):
-    """Abstract interface for persisted follow actions (run-scoped)."""
+    """Abstract interface for persisted follow actions (run-scoped, ``turn_follows``)."""
 
     @abstractmethod
     def write_follows(

--- a/db/repositories/like_repository.py
+++ b/db/repositories/like_repository.py
@@ -11,7 +11,7 @@ from simulation.core.models.persisted_actions import PersistedLike
 
 
 class SQLiteLikeRepository(LikeRepository):
-    """SQLite implementation of LikeRepository."""
+    """SQLite implementation of LikeRepository (``turn_likes``)."""
 
     def __init__(
         self,
@@ -29,6 +29,7 @@ class SQLiteLikeRepository(LikeRepository):
         likes: Iterable[GeneratedLike],
         conn: object | None = None,
     ) -> None:
+        """Persist generated likes for one turn (runtime history, not seed state)."""
         if conn is not None:
             self._db_adapter.write_likes(run_id, turn_number, likes, conn=conn)
         else:

--- a/db/repositories/run_repository.py
+++ b/db/repositories/run_repository.py
@@ -27,7 +27,8 @@ from simulation.core.utils.validators import (
 class SQLiteRunRepository(RunRepository):
     """SQLite implementation of RunRepository.
 
-    Uses dependency injection to accept a database adapter.
+    Uses dependency injection to accept a database adapter. Turn metadata
+    accessors read and write the ``turns`` table via the run adapter.
     """
 
     # Valid state transitions for run status
@@ -180,7 +181,7 @@ class SQLiteRunRepository(RunRepository):
 
     @validate_inputs((validate_run_id, "run_id"), (validate_turn_number, "turn_number"))
     def get_turn_metadata(self, run_id: str, turn_number: int) -> TurnMetadata | None:
-        """Get turn metadata for a specific run and turn.
+        """Get turn metadata for a specific run and turn (``turns`` table).
 
         Args:
             run_id: The ID of the run
@@ -200,7 +201,7 @@ class SQLiteRunRepository(RunRepository):
 
     @validate_inputs((validate_run_id, "run_id"))
     def list_turn_metadata(self, run_id: str) -> list[TurnMetadata]:
-        """List all turn metadata for a run in turn order.
+        """List all turn metadata for a run in turn order (``turns`` rows).
 
         Args:
             run_id: The ID of the run
@@ -223,7 +224,7 @@ class SQLiteRunRepository(RunRepository):
         turn_metadata: TurnMetadata,
         conn: object | None = None,
     ) -> None:
-        """Write turn metadata to the database.
+        """Write turn metadata to the database (``turns`` table).
 
         Args:
             turn_metadata: TurnMetadata model to write

--- a/docs/plans/2026-03-23_turn_repository_read_path_cutover_431286/plan.md
+++ b/docs/plans/2026-03-23_turn_repository_read_path_cutover_431286/plan.md
@@ -1,0 +1,280 @@
+---
+name: Turn repository read-path cutover
+description: Repository and query consistency pass after turn-table schema and atomic turn-write bundle; no turn_posts or UI
+tags: [plan, database, turns, repositories, query]
+overview: "Align runtime repository surfaces and read-path tests with turns/turn_* tables; preserve canonical agent_id TurnData and API contracts; defer turn_posts and mixed-ID resolution."
+todos:
+  - id: freeze-scope
+    content: Confirm slice is repo/query consistency (not broad SQL rename); audit adapters at head; freeze minimal-churn naming for TurnMetadata/turns.
+    status: completed
+  - id: r1-repo-surface
+    content: "Packet R1 — Align repository interfaces, wrappers, and related model docs with turn_* steady state (forbidden files unchanged per packet)."
+    status: completed
+  - id: r2-query-read-path
+    content: "Packet R2 — Stabilize query_service, run_query_service, and tests; no turn_posts or mixed-ID resolvers."
+    status: completed
+  - id: integrate-reconcile
+    content: Reconcile simulation/core/models/turns.py if R1 and R2 both touched it; run combined targeted pytest.
+    status: completed
+  - id: final-verification
+    content: Grep for legacy table names in runtime paths; run full targeted pytest suite + optional run_adapter tests.
+    status: completed
+isProject: false
+---
+
+# Turn repository read-path cutover
+
+## Remember
+
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Maximum safely delegable parallelism
+- Delegated tasks must be impossible to misread
+- UI changes: not in scope (no before/after screenshots)
+
+## Overview
+
+This slice assumes the new turn-table schema and the atomic turn-write bundle are already present at head. Most SQLite adapters already read and write `turns`, `turn_generated_feeds`, `turn_likes`, `turn_comments`, and `turn_follows`, so this must **not** be planned as a broad SQL rename pass. Treat it as a repository/query consistency cutover: remove remaining legacy semantics from runtime repository surfaces, preserve canonical-`agent_id` query/API contracts, harden targeted tests around the new table family, and explicitly **defer** `turn_posts` mixed-ID resolution to a following slice.
+
+## Happy Flow
+
+1. `simulation/core/services/query_service.py` loads turn feeds from `db/repositories/generated_feed_repository.py` and turn actions from `db/repositories/like_repository.py`, `db/repositories/comment_repository.py`, and `db/repositories/follow_repository.py`. Those repositories delegate to adapters that hit `turn_generated_feeds`, `turn_likes`, `turn_comments`, and `turn_follows`.
+2. `RunRepository` provides `TurnMetadata` through `db/adapters/sqlite/run_adapter.py`, backed by the `turns` table. Prefer keeping `get_turn_metadata()` / `list_turn_metadata()` / `write_turn_metadata()` names stable unless a concrete bug forces a rename.
+3. `SimulationQueryService.get_turn_data()` in `simulation/core/services/query_service.py` returns `TurnData` keyed by canonical `agent_id`, with hydrated posts and action payloads logically unchanged for callers.
+4. API serialization in `simulation/api/services/run_query_service.py` exposes the same ID-keyed turn payloads; table-source changes are internal only.
+5. Tests under `tests/db/repositories/`, `tests/simulation/core/`, and `tests/api/` prove live runtime code depends on the new turn tables for this slice and behavior did not regress.
+
+```mermaid
+flowchart LR
+  queryService[SimulationQueryService]
+  runRepo[RunRepository]
+  feedRepo[GeneratedFeedRepository]
+  likeRepo[LikeRepository]
+  commentRepo[CommentRepository]
+  followRepo[FollowRepository]
+  turnsTable[turns]
+  turnFeedTable[turn_generated_feeds]
+  turnLikeTable[turn_likes]
+  turnCommentTable[turn_comments]
+  turnFollowTable[turn_follows]
+  apiLayer[run_query_service]
+
+  queryService --> runRepo
+  queryService --> feedRepo
+  queryService --> likeRepo
+  queryService --> commentRepo
+  queryService --> followRepo
+  runRepo --> turnsTable
+  feedRepo --> turnFeedTable
+  likeRepo --> turnLikeTable
+  commentRepo --> turnCommentTable
+  followRepo --> turnFollowTable
+  queryService --> apiLayer
+```
+
+## Interface or contract freeze
+
+- `TurnData.feeds`, `TurnData.feed_records`, and `TurnData.actions` remain keyed by canonical `agent_id`, not handles.
+- `simulation/api/services/run_query_service.py` continues to serialize the same logical turn payloads; table-source changes are internal only.
+- This slice does **not** add `turn_posts`, mixed `run_post_id` / `turn_post_id` resolution, or authored-post generation behavior.
+- Prefer the smallest safe public interface change. Repository/service method names such as `get_turn_metadata()` and `write_turn_metadata()` may stay even though they read/write `turns`; avoid churn unless a misleading name causes real correctness or maintenance problems.
+- Live runtime code in `db/` repositories/adapters and `simulation/core/services/query_service.py` must not depend on legacy table names (`turn_metadata`, `generated_feeds`, `likes`, `comments`, `follows`) after this slice, except migration/history-only code explicitly out of runtime scope.
+
+## Serial coordination spine
+
+1. Audit real head state before editing: confirm `db/adapters/sqlite/generated_feed_adapter.py`, `db/adapters/sqlite/like_adapter.py`, `db/adapters/sqlite/comment_adapter.py`, `db/adapters/sqlite/follow_adapter.py`, and `db/adapters/sqlite/run_adapter.py` already use the new tables. Avoid redundant rename work.
+2. Freeze the minimal-churn decision for repository/service surface names around `TurnMetadata` and `turns`.
+3. Land runtime consistency updates in repositories/models/query service only where legacy semantics still leak.
+4. Land targeted tests proving unchanged behavior.
+5. Run final grep and focused pytest pass.
+
+## Parallel task packets
+
+### Packet R1 — `R1-repo-surface-cleanup`
+
+**Objective:** Align repository interfaces, wrappers, and closely related model/docstring semantics with the new `turns` / `turn_*` steady state without unnecessary public API churn.
+
+**Why parallelizable:** Stays inside repository wrappers, interfaces, and related turn/action model documentation; does not change query orchestration logic.
+
+**Exact files to inspect:**
+
+- `db/repositories/interfaces.py`
+- `db/repositories/generated_feed_repository.py`
+- `db/repositories/like_repository.py`
+- `db/repositories/comment_repository.py`
+- `db/repositories/follow_repository.py`
+- `simulation/core/models/turns.py`
+- `simulation/core/models/persisted_actions.py`
+
+**Exact files allowed to change:**
+
+- The files listed immediately above
+- Repository-focused tests only if required to reflect clarified contracts:
+  - `tests/db/repositories/test_generated_feed_repository.py`
+  - `tests/db/repositories/test_generated_feed_repository_integration.py`
+  - `tests/db/repositories/test_action_repositories_integration.py`
+  - `tests/db/repositories/test_run_repository.py`
+  - `tests/db/repositories/test_run_repository_integration.py`
+
+**Exact files forbidden to change:**
+
+- `feeds/feed_generator.py`
+- `simulation/core/models/actions.py`
+- `simulation/core/services/query_service.py`
+- `ui/`
+- Any migration file under `db/migrations/versions/`
+
+**Preconditions:** Serial step 1 completed; team agrees this slice is not a schema rewrite.
+
+**Dependency tasks:** Depends only on `freeze-scope`.
+
+**Required contracts and invariants:**
+
+- Keep canonical ID semantics exactly as-is.
+- Do not rename public methods unless the legacy name is actively misleading enough to justify downstream churn.
+- Clarify in docstrings/comments that persisted action rows are turn-scoped runtime history, not seed-state facts.
+
+**Step-by-step implementation instructions:**
+
+1. Review repository interface docstrings and method comments for wording that implies legacy table names or ambiguous persistence scope.
+2. Update docstrings/types/comments in repository wrappers and related models so they describe `turns` / `turn_*` reality accurately.
+3. If a method name looks legacy but callers are widespread, prefer documenting the `turns` backing table rather than renaming in this slice.
+4. Tighten repository tests only where they must assert the clarified contract.
+
+**Exact verification commands:**
+
+```bash
+uv run pytest tests/db/repositories/test_generated_feed_repository.py tests/db/repositories/test_generated_feed_repository_integration.py tests/db/repositories/test_action_repositories_integration.py tests/db/repositories/test_run_repository.py tests/db/repositories/test_run_repository_integration.py -q
+```
+
+**Expected outputs from verification:** All targeted repository tests pass; no test needs legacy table names to explain current runtime behavior.
+
+**Done-when checklist:**
+
+- Repository interfaces and wrappers describe the new turn-table steady state.
+- `TurnMetadata` comments/docs clearly map to the `turns` table.
+- No unnecessary public API rename churn was introduced.
+
+**Coordinator review checklist:**
+
+- Any retained legacy method name has an explicit justification.
+- No repository docstring promises behavior that belongs to the future `turn_posts` slice.
+
+### Packet R2 — `R2-query-read-path-stabilization`
+
+**Objective:** Verify and, only where necessary, tighten query/read-path code so turn data stays logically unchanged while sourcing rows from the new turn tables.
+
+**Why parallelizable:** Confined to read-path orchestration and API/query tests; does not edit repository wrappers if contract freeze is understood.
+
+**Exact files to inspect:**
+
+- `simulation/core/services/query_service.py`
+- `simulation/api/services/run_query_service.py`
+- `db/adapters/sqlite/run_adapter.py`
+- `tests/simulation/core/test_query_service.py`
+- `tests/api/test_run_query_service.py`
+- `tests/api/test_simulation_run.py`
+
+**Exact files allowed to change:**
+
+- The files listed immediately above
+- `simulation/core/models/turns.py` only if the read-path contract needs a clarifying type/doc update
+
+**Exact files forbidden to change:**
+
+- `feeds/feed_generator.py`
+- Any `turn_posts` repository/adapter/model file added in a later slice
+- `ui/`
+- Any migration file under `db/migrations/versions/`
+
+**Preconditions:** Serial step 2 completed; minimal-churn decision on repository method names is frozen.
+
+**Dependency tasks:** Depends on `freeze-scope`; can run in parallel with R1 as long as no shared file ownership is introduced (coordinate `simulation/core/models/turns.py`).
+
+**Required contracts and invariants:**
+
+- `TurnData` remains keyed by canonical `agent_id`.
+- API turn payloads remain structurally unchanged.
+- This slice does not begin mixed `run_post_id` / `turn_post_id` resolution work.
+- Any remaining legacy name references in runtime code must be comments/docstrings only if unavoidable; live SQL/runtime semantics must point at the new turn tables.
+
+**Step-by-step implementation instructions:**
+
+1. Review `simulation/core/services/query_service.py` for stale comments, naming, or assumptions that contradict the new turn-table steady state.
+2. Confirm `get_turn_data()` reads feeds/actions through repositories backed by `turn_*` tables and that `TurnData` assembly stays canonical-ID keyed.
+3. Update query/API tests to make the table-source cutover explicit through behavior, not brittle implementation mocking.
+4. Avoid adding `turn_posts` branches, mixed-ID helpers, or broader resolver work; note those as follow-on work.
+
+**Exact verification commands:**
+
+```bash
+uv run pytest tests/simulation/core/test_query_service.py tests/api/test_run_query_service.py tests/api/test_simulation_run.py -q
+```
+
+**Expected outputs from verification:** All targeted query/API tests pass; canonical `agent_id` keys remain intact across `TurnData` and serialized API responses.
+
+**Done-when checklist:**
+
+- Query/read-path code has no stale legacy semantics that misdescribe the live turn-table source.
+- API tests still prove unchanged logical output.
+- No `turn_posts` or mixed-ID resolver work leaked into this slice.
+
+**Coordinator review checklist:**
+
+- The diff is stabilization, not a hidden feature addition.
+- Query behavior remains the same from callers’ perspective.
+
+## Integration order
+
+1. Complete serial audit and freeze minimal-churn rule.
+2. Run R1 and R2 in parallel (avoid simultaneous edits to `simulation/core/models/turns.py` without coordination).
+3. Reconcile `simulation/core/models/turns.py` if both packets touched it; otherwise keep file ownership disjoint.
+4. Run combined verification suite.
+5. Final grep for live runtime legacy table-name references.
+
+## Alternative approaches
+
+- **Broad public rename of repository/service methods now:** Rejected — churn without behavior change; head already stores turn metadata in `turns` correctly.
+- **Treat as no-op because adapters already use `turn_*`:** Rejected — repository semantics, read-path expectations, and tests need an explicit stabilization pass for reviewability and regression resistance.
+- **Pull `turn_posts` mixed-ID support into this slice:** Rejected — combines two behaviorally meaningful changes; proposal keeps them separate.
+
+## Manual verification
+
+See `verification.md` in this folder for a copy-paste checklist. Summary:
+
+- Repository tests (command in R1) — expected: all pass.
+- Query/API tests (command in R2) — expected: all pass.
+- Grep for legacy runtime references:
+
+```bash
+rg "\b(turn_metadata|generated_feeds|likes|comments|follows)\b" db/repositories db/adapters/sqlite simulation/core/services tests/db/repositories tests/simulation/core tests/api
+```
+
+Expected: remaining hits are intentional method/model names, migration-history tests, or comments documenting old-to-new mapping; no live SQL on legacy tables.
+
+- Optional:
+
+```bash
+uv run pytest tests/db/adapters/sqlite/test_run_adapter.py -q
+```
+
+Expected: pass.
+
+## Final verification
+
+- Runtime repository wrappers and query code align with `turns` plus `turn_*` tables.
+- `TurnData` and API turn payloads remain keyed by canonical `agent_id`.
+- No accidental `turn_posts` or mixed-ID resolver work was added.
+- Targeted repository, query, and API tests pass.
+- Remaining legacy-name references in touched runtime areas are intentionally retained public names or clearly non-runtime historical references.
+
+## Plan asset storage
+
+All notes and verification artifacts for this slice: `docs/plans/2026-03-23_turn_repository_read_path_cutover_431286/`.
+
+## Areas for improvement or clarification
+
+- Proposal text saying “replace all live SQL references” can overstate remaining work; adapters at head already target `turn_*` — stay grounded in actual head state.
+- `db/adapters/sqlite/turn_parent.py` may have a stale module docstring (pre-atomic feeds); cleanup only if it blocks tests or creates confusion in touched files.
+- `simulation/core/services/query_service.py` still hydrates post IDs through `run_posts` only — intentional deferment for the next slice, not scope creep here.

--- a/docs/plans/2026-03-23_turn_repository_read_path_cutover_431286/verification.md
+++ b/docs/plans/2026-03-23_turn_repository_read_path_cutover_431286/verification.md
@@ -1,0 +1,11 @@
+---
+description: Verification checklist for turn repository read-path cutover slice
+tags: [verification, plan, database, turns, repositories]
+---
+
+# Turn repository read-path cutover — verification
+
+- [ ] `uv run pytest tests/db/repositories/test_generated_feed_repository.py tests/db/repositories/test_generated_feed_repository_integration.py tests/db/repositories/test_action_repositories_integration.py tests/db/repositories/test_run_repository.py tests/db/repositories/test_run_repository_integration.py -q` — all pass.
+- [ ] `uv run pytest tests/simulation/core/test_query_service.py tests/api/test_run_query_service.py tests/api/test_simulation_run.py -q` — all pass.
+- [ ] `rg "\b(turn_metadata|generated_feeds|likes|comments|follows)\b" db/repositories db/adapters/sqlite simulation/core/services tests/db/repositories tests/simulation/core tests/api` — remaining hits are intentional names, migration tests, or mapping comments; no live SQL on legacy tables.
+- [ ] Optional: `uv run pytest tests/db/adapters/sqlite/test_run_adapter.py -q` — pass.

--- a/simulation/api/services/run_query_service.py
+++ b/simulation/api/services/run_query_service.py
@@ -47,7 +47,12 @@ def list_runs(*, engine: SimulationEngine) -> list[RunListItem]:
 def get_turns_for_run(
     *, run_id: str, engine: SimulationEngine
 ) -> dict[str, TurnSchema]:
-    """Build TurnSchema payloads from persisted turn metadata via ``get_turn_data``."""
+    """Build TurnSchema payloads from persisted turn metadata via ``get_turn_data``.
+
+    Turn list order comes from ``turns``-backed metadata; per-turn feeds and
+    actions match ``SimulationQueryService.get_turn_data`` (same repository
+    contracts as the core query service).
+    """
     validated_run_id = validate_run_id(run_id)
     run = engine.get_run(validated_run_id)
     if run is None:

--- a/simulation/core/models/persisted_actions.py
+++ b/simulation/core/models/persisted_actions.py
@@ -1,6 +1,7 @@
 """Persisted action row models for run-scoped likes, comments, follows.
 
-These are pure data shapes used when reading/writing action tables.
+These are pure data shapes for rows in ``turn_likes``, ``turn_comments``, and
+``turn_follows`` (runtime simulation history, not immutable seed snapshots).
 No imports from db, feeds, or ai.
 """
 
@@ -10,7 +11,7 @@ from lib.validation_utils import validate_nonnegative_value
 
 
 class PersistedLike(BaseModel):
-    """Row shape for a persisted like action."""
+    """Row shape for a persisted like action (``turn_likes``)."""
 
     like_id: str
     run_id: str
@@ -30,7 +31,7 @@ class PersistedLike(BaseModel):
 
 
 class PersistedComment(BaseModel):
-    """Row shape for a persisted comment action."""
+    """Row shape for a persisted comment action (``turn_comments``)."""
 
     comment_id: str
     run_id: str
@@ -51,7 +52,7 @@ class PersistedComment(BaseModel):
 
 
 class PersistedFollow(BaseModel):
-    """Row shape for a persisted follow action."""
+    """Row shape for a persisted follow action (``turn_follows``)."""
 
     follow_id: str
     run_id: str

--- a/simulation/core/models/turns.py
+++ b/simulation/core/models/turns.py
@@ -38,9 +38,10 @@ class TurnResult(BaseModel):
 
 
 class TurnMetadata(BaseModel):
-    """Metadata for a simulation turn.
+    """Metadata for a simulation turn as stored in the ``turns`` table.
 
-    Contains basic information about a turn without the full data.
+    One row per (run_id, turn_number). Contains basic information about a turn
+    without feeds, actions, or metrics payloads.
     """
 
     run_id: str
@@ -68,7 +69,9 @@ class TurnData(BaseModel):
 
     ``feeds`` and ``actions`` map canonical ``agent_id`` strings to per-agent data.
     ``feed_records`` holds the persisted ``GeneratedFeed`` row for each agent that
-    had a feed on this turn (aligned with ``feeds`` keys). Display handles live on
+    had a feed on this turn (aligned with ``feeds`` keys); those rows come from
+    ``turn_generated_feeds`` at persistence time. Action lists are built from
+    persisted turn-scoped like/comment/follow rows. Display handles live on
     nested models, not in dict keys.
     """
 

--- a/simulation/core/services/query_service.py
+++ b/simulation/core/services/query_service.py
@@ -36,7 +36,13 @@ from simulation.core.utils.validators import validate_run_id, validate_turn_numb
 
 
 class SimulationQueryService:
-    """Query service for retrieving simulation run and turn data."""
+    """Query service for retrieving simulation run and turn data.
+
+    Turn-scoped feeds and actions are loaded via repositories backed by
+    ``turn_generated_feeds`` and ``turn_likes`` / ``turn_comments`` /
+    ``turn_follows``. Post bodies for feed cards are resolved from ``run_posts``
+    snapshots; ``turn_posts`` is not used on this read path yet.
+    """
 
     def __init__(
         self,
@@ -113,9 +119,12 @@ class SimulationQueryService:
 
     @validate_inputs((validate_run_id, "run_id"), (validate_turn_number, "turn_number"))
     def get_turn_data(self, run_id: str, turn_number: int) -> TurnData | None:
-        """Returns full turn data with feeds and posts.
+        """Return full turn data: feeds, hydrated posts, and actions.
 
-        ``feeds`` and ``actions`` maps are keyed by canonical ``agent_id`` only.
+        ``feeds``, ``feed_records``, and ``actions`` are keyed by canonical
+        ``agent_id`` only. Feeds and actions are read from the generated-feed
+        and action repositories (turn-scoped tables). Post text and metadata
+        come from ``run_post_repo`` for IDs referenced in feeds.
         """
         run = self.run_repo.get_run(run_id)
         if run is None:

--- a/tests/simulation/core/test_query_service.py
+++ b/tests/simulation/core/test_query_service.py
@@ -1,4 +1,9 @@
-"""Tests for simulation.core.services.query_service module."""
+"""Tests for simulation.core.services.query_service module.
+
+Mocks stand in for repositories that, at runtime, read ``turn_generated_feeds``
+and ``turn_likes`` / ``turn_comments`` / ``turn_follows``; post hydration still
+uses ``run_posts`` snapshots via ``run_post_repo``.
+"""
 
 from unittest.mock import Mock
 


### PR DESCRIPTION
## Overview

This slice assumes the new turn-table schema and the atomic turn-write bundle are already present at head. Most SQLite adapters already read and write `turns`, `turn_generated_feeds`, `turn_likes`, `turn_comments`, and `turn_follows`, so this is **not** a broad SQL rename pass. This PR is a repository/query documentation cutover: align runtime repository surfaces and read-path docs with the new table family, preserve canonical-`agent_id` query/API contracts in code comments, and explicitly defer `turn_posts` mixed-ID resolution.

## Problem / motivation

Repository interfaces and query-layer docstrings still read like the old pre–turn-table era in places, or did not name the actual SQLite tables (`turns`, `turn_*`). That makes reviews and onboarding harder without changing runtime behavior.

## Solution

Clarify docstrings and module comments on repositories, core models, `SimulationQueryService`, API run query helpers, and SQLite run/turn_parent adapters so they describe the steady-state `turns` / `turn_*` mapping, `run_posts` hydration for feed cards, and the intentional deferral of `turn_posts`. No API or SQL behavior changes.

## Happy Flow

1. `simulation/core/services/query_service.py` loads turn feeds from `db/repositories/generated_feed_repository.py` and turn actions from like/comment/follow repositories; those hit `turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`.
2. `RunRepository` provides `TurnMetadata` through `db/adapters/sqlite/run_adapter.py`, backed by the `turns` table; method names `get_turn_metadata` / `list_turn_metadata` / `write_turn_metadata` stay stable.
3. `SimulationQueryService.get_turn_data()` returns `TurnData` keyed by canonical `agent_id`; post bodies still come from `run_posts`.
4. `simulation/api/services/run_query_service.py` exposes the same ID-keyed turn payloads.
5. Tests continue to prove behavior; `tests/simulation/core/test_query_service.py` module doc notes the mock vs runtime table mapping.

## Data Flow

N/A (documentation-only alignment with existing read path).

## Changes

- `db/repositories/interfaces.py`: `RunRepository`, `GeneratedFeedRepository`, action repository class docs; `RunPostRepository` doc references `turn_generated_feeds.post_ids`.
- `db/repositories/generated_feed_repository.py`, `like_repository.py`, `comment_repository.py`, `follow_repository.py`, `run_repository.py`: class/method docstrings.
- `simulation/core/models/turns.py`, `simulation/core/models/persisted_actions.py`: model and module docs.
- `simulation/core/services/query_service.py`, `simulation/api/services/run_query_service.py`: service docs.
- `db/adapters/sqlite/run_adapter.py`, `db/adapters/sqlite/turn_parent.py`: adapter/module docs.
- `tests/simulation/core/test_query_service.py`: module docstring.
- `docs/plans/2026-03-23_turn_repository_read_path_cutover_431286/`: plan + verification assets.

## Manual Verification

- `uv run pytest tests/db/repositories/test_generated_feed_repository.py tests/db/repositories/test_generated_feed_repository_integration.py tests/db/repositories/test_action_repositories_integration.py tests/db/repositories/test_run_repository.py tests/db/repositories/test_run_repository_integration.py -q` — all pass
- `uv run pytest tests/simulation/core/test_query_service.py tests/api/test_run_query_service.py tests/api/test_simulation_run.py -q` — all pass
- `uv run pytest tests/db/adapters/sqlite/test_run_adapter.py -q` — all pass
- Combined run (executed): 195 passed

## State (Before) / State (After)

N/A — no UI changes.

Plan: `docs/plans/2026-03-23_turn_repository_read_path_cutover_431286/plan.md`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal documentation across database and service modules regarding data persistence behavior and storage semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->