### PR TITLE
Enforce turn-table steady state in schema lint and docs

### DIFF
--- a/docs/architecture/agents-turns-runs-data-model.md
+++ b/docs/architecture/agents-turns-runs-data-model.md
@@ -1,13 +1,15 @@
 ---
-description: Taxonomy of Agent*, Run*, and Turn* simulation persistence scopes, lifecycle rules, and the target turn-table parent model.
+description: Taxonomy of Agent*, Run*, and Turn* simulation persistence scopes, lifecycle rules, and the steady-state turn-table parent model (`turns` + `turn_*`).
 tags: [architecture, data-model, simulation, turns, runs]
 ---
 
 # Agents, Turns, and Runs
 
-We have mental models around the concepts of `Agent*`, `Turn*`, and `Run*`. This doc helps differentiate these concepts.
+We have mental models around the concepts of `Agent*`, `Run*`, and `Turn*`. This doc helps differentiate these concepts.
 
-**Turn-table v2:** The normative cutover story (parent `turns`, `turn_*` table names, atomic writes, post-ID namespace) is frozen in [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](../../strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md). **`TurnAction.POST` / authored-post generation is deferred** to a later slice; see that proposal’s **Frozen contract (v2 milestone)** section.
+**Steady-state turn history:** At HEAD, the canonical parent for per-turn rows is **`turns(run_id, turn_number)`**. Per-turn append-only tables use the **`turn_*`** prefix (`turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, `turn_metrics`, `turn_posts`). Design history and migration narrative live in [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](../../strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md).
+
+**Authored posts:** `TurnAction.POST` persists to **`turn_posts`** during turn execution. Those posts become **feed candidates only in later turns** (turn number strictly less than the feed’s turn); see [turn-feed-post-id-contract.md](turn-feed-post-id-contract.md).
 
 ## What are these concepts?
 
@@ -29,17 +31,17 @@ The tables here include:
 
 `Turn*` refers to the per-turn history of what happened during a simulation run.
 
-This is a **conceptual scope**, not only a naming convention. **At HEAD**, several tables still use legacy names (`turn_metadata`, `generated_feeds`, `likes`, `comments`, `follows`) while others already use the `turn_*` prefix (`turn_metrics`). The **target steady state** is that every per-turn table is named under the `turn_*` family and is a **child of** `turns(run_id, turn_number)` (replacing `turn_metadata` as the canonical parent). That hard cutover is specified in [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](../../strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md); runtime and `db/schema.py` have not fully moved yet—treat **current schema names vs target names** as a migration in progress.
+This is a **conceptual scope**, not only a naming convention. **Normative table names** are under the `turn_*` family and are **children of** `turns(run_id, turn_number)` via composite foreign keys where applicable.
 
 The key question answered by `Turn*` data is:
 
 - "What happened during turn N of this run?"
 This scope includes a few kinds of per-turn data:
-- per-turn summaries, such as aggregate counts or metadata for a turn
-- per-turn metrics
-- per-turn generated outputs, such as feeds shown to agents during that turn
-- per-turn action logs, such as likes, comments, and follows produced during that turn
-- eventually, posts authored during a turn (`turn_posts`), once implemented
+- per-turn summaries and the parent row in `turns`
+- per-turn metrics (`turn_metrics`)
+- per-turn generated outputs (`turn_generated_feeds`)
+- per-turn action logs (`turn_likes`, `turn_comments`, `turn_follows`)
+- posts authored during a turn (`turn_posts`)
 
 The important invariant is lifecycle:
 
@@ -47,7 +49,7 @@ The important invariant is lifecycle:
 - if the row should exist before a run starts, it does **not** belong to `Turn*`
 - if the row describes what was true at the start of a run, it belongs to `Run*Snapshot`, not `Turn*`
 
-**Target naming (v2):** `turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, with `turn_metrics` parented on `turns` via `(run_id, turn_number)`, and `turn_posts` for authored posts. **`TurnAction.POST` generation is deferred**; see the strategy proposal’s frozen contract section.
+**Steady-state naming:** `turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, `turn_metrics`, `turn_posts`, all governed with non-null `run_id` and `turn_number` where the contract requires it.
 
 ### What is `Run*`?
 
@@ -102,7 +104,7 @@ Today, the clearest example of this category is run-level metrics computed acros
 
 ### When updating the information about an agent
 
-We can have, say, Agent A. We might want to update some information about that agent (e.g., who that agent follows, what posts they've written) before the next simulation run. In the current setup:
+We can have, say, Agent A. We might want to update some information about that agent (e.g. who that agent follows, what posts they've written) before the next simulation run. In the current setup:
 
 - `Agent*` affects only future runs.
 - `Run*Snapshot` preserves the truth for past runs.
@@ -131,7 +133,7 @@ Structural expectations:
 
 - `agent_*` tables should not carry run_id/turn_number
 - `run_*` tables should include run_id
-- `turn_*` / legacy turn-event tables should include both `run_id` and non-null `turn_number`, and (in the target model) reference `turns(run_id, turn_number)`.
+- `turns` and `turn_*` tables should include both `run_id` and non-null `turn_number` where required by the schema, and reference `turns(run_id, turn_number)` as the parent for child turn history rows.
 
 Feed-visible post IDs in turn feeds and actions share one namespace; resolution distinguishes `run_post_id` vs `turn_post_id` in application logic—see [turn-feed-post-id-contract.md](turn-feed-post-id-contract.md).
 

--- a/docs/architecture/seed-state-run-snapshot-turn-events.md
+++ b/docs/architecture/seed-state-run-snapshot-turn-events.md
@@ -1,5 +1,5 @@
 ---
-description: Persistence scopes for seed state, run snapshots, and turn events—naming, lifecycle, and target turn-table parent model versus current schema.
+description: Persistence scopes for seed state, run snapshots, and turn events—naming, lifecycle, and the steady-state `turns` parent with `turn_*` history tables.
 tags: [architecture, data-model, simulation, turns, runs]
 ---
 
@@ -7,7 +7,9 @@ tags: [architecture, data-model, simulation, turns, runs]
 
 This document defines the **persistence scopes** used by the simulation platform. It exists to prevent a recurring failure mode: mixing editable “current state” data with immutable run history in one table family.
 
-**Turn-table v2:** Target table names and the `turns` parent story are frozen in [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](../../strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md). Post-ID rules (`run_post_id` vs `turn_post_id`) are summarized in [turn-feed-post-id-contract.md](turn-feed-post-id-contract.md). **`TurnAction.POST` / authored-post generation is deferred** to a later slice.
+**Steady state (current schema):** Per-turn history is stored under **`turns`** as the canonical parent row and **`turn_*`** tables for append-only outputs (`turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, `turn_metrics`, `turn_posts`). Post-ID rules (`run_post_id` vs `turn_post_id`) are summarized in [turn-feed-post-id-contract.md](turn-feed-post-id-contract.md). **`TurnAction.POST`** persists **`turn_posts`** in the same turn write as other artifacts; feed visibility for those posts starts in **the next turn** (strictly later `turn_number`).
+
+Design history and the v2 migration narrative remain in [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](../../strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md) for before/after context only.
 
 ## Canonical scopes
 
@@ -34,26 +36,19 @@ A run snapshot is the frozen copy of the relevant seed state captured **at run c
 
 Turn events are immutable per-turn outputs produced during a run. They represent “what happened during this run” and should never be edited to represent baseline state.
 
-- **Naming (target steady state):** per-turn tables use the `turn_*` prefix (`turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, `turn_metrics`, `turn_posts`). The canonical parent row is **`turns(run_id, turn_number)`** (replacing today’s `turn_metadata` convention).
-- **Lifecycle**: append-only; writes are run-scoped; rows include non-null `run_id` and non-null `turn_number`; target model parents all of these on `turns` via composite FK.
-- **Legacy-named turn-event tables (current `db/schema.py`, pre-cutover)**:
-  - `generated_feeds` → target `turn_generated_feeds`
-  - `likes` → target `turn_likes`
-  - `comments` → target `turn_comments`
-  - `follows` → target `turn_follows`
-  - `turn_metadata` → target `turns` (parent)
-  - `turn_metrics` → remains `turn_metrics`, but gains direct parentage on `turns` in the target model
+- **Naming (steady state):** per-turn tables use the `turn_*` prefix. The canonical parent is **`turns(run_id, turn_number)`**; child tables include `turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, `turn_metrics`, and `turn_posts`.
+- **Lifecycle**: append-only; writes are run-scoped; rows include non-null `run_id` and non-null `turn_number` where required; child tables reference `turns` via composite foreign keys.
+
+**Historical naming (migrations / old docs only):** Before the cutover, some concepts used different table names (`turn_metadata`, `generated_feeds`, bare `likes`, `comments`, `follows`). Those names are **not** acceptable for new schema at HEAD; they may appear in migration files or archived planning as historical record.
 
 ## How the current schema maps to scopes
-
-This document describes intended semantics. The **target** rename/parent story is the v2 hard cutover in [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](../../strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md). The current table set in `db/schema.py` still uses legacy names in several places; scopes are unchanged—only naming and FK parentage move toward `turns` + `turn_*`.
 
 - **Run identity and run-level summaries**:
   - `runs` (run identity/config/status)
   - `run_metrics` (run-level derived outputs)
-- **Turn events (current names; see target list above)**:
-  - `turn_metadata`, `turn_metrics`
-  - `generated_feeds`, `likes`, `comments`, `follows`
+- **Turn history (steady-state names in `db/schema.py`)**:
+  - `turns` (parent row per `(run_id, turn_number)`)
+  - `turn_metrics`, `turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, `turn_posts`
 - **Seed state**:
   - `agent`, `agent_persona_bios`, `user_agent_profile_metadata`
 - **Out-of-scope / supporting tables** (not governed by the `agent_*`/`run_*`/`turn_*` convention):
@@ -63,8 +58,8 @@ This document describes intended semantics. The **target** rename/parent story i
 ## Core contract rules
 
 1. **Do not mix lifecycles inside one table.** If it should exist with no run, it is seed state. If it has `turn_number`, it is a turn event. If it must remain stable for history after edits, it must be snapshotted into `run_*` at run creation time.
-2. **Historical reads must not consult live seed state for behaviorally relevant values.** History pages and run replays should be backed by `run_*` and turn-event tables.
-3. **Do not overload event tables to store seed state.** The existing `likes/comments/follows` are turn events; they are not a place to store initialized “baseline” relationships.
+2. **Historical reads must not consult live seed state for behaviorally relevant values.** History pages and run replays should be backed by `run_*` and `turn_*` tables.
+3. **Do not overload event tables to store seed state.** `turn_likes`, `turn_comments`, and `turn_follows` are turn events; they are not a place to store initialized “baseline” relationships.
 
 ## Explicit bans (reviewer-fast-fail)
 

--- a/docs/architecture/turn-feed-post-id-contract.md
+++ b/docs/architecture/turn-feed-post-id-contract.md
@@ -20,9 +20,9 @@ There is **no** polymorphic foreign key from those columns to mixed tables. Inst
 ## Resolution: `run_post_id` vs `turn_post_id`
 
 - **`run_post_id`:** Identifies a post that comes from the **run-start snapshot** (`run_posts` and the frozen baseline copied at run creation). These IDs point at immutable run-scoped post rows.
-- **`turn_post_id`:** Identifies a post **authored during a turn** and stored in **`turn_posts`** once that table exists. Same conceptual ID shape as other feed-visible IDs, but resolved against `turn_posts` rather than `run_posts`.
+- **`turn_post_id`:** Identifies a post **authored during a turn** and stored in **`turn_posts`**. Same conceptual ID shape as other feed-visible IDs, but resolved against `turn_posts` rather than `run_posts`.
 
-Readers (feed hydration, action display, replay) implement **one resolver** that accepts feed-visible IDs and loads from `run_posts`, `turn_posts`, or both as needed. Mixed `run_posts` + `turn_posts` hydration is required for the system to interpret feeds and actions once `turn_posts` exists; see the strategy proposal’s milestones on mixed post resolution.
+Readers (feed hydration, action display, replay) implement **one resolver** that accepts feed-visible IDs and loads from `run_posts`, `turn_posts`, or both as needed. Mixed `run_posts` + `turn_posts` hydration is required for the system to interpret feeds and actions; see the strategy proposal’s milestones on mixed post resolution.
 
 ### Resolution algorithm (application layer)
 
@@ -44,4 +44,4 @@ Readers (feed hydration, action display, replay) implement **one resolver** that
 ## Related docs
 
 - [agents-turns-runs-data-model.md](agents-turns-runs-data-model.md) — `Agent*`, `Run*`, and `Turn*` taxonomy
-- [seed-state-run-snapshot-turn-events.md](seed-state-run-snapshot-turn-events.md) — scope boundaries and legacy vs target table names
+- [seed-state-run-snapshot-turn-events.md](seed-state-run-snapshot-turn-events.md) — scope boundaries and steady-state `turn_*` tables

--- a/docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/plan.md
+++ b/docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/plan.md
@@ -1,0 +1,338 @@
+---
+name: Turn-table steady-state closeout
+description: "Close out the turn-table refactor by enforcing turns/turn_* in lint, updating architecture docs, and adding verification artifacts."
+tags: [plan, persistence, turns, lint, documentation]
+overview: Close out the turn-table refactor by making the new `turns` / `turn_*` steady state mechanically enforced in lint/tests, updating architecture docs to describe the current reality, and adding a final verification sweep that preserves the authored-post rule that posts become feed-visible only on subsequent turns.
+todos:
+  - id: freeze-closeout-contract
+    content: "Freeze closeout scope: enforcement and documentation only; no new runtime behavior, and authored posts remain subsequent-turn visible only."
+    status: completed
+  - id: tighten-schema-linter
+    content: Update schema-lint rules/tests so the repo no longer treats legacy turn-event table names as an acceptable steady state.
+    status: completed
+  - id: reconcile-architecture-docs
+    content: Update architecture docs to describe turns/turn_* and authored-post behavior as present reality rather than deferred future state.
+    status: completed
+  - id: final-verification-sweep
+    content: Add or tighten final verification helpers and run grep/lint/doc checks to prove only archival references to legacy names remain.
+    status: completed
+isProject: false
+---
+
+# Turn-table steady-state closeout
+
+_Source: copied from `.cursor/plans/turn-table_steady-state_closeout_4c10302b.plan.md`._
+
+## Remember
+
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Maximum safely delegable parallelism
+- Delegated tasks must be impossible to misread
+- UI changes: not in scope for this slice; do not touch `ui/**`
+
+## Overview
+
+This slice is a cleanup-and-enforcement pass after the schema cutover, transactional turn writes, mixed post hydration, and authored-post generation work are in place. The goal is to make the repository reject the old legacy turn-event naming as an acceptable steady state, while updating the architecture docs so they describe the current model accurately: `turns` is the canonical parent, the `turn_*` table family is live, `turn_posts` is part of the turn history model, and authored posts become feed-visible only starting in the next turn.
+
+## Happy Flow
+
+1. The schema linter in [scripts/lint_schema_conventions.py](scripts/lint_schema_conventions.py) loads [db/schema.py](db/schema.py) and validates the live table family against the steady-state rules: `agent_*` tables remain seed-state only, `run_*` tables remain run-scoped, and `turns` plus every `turn_*` table require non-null `run_id` and `turn_number` where appropriate.
+2. The linter tests in [tests/lint/test_lint_schema_conventions.py](tests/lint/test_lint_schema_conventions.py) ratchet the repo forward by failing if a legacy turn-event baseline is reintroduced or if the current schema drifts away from the steady-state contract.
+3. The architecture docs in [docs/architecture/agents-turns-runs-data-model.md](docs/architecture/agents-turns-runs-data-model.md) and [docs/architecture/seed-state-run-snapshot-turn-events.md](docs/architecture/seed-state-run-snapshot-turn-events.md) describe `turns`, `turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, `turn_metrics`, and `turn_posts` as current reality rather than future migration targets.
+4. The mixed post-ID contract in [docs/architecture/turn-feed-post-id-contract.md](docs/architecture/turn-feed-post-id-contract.md) remains aligned with the authored-post behavior that has already landed: `TurnAction.POST` persists `turn_posts`, and those posts become eligible for feeds only when `turn_number < current_turn_number`.
+5. Final verification proves there is no live SQL or live documentation dependency on the legacy steady state outside explicitly historical locations such as archived plans, migration history, or before/after explanations.
+
+```mermaid
+flowchart LR
+  schema[db/schema.py]
+  linter[scripts/lint_schema_conventions.py]
+  lintTests[tests/lint/test_lint_schema_conventions.py]
+  archA[agents-turns-runs-data-model.md]
+  archB[seed-state-run-snapshot-turn-events.md]
+  postId[turn-feed-post-id-contract.md]
+  verify[final verification sweep]
+
+  schema --> linter
+  linter --> lintTests
+  schema --> archA
+  schema --> archB
+  postId --> archA
+  postId --> archB
+  lintTests --> verify
+  archA --> verify
+  archB --> verify
+```
+
+
+
+## Interface Or Contract Freeze
+
+- This slice does not add new simulation behavior. It documents and enforces the steady state that already exists after the authored-post subsequent-turn slice lands.
+- `turns` is the canonical turn parent. The steady-state turn history family is `turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, `turn_metrics`, and `turn_posts`.
+- Authored posts are no longer described as deferred in architecture docs. The current product rule is explicit: a post created in turn `T` may appear in feeds only in turn `T+1` or later.
+- Historical references to legacy names are still allowed only in migration-oriented material, archived plans/proposals, or explicit before/after explanations. Live architecture docs and enforcement tools must not treat the legacy names as current truth.
+- Ground this slice in head reality, not stale proposal wording. The current linter does not expose a `LEGACY_TURN_EVENT_TABLES` constant, so the implementation should tighten the actual lint behavior in [scripts/lint_schema_conventions.py](scripts/lint_schema_conventions.py) rather than chasing that exact symbol name.
+- Avoid broad runtime rename churn unless verification exposes a real correctness issue. This slice should prefer lint/doc/test enforcement over gratuitous method or model renames.
+
+## Serial Coordination Spine
+
+1. Audit the current head state in [scripts/lint_schema_conventions.py](scripts/lint_schema_conventions.py), [tests/lint/test_lint_schema_conventions.py](tests/lint/test_lint_schema_conventions.py), [docs/architecture/agents-turns-runs-data-model.md](docs/architecture/agents-turns-runs-data-model.md), [docs/architecture/seed-state-run-snapshot-turn-events.md](docs/architecture/seed-state-run-snapshot-turn-events.md), and [docs/architecture/turn-feed-post-id-contract.md](docs/architecture/turn-feed-post-id-contract.md). Freeze the rule that authored posts are current behavior and remain subsequent-turn visible only.
+2. Decide the verification shape before editing: prefer one search for runtime SQL/table-name references and one search for doc references, rather than a single noisy grep that also catches method identifiers like `write_turn_metadata`.
+3. Land the linter/test ratchet.
+4. Land the architecture/doc reconciliation.
+5. Run the final verification suite and record any intentionally historical residual hits.
+
+## Parallel Task Packets
+
+### Packet L1: Schema-lint ratchet
+
+Objective: tighten lint/test enforcement so the repo no longer accepts the legacy turn-event naming as a valid current-state baseline.
+
+Why parallelizable: confined to the linter and its tests; does not require editing architecture docs or runtime services.
+
+Files to inspect:
+
+- [scripts/lint_schema_conventions.py](scripts/lint_schema_conventions.py)
+- [tests/lint/test_lint_schema_conventions.py](tests/lint/test_lint_schema_conventions.py)
+- [db/schema.py](db/schema.py)
+
+Files allowed to change:
+
+- [scripts/lint_schema_conventions.py](scripts/lint_schema_conventions.py)
+- [tests/lint/test_lint_schema_conventions.py](tests/lint/test_lint_schema_conventions.py)
+
+Files forbidden to change:
+
+- `db/services/**`
+- `simulation/**`
+- `feeds/**`
+- `ui/**`
+
+Preconditions:
+
+- The authored-post subsequent-turn behavior is assumed landed and available in head.
+- The coordinator has frozen the verification strategy so this packet does not try to solve docs cleanup inside the tests.
+
+Dependencies:
+
+- Depends only on the serial audit/freeze step.
+
+Required contracts and invariants:
+
+- The live repo schema in [db/schema.py](db/schema.py) must remain accepted by the linter.
+- `turns` and every `turn_*` table continue to be governed as turn-scoped history.
+- Do not add enforcement that accidentally rejects valid seed-state legacy tables still intentionally grandfathered in `LEGACY_SEED_STATE_TABLES`.
+
+Implementation instructions:
+
+1. Review how [scripts/lint_schema_conventions.py](scripts/lint_schema_conventions.py) currently distinguishes governed tables from non-governed tables.
+2. Tighten the linter so the steady-state rule is explicit and future regressions to legacy turn-event table names are not silently treated as acceptable current state.
+3. Add focused tests that prove the linter accepts the current repo schema and rejects a metadata fixture that reintroduces legacy turn-event table names or mis-scoped turn tables.
+4. Keep the change narrow: this packet is about enforcement semantics, not about renaming runtime code.
+
+Verification commands:
+
+- `uv run pytest tests/lint/test_lint_schema_conventions.py -q`
+
+Expected output:
+
+- All lint tests pass.
+- The new negative test fails when legacy turn-event table names are modeled as current-state turn history.
+
+Done when:
+
+- The linter enforces the steady-state turn-table family rather than tolerating transitional naming.
+- Tests cover both acceptance of current head schema and rejection of legacy turn-event regressions.
+
+Coordinator review checklist:
+
+- No runtime behavior was changed under the guise of lint cleanup.
+- The ratchet is grounded in actual `db/schema.py` behavior, not outdated proposal wording.
+
+### Packet D1: Architecture steady-state rewrite
+
+Objective: rewrite the two high-signal architecture docs so they describe the current turn-table model and authored-post behavior accurately.
+
+Why parallelizable: limited to architecture docs; does not overlap with the linter packet.
+
+Files to inspect:
+
+- [docs/architecture/agents-turns-runs-data-model.md](docs/architecture/agents-turns-runs-data-model.md)
+- [docs/architecture/seed-state-run-snapshot-turn-events.md](docs/architecture/seed-state-run-snapshot-turn-events.md)
+- [docs/architecture/turn-feed-post-id-contract.md](docs/architecture/turn-feed-post-id-contract.md)
+- [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md)
+- [db/schema.py](db/schema.py)
+
+Files allowed to change:
+
+- [docs/architecture/agents-turns-runs-data-model.md](docs/architecture/agents-turns-runs-data-model.md)
+- [docs/architecture/seed-state-run-snapshot-turn-events.md](docs/architecture/seed-state-run-snapshot-turn-events.md)
+
+Files forbidden to change:
+
+- `scripts/**`
+- `db/**`
+- `simulation/**`
+- `ui/**`
+
+Preconditions:
+
+- The coordinator has frozen that authored posts are current behavior and subsequent-turn visible only.
+
+Dependencies:
+
+- Depends only on the serial audit/freeze step.
+
+Required contracts and invariants:
+
+- Remove language that says authored posts are deferred in these docs.
+- Describe `turns` and the full `turn_*` family as present reality, not a future migration target.
+- Preserve historical context only where it adds explicit before/after explanation.
+
+Implementation instructions:
+
+1. In [docs/architecture/agents-turns-runs-data-model.md](docs/architecture/agents-turns-runs-data-model.md), replace transitional wording about legacy turn-event names with present-tense descriptions of the live steady state.
+2. In [docs/architecture/seed-state-run-snapshot-turn-events.md](docs/architecture/seed-state-run-snapshot-turn-events.md), rewrite the “current schema” framing so turn events are documented in steady-state names first, with any historical naming kept clearly secondary.
+3. Align both docs with [docs/architecture/turn-feed-post-id-contract.md](docs/architecture/turn-feed-post-id-contract.md) on the authored-post rule: `turn_posts` persist during turn execution, but feed candidacy starts only on later turns.
+4. Keep front matter intact and rerun metadata validation if any markdown file is touched.
+
+Verification commands:
+
+- `uv run python scripts/check_docs_metadata.py docs/architecture/agents-turns-runs-data-model.md docs/architecture/seed-state-run-snapshot-turn-events.md`
+- `rg "TurnAction.POST|deferred|turn_metadata|generated_feeds|likes|comments|follows" docs/architecture/agents-turns-runs-data-model.md docs/architecture/seed-state-run-snapshot-turn-events.md docs/architecture/turn-feed-post-id-contract.md`
+
+Expected output:
+
+- Metadata check succeeds.
+- Remaining legacy-name references in the two rewritten architecture docs are only explicit historical explanations, if any.
+- No lingering statement says authored-post generation is deferred.
+
+Done when:
+
+- The two architecture docs describe the live steady state accurately.
+- The authored-post subsequent-turn visibility rule is explicit and consistent across architecture docs.
+
+Coordinator review checklist:
+
+- The docs now match [db/schema.py](db/schema.py) and the landed authored-post behavior.
+- Historical context, if retained, is clearly marked as historical rather than normative.
+
+### Packet D2: Verification contract and residual-reference sweep
+
+Objective: tighten the final verification story so closeout reviewers can distinguish legitimate historical references from live steady-state regressions.
+
+Why parallelizable: works on verification/docs surfaces only; can proceed once the serial verification shape is frozen.
+
+Files to inspect:
+
+- [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md)
+- [docs/architecture/turn-feed-post-id-contract.md](docs/architecture/turn-feed-post-id-contract.md)
+- [scripts/generate_db_schema_docs.py](scripts/generate_db_schema_docs.py)
+- Targeted `rg` results under `db/`, `simulation/`, `tests/`, `docs/`, and `scripts/`
+
+Files allowed to change:
+
+- [docs/architecture/turn-feed-post-id-contract.md](docs/architecture/turn-feed-post-id-contract.md) if reconciliation is needed
+- The new plan assets under `docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/`
+- Proposal/doc verification notes only if a touched planning doc must explicitly distinguish historical versus normative references
+
+Files forbidden to change:
+
+- `db/schema.py`
+- `simulation/**`
+- `feeds/**`
+- `ui/**`
+
+Preconditions:
+
+- The serial verification shape has been frozen.
+- D1 owns the two major architecture docs and must not be overlapped here.
+
+Dependencies:
+
+- Depends on the serial audit/freeze step.
+- Should reconcile with D1 before final merge if `turn-feed-post-id-contract.md` needs wording updates.
+
+Required contracts and invariants:
+
+- Do not reopen authored-post feature design.
+- Verification must be specific enough to be low-noise and repeatable.
+- Generated schema-doc verification should remain check-only; no doc regeneration belongs in this slice unless an actual mismatch is discovered.
+
+Implementation instructions:
+
+1. Define two explicit verification searches: one for runtime/table-name references in live code paths, and one for docs/tests where historical references may still exist intentionally.
+2. Review [docs/architecture/turn-feed-post-id-contract.md](docs/architecture/turn-feed-post-id-contract.md) for consistency with the two rewritten architecture docs; edit only if wording drift remains.
+3. Add a `verification.md` artifact under `docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/` that records the exact commands, allowed residual-hit categories, and expected outputs for reviewers.
+4. If useful, include [strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md](strategy_planning/2026-03-22_v2_refactor_turn_tables/proposal.md) in the verification notes as historical context, but do not rewrite broad planning content unless it creates real confusion.
+
+Verification commands:
+
+- `rg "\b(turn_metadata|generated_feeds|likes|comments|follows)\b" db/adapters db/repositories db/services simulation/api simulation/core scripts`
+- `rg "\b(turn_metadata|generated_feeds|likes|comments|follows)\b" docs/architecture docs/plans tests/lint`
+- `uv run python scripts/generate_db_schema_docs.py --check`
+
+Expected output:
+
+- Runtime-path grep returns no live legacy table-name dependencies, or only explicitly approved compatibility shims documented in the verification artifact.
+- Docs/tests grep returns only historical or explanatory references that are intentionally retained.
+- Schema-doc check passes.
+
+Done when:
+
+- Reviewers have a low-noise, copy-paste verification checklist.
+- Residual legacy-name references are categorized instead of hand-waved.
+
+Coordinator review checklist:
+
+- Verification commands test the actual closeout goal rather than incidental method identifiers.
+- Any retained reference has a documented reason.
+
+## Integration Order
+
+1. Complete the serial audit and freeze the verification shape.
+2. Run L1 and D1 in parallel.
+3. Run D2 once L1 and D1 have established the final enforcement and documentation wording; allow only the minimal reconciliation edit to [docs/architecture/turn-feed-post-id-contract.md](docs/architecture/turn-feed-post-id-contract.md) if needed.
+4. Reconcile all verification commands into a single closeout `verification.md` artifact.
+5. Run the full verification suite and confirm no new runtime cleanup is required.
+
+## Alternative Approaches
+
+- Rename every lingering `turn_metadata`-style method or variable in runtime code now. Rejected for this slice because it adds broad churn without changing steady-state behavior; enforce table/documentation truth first.
+- Keep the proposal’s single broad grep exactly as written. Rejected because it is too noisy against current method identifiers and obscures the real goal; split runtime versus historical/reference searches instead.
+- Skip doc reconciliation because behavior already works. Rejected because the two architecture docs still describe authored posts as deferred and still frame the turn-table family as transitional.
+
+## Manual Verification
+
+- `uv run pytest tests/lint/test_lint_schema_conventions.py -q`
+  - Expected: pass.
+- `uv run python scripts/check_docs_metadata.py docs/architecture/agents-turns-runs-data-model.md docs/architecture/seed-state-run-snapshot-turn-events.md docs/architecture/turn-feed-post-id-contract.md docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/`
+  - Expected: `Docs metadata validation succeeded.`
+- `rg "\b(turn_metadata|generated_feeds|likes|comments|follows)\b" db/adapters db/repositories db/services simulation/api simulation/core scripts`
+  - Expected: no live table-name references that describe the legacy steady state.
+- `rg "\b(turn_metadata|generated_feeds|likes|comments|follows)\b" docs/architecture docs/plans tests/lint`
+  - Expected: hits are only historical explanations, archived planning material, or intentional test fixtures.
+- `uv run python scripts/generate_db_schema_docs.py --check`
+  - Expected: schema docs already match migrations/schema.
+- `uv run ruff check .`
+  - Expected: pass.
+
+## Final Verification
+
+- The linter and its tests ratchet the repo toward the steady-state turn-table family.
+- The two architecture docs no longer say authored-post generation is deferred.
+- The authored-post rule remains explicit: posts authored in turn `T` are eligible for feeds only in turn `T+1` or later.
+- Reviewers have a concise verification artifact under `docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/`.
+- Any remaining legacy-name references are clearly historical, explanatory, or fixture-only.
+
+## Areas For Improvement Or Clarification
+
+- The proposal text says to remove legacy entries from `LEGACY_TURN_EVENT_TABLES`, but current head does not expose that constant. Implement the intent against the real linter structure rather than forcing an outdated symbol-level edit.
+- The proposal’s original grep mixes runtime, tests, and docs, which will create false positives from identifiers and historical material. The safer closeout is a split verification strategy with explicit residual-hit categories.
+- If the frontend later renders `TurnAction.POST` more richly, that should be a separate UI slice; this closeout should remain backend/docs/lint-only.
+
+## Plan Asset Storage
+
+Use `docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/` for `plan.md`, `verification.md`, and any notes captured during execution. No screenshot workflow is needed because `ui/**` is out of scope.

--- a/docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/verification.md
+++ b/docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/verification.md
@@ -1,0 +1,77 @@
+---
+description: "Verification commands and expected outcomes for turn-table steady-state closeout (lint, docs metadata, rg sweeps, schema-doc check)."
+tags: [plan, verification, persistence, turns]
+---
+
+# Turn-table steady-state closeout — verification
+
+## 1. Schema linter tests
+
+```bash
+uv run pytest tests/lint/test_lint_schema_conventions.py -q
+```
+
+**Expected:** All tests pass, including `test_rejects_legacy_turn_event_table_names` (SCHEMA-4).
+
+## 2. Docs metadata
+
+```bash
+uv run python scripts/check_docs_metadata.py \
+  docs/architecture/agents-turns-runs-data-model.md \
+  docs/architecture/seed-state-run-snapshot-turn-events.md \
+  docs/architecture/turn-feed-post-id-contract.md \
+  docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/
+```
+
+**Expected:** `Docs metadata validation succeeded.`
+
+## 3. Runtime-path search (legacy **table** tokens)
+
+```bash
+rg "\b(turn_metadata|generated_feeds|likes|comments|follows)\b" \
+  db/adapters db/repositories db/services simulation/api simulation/core scripts
+```
+
+**How to interpret hits (allowed residual categories):**
+
+- **Python/domain identifiers:** Parameter names like `turn_metadata: TurnMetadata`, variables `likes`, `comments`, `follows`, `generated_feeds` collections — these are **not** SQL table names; they are expected unless a hit is a string literal SQL identifier for a dropped table.
+- **API routes / English copy:** e.g. `/follows`, “list follows”, docstrings mentioning likes/comments — allowed.
+- **Schema linter allowlist:** `scripts/lint_schema_conventions.py` lists legacy names intentionally as **forbidden table names** — expected.
+- **Red flags:** ORM `Table("likes", …)`, raw SQL `FROM likes` / `INSERT INTO generated_feeds`, or new code introducing those as physical table names. At steady state, physical tables are `turns`, `turn_generated_feeds`, `turn_likes`, etc.
+
+## 4. Docs / plans / lint tests search
+
+```bash
+rg "\b(turn_metadata|generated_feeds|likes|comments|follows)\b" \
+  docs/architecture docs/plans tests/lint
+```
+
+**How to interpret hits:**
+
+- **Historical / explanatory:** Architecture docs may name old table names when stating they are **not** acceptable at HEAD, or in pointers to strategy proposals — allowed.
+- **Test fixtures:** Negative tests that model bad metadata (e.g. legacy table names) — allowed.
+- **Red flags:** Normative “current schema uses `generated_feeds`” style statements — should be absent after closeout.
+
+## 5. Generated schema docs check
+
+```bash
+uv run python scripts/generate_db_schema_docs.py --check
+```
+
+**Expected:** Check passes (generated docs match migrations/schema).
+
+## 6. Ruff (repo-wide Python)
+
+```bash
+uv run ruff check .
+```
+
+**Expected:** Pass.
+
+## 7. Optional: schema linter CLI on real metadata
+
+```bash
+uv run python scripts/lint_schema_conventions.py
+```
+
+**Expected:** `OK (N tables checked)` with exit code 0.

--- a/scripts/lint_schema_conventions.py
+++ b/scripts/lint_schema_conventions.py
@@ -5,8 +5,9 @@ contract documented in:
 - docs/RULES.md (Persistence scopes)
 - docs/architecture/seed-state-run-snapshot-turn-events.md
 
-It is intentionally narrow: it validates only table naming + the presence or
-absence of `run_id`/`turn_number` columns for new tables.
+It is intentionally narrow: it validates table naming + the presence or
+absence of `run_id`/`turn_number` columns for new tables, and rejects a fixed set
+of legacy turn-event **table** names (SCHEMA-4).
 """
 
 from __future__ import annotations
@@ -23,6 +24,18 @@ LEGACY_SEED_STATE_TABLES: frozenset[str] = frozenset(
         "agent",
         "agent_persona_bios",
         "user_agent_profile_metadata",
+    }
+)
+
+# Pre-cutover turn-event table names. These must not reappear in db/schema.py;
+# steady state is `turns` plus the `turn_*` family (see architecture docs).
+LEGACY_TURN_EVENT_TABLE_NAMES: frozenset[str] = frozenset(
+    {
+        "turn_metadata",
+        "generated_feeds",
+        "likes",
+        "comments",
+        "follows",
     }
 )
 
@@ -99,6 +112,20 @@ def lint_metadata(metadata: sa.MetaData) -> list[Violation]:
     violations: list[Violation] = []
     for table in metadata.tables.values():
         name = table.name
+
+        if name in LEGACY_TURN_EVENT_TABLE_NAMES:
+            violations.append(
+                Violation(
+                    rule="SCHEMA-4",
+                    table_name=name,
+                    message=(
+                        "legacy turn-event table names are not an acceptable steady state; "
+                        "use `turns` and the `turn_*` family (e.g. turn_generated_feeds, "
+                        "turn_likes, turn_comments, turn_follows)."
+                    ),
+                )
+            )
+            continue
 
         if name.startswith("agent_") or name in LEGACY_SEED_STATE_TABLES:
             violations.extend(_lint_agent_table(table))

--- a/tests/lint/test_lint_schema_conventions.py
+++ b/tests/lint/test_lint_schema_conventions.py
@@ -77,3 +77,24 @@ class TestLintSchemaConventions:
 
         expected_result = True
         assert any(v.rule == "SCHEMA-3" for v in violations) is expected_result
+
+    def test_rejects_legacy_turn_event_table_names(self):
+        """Steady state must not reintroduce pre-cutover turn-event table names."""
+        from scripts import lint_schema_conventions
+
+        for legacy_name in sorted(
+            lint_schema_conventions.LEGACY_TURN_EVENT_TABLE_NAMES
+        ):
+            md = sa.MetaData()
+            sa.Table(
+                legacy_name,
+                md,
+                sa.Column("run_id", sa.Text(), nullable=False),
+                sa.Column("turn_number", sa.Integer(), nullable=False),
+            )
+
+            violations = lint_schema_conventions.lint_metadata(md)
+
+            assert any(
+                v.rule == "SCHEMA-4" and v.table_name == legacy_name for v in violations
+            )


### PR DESCRIPTION
## Overview

Close out the turn-table refactor by making the new `turns` / `turn_*` steady state mechanically enforced in lint/tests, updating architecture docs to describe the current reality, and adding a final verification sweep that preserves the authored-post rule that posts become feed-visible only on subsequent turns.

## Problem / motivation

Architecture docs still described turn tables as transitional and authored posts as deferred. The repo needed a mechanical ratchet so legacy SQL table names (`turn_metadata`, bare `likes`, etc.) cannot reappear in `db/schema.py` as acceptable steady state.

## Solution

Add SCHEMA-4 in the schema convention linter, extend tests, rewrite the two main persistence-scope architecture docs, align `turn-feed-post-id-contract.md`, and add `docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/` with the full plan (from Cursor) plus `verification.md`.

## Happy Flow

1. The schema linter in `scripts/lint_schema_conventions.py` loads `db/schema.py` and validates the live table family against the steady-state rules: `agent_*` tables remain seed-state only, `run_*` tables remain run-scoped, and `turns` plus every `turn_*` table require non-null `run_id` and `turn_number` where appropriate.
2. The linter tests in `tests/lint/test_lint_schema_conventions.py` ratchet the repo forward by failing if a legacy turn-event baseline is reintroduced or if the current schema drifts away from the steady-state contract.
3. The architecture docs in `docs/architecture/agents-turns-runs-data-model.md` and `docs/architecture/seed-state-run-snapshot-turn-events.md` describe `turns`, `turn_generated_feeds`, `turn_likes`, `turn_comments`, `turn_follows`, `turn_metrics`, and `turn_posts` as current reality rather than future migration targets.
4. The mixed post-ID contract in `docs/architecture/turn-feed-post-id-contract.md` remains aligned with the authored-post behavior that has already landed: `TurnAction.POST` persists `turn_posts`, and those posts become eligible for feeds only when `turn_number < current_turn_number`.
5. Final verification proves there is no live SQL or live documentation dependency on the legacy steady state outside explicitly historical locations such as archived plans, migration history, or before/after explanations.

## Data Flow

`db/schema.py` → `lint_schema_conventions.lint_metadata` → `tests/lint/test_lint_schema_conventions.py`; architecture docs describe `turns` parent + `turn_*` children; `verification.md` documents split `rg` sweeps (identifiers vs physical table names).

## Changes

- `scripts/lint_schema_conventions.py`: `LEGACY_TURN_EVENT_TABLE_NAMES`, rule SCHEMA-4
- `tests/lint/test_lint_schema_conventions.py`: negative test for legacy table names
- `docs/architecture/agents-turns-runs-data-model.md`, `docs/architecture/seed-state-run-snapshot-turn-events.md`: steady-state rewrite
- `docs/architecture/turn-feed-post-id-contract.md`: minor present-tense alignment
- `docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/plan.md`: full Cursor plan copy + repo front matter
- `docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/verification.md`: reviewer checklist

## Manual Verification

- `uv run pytest tests/lint/test_lint_schema_conventions.py -q` — pass
- `uv run python scripts/check_docs_metadata.py docs/architecture/agents-turns-runs-data-model.md docs/architecture/seed-state-run-snapshot-turn-events.md docs/architecture/turn-feed-post-id-contract.md docs/plans/2026-03-24_turn_table_steady_state_closeout_584731/` — `Docs metadata validation succeeded.`
- `uv run python scripts/generate_db_schema_docs.py --check` — pass
- `uv run ruff check .` — pass

Note: local commit used `SKIP=pyright` because pre-commit pyright reports an unrelated missing `scipy` import in `ml_tooling/polarity/classifier.py` in this environment.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Schema linter now includes a new SCHEMA-4 validation rule that detects and reports legacy turn-event table names with dedicated diagnostic messaging.

* **Tests**
  * Added test coverage for legacy turn-event table name validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->