### PR TITLE
hotfix: unpin git in Docker image for Railway (Debian trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 # litellm is installed from git (pyproject.toml); uv needs git during sync.
-# Pin matches Debian bookworm (python:3.12-slim); bump when the base image moves.
+# Do not pin git to a Debian release: python:3.12-slim tracks debian:*-slim and the
+# suite (bookworm, trixie, …) changes; a bookworm-only version breaks apt on trixie.
+# hadolint ignore=DL3008
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git=1:2.39.5-0+deb12u3 \
+    && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --create-home --shell /usr/sbin/nologin appuser \
     && pip install --no-cache-dir 'uv==0.10.3'


### PR DESCRIPTION
## Problem

Railway Docker build failed: `git=1:2.39.5-0+deb12u3` is not available on the current `python:3.12-slim` base (Debian trixie), so `apt-get install` exited 100.

## Solution

Install `git` without a release-specific version pin; suppress hadolint DL3008 with an inline comment (documented).

## Verification

- `railway up` from this branch: deployment **450292cb** → **SUCCESS**
- `curl` `https://agent-simulation-platform-production.up.railway.app/health` → 200 `{"status":"ok"}`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to use the latest available version of git from system repositories instead of a pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->