### PR TITLE
Add Feature Extraction API health endpoint and Railway scaffold

### DIFF
--- a/Dockerfile.feature-extraction
+++ b/Dockerfile.feature-extraction
@@ -11,7 +11,10 @@ RUN useradd --create-home --shell /usr/sbin/nologin appuser \
 COPY . /app
 
 # Health-only image: same lockfile as the main app, no simulation bootstrap / SQLite.
-RUN if [ -f uv.lock ]; then uv sync --frozen --no-dev; else uv sync --no-dev; fi
+RUN if [ -f uv.lock ]; then uv sync --frozen --no-dev; else uv sync --no-dev; fi \
+    && chown -R appuser:appuser /app
+
+USER appuser
 
 EXPOSE 8000
 

--- a/Dockerfile.feature-extraction
+++ b/Dockerfile.feature-extraction
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN useradd --create-home --shell /usr/sbin/nologin appuser \
+    && pip install --no-cache-dir 'uv==0.10.3'
+
+COPY . /app
+
+# Health-only image: same lockfile as the main app, no simulation bootstrap / SQLite.
+RUN if [ -f uv.lock ]; then uv sync --frozen --no-dev; else uv sync --no-dev; fi
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=5 \
+  CMD ["sh", "-c", "python -c \"import urllib.request, os; u = urllib.request.urlopen('http://127.0.0.1:' + os.environ.get('PORT', '8000') + '/health', timeout=5); exit(0 if u.getcode() == 200 else 1)\" || exit 1"]
+
+CMD ["sh", "-c", "uv run uvicorn ml_tooling.api.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/docs/plans/2026-03-25_feature_extraction_api_health_847291/plan.md
+++ b/docs/plans/2026-03-25_feature_extraction_api_health_847291/plan.md
@@ -1,0 +1,65 @@
+---
+name: Feature Extraction API Health
+description: "Add a minimal FastAPI app under ml_tooling/api with GET /health, tests, Dockerfile.feature-extraction, and Railway second-service runbook — without changing the simulation Dockerfile or railway.json."
+tags: [plan, fastapi, railway, docker, ml-tooling, health]
+overview: Ship the first slice of the Feature Extraction PRD — a standalone FastAPI service with GET /health for Railway health checks and future readiness fields — with pytest (TestClient), a dedicated Dockerfile, and documented Railway steps for a second service.
+todos:
+  - id: contract-freeze
+    content: Freeze GET /health JSON shape and status codes (document in PR or plan section)
+    status: completed
+  - id: ptp-1-tests
+    content: Add tests/ml_tooling/api/test_health.py with TestClient (TDD red)
+    status: completed
+  - id: ptp-2-api
+    content: Implement ml_tooling/api/main.py + routes/health.py; wire router; green tests
+    status: completed
+  - id: ptp-3-docker-railway
+    content: Add Dockerfile.feature-extraction + Railway runbook subsection; optional HEALTHCHECK
+    status: completed
+  - id: ptp-4-pyproject
+    content: "Only if needed: extend pyproject hatch packages for ml_tooling"
+    status: cancelled
+  - id: docs-plan-file
+    content: Write docs/plans/2026-03-25_feature_extraction_api_health_847291/plan.md with YAML front matter; run check_docs_metadata.py
+    status: completed
+  - id: final-verify
+    content: Run pytest, ruff, pyright on touched paths; manual curl + optional Railway deploy check
+    status: completed
+isProject: false
+---
+
+# Feature Extraction API — health endpoint + Railway scaffold
+
+## Overview
+
+Ship the first slice of the [Feature Extraction PRD](strategy_planning/2026-03-13_feature_extraction_api/FEATURE_EXTRACTION_API_PRD.md): a standalone FastAPI service entrypoint under `ml_tooling/api/` with **GET /health** returning JSON suitable for Railway’s HTTP health checks and future readiness fields (models, version). Include **pytest coverage** using `TestClient`, and **deployment artifacts** (slim Dockerfile + documented Railway service settings) so a **second** Railway service can run this app without altering the existing `Dockerfile` / `railway.json` used by `simulation.api.main`.
+
+## Interface or Contract Freeze
+
+| Item                  | Value                                                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Path                  | `GET /health`                                                                                                            |
+| Status                | `200` when process is up (no model loading yet — always ready for v1)                                                    |
+| JSON fields (minimum) | `status`: `"ok"`; `service`: `"feature-extraction"`                                                                      |
+| Optional fields       | `version`: string from env e.g. `FEATURE_EXTRACTION_VERSION` or `GIT_COMMIT` / Railway’s `RAILWAY_GIT_COMMIT_SHA` if set |
+| Future                | `readiness` object reserved for Phase 2 — may be `{}` or omitted in v1                                                   |
+
+## Happy Flow
+
+1. Operator runs the service locally: `PYTHONPATH=. uv run uvicorn ml_tooling.api.main:app --reload --host 127.0.0.1 --port 8010`.
+2. Client calls `GET http://127.0.0.1:8010/health`.
+3. FastAPI resolves the health router in `ml_tooling/api/routes/health.py` (included from `ml_tooling/api/main.py`).
+4. Response is **HTTP 200** with JSON body (`status`, `service`, optional `version`).
+5. On Railway, the platform probes `/health` against the public URL; container binds `$PORT` with `--host 0.0.0.0`.
+
+## Data Flow
+
+Client or Railway health probe sends HTTP GET to Uvicorn; FastAPI dispatches to the health router; the handler returns a small JSON dict (status, service, optional version from environment) with no database or model loading.
+
+## Manual Verification
+
+- **Unit tests:** `uv run pytest tests/ml_tooling/api/test_health.py -v` — all passed.
+- **Local server:** `PYTHONPATH=. uv run uvicorn ml_tooling.api.main:app --host 127.0.0.1 --port 8010` then `curl -sS http://127.0.0.1:8010/health` — HTTP 200 and JSON with `status` key.
+- **OpenAPI:** `curl -sS http://127.0.0.1:8010/openapi.json` returns schema.
+- **Docker (optional):** `docker build -f Dockerfile.feature-extraction -t fe-api:local .` then run with `-e PORT=8010` and curl `/health`.
+- **Docs metadata:** `uv run python scripts/check_docs_metadata.py docs/runbooks/RAILWAY_DEPLOYMENT.md docs/plans/2026-03-25_feature_extraction_api_health_847291/plan.md`

--- a/docs/runbooks/RAILWAY_DEPLOYMENT.md
+++ b/docs/runbooks/RAILWAY_DEPLOYMENT.md
@@ -81,6 +81,26 @@ uv run python -m simulation.bootstrap.railway && uv run uvicorn simulation.api.m
 
 **Proxy headers (FASTAPI-PROXY-001):** Set `FORWARDED_ALLOW_IPS=*` in Railway variables. The container is only reachable through Railway's proxy, so trusting forwarded headers from all connections is safe. This ensures `X-Forwarded-For` and other proxy headers are applied for rate limiting and client IP detection. See [plan Security section](../plans/2026-02-19_rate_limiting_post_paths_847291/plan.md#security-proxy-trust-fastapi-proxy-001).
 
+## Feature Extraction API (second Railway service)
+
+The simulation API uses the root [`Dockerfile`](../../Dockerfile) and [`railway.json`](../../railway.json). To run the **Feature Extraction** FastAPI app (`GET /health`, future extraction routes) as a **separate** Railway service without changing that contract:
+
+1. In Railway, **add a new service** from the same GitHub repo (or duplicate the service and repoint the Dockerfile).
+2. Set **Dockerfile path** to `Dockerfile.feature-extraction` (not the default `Dockerfile`).
+3. Set **health check path** to `/health` (same pattern as the simulation service).
+4. The container listens on **`0.0.0.0:$PORT`**; Railway sets `PORT` automatically.
+5. Optional: set `FEATURE_EXTRACTION_VERSION` and/or rely on `RAILWAY_GIT_COMMIT_SHA` for the optional `version` field in `GET /health` JSON.
+
+Local image check:
+
+```bash
+docker build -f Dockerfile.feature-extraction -t fe-api:local .
+docker run --rm -p 8010:8010 -e PORT=8010 fe-api:local
+curl -sS http://127.0.0.1:8010/health
+```
+
+After deploy, verify with `railway domain` (scoped to that service) and `curl -sS "<FE_APP_URL>/health"`.
+
 ## Verify Deployment With Railway CLI + HTTP Checks
 
 Check service status and logs:

--- a/ml_tooling/api/__init__.py
+++ b/ml_tooling/api/__init__.py
@@ -1,0 +1,1 @@
+"""Feature Extraction HTTP API (FastAPI)."""

--- a/ml_tooling/api/main.py
+++ b/ml_tooling/api/main.py
@@ -1,0 +1,14 @@
+"""FastAPI entrypoint for the Feature Extraction API."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from ml_tooling.api.routes.health import router as health_router
+
+app = FastAPI(
+    title="Feature Extraction API",
+    version="0.1.0",
+    description="HTTP API for feature extraction (health and future model endpoints).",
+)
+app.include_router(health_router)

--- a/ml_tooling/api/routes/__init__.py
+++ b/ml_tooling/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP route modules for the Feature Extraction API."""

--- a/ml_tooling/api/routes/health.py
+++ b/ml_tooling/api/routes/health.py
@@ -1,0 +1,30 @@
+"""Health check route for Railway and operators."""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["health"])
+
+
+def _version_from_env() -> str | None:
+    return (
+        os.environ.get("FEATURE_EXTRACTION_VERSION")
+        or os.environ.get("GIT_COMMIT")
+        or os.environ.get("RAILWAY_GIT_COMMIT_SHA")
+    )
+
+
+@router.get("/health")
+def health() -> dict[str, str]:
+    """Liveness: process is up. Readiness fields may be added in a later phase."""
+    body: dict[str, str] = {
+        "status": "ok",
+        "service": "feature-extraction",
+    }
+    version = _version_from_env()
+    if version:
+        body["version"] = version
+    return body

--- a/tests/ml_tooling/api/test_health.py
+++ b/tests/ml_tooling/api/test_health.py
@@ -1,0 +1,46 @@
+"""Tests for Feature Extraction API health endpoint."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ml_tooling.api.main import app
+
+
+class TestHealthEndpoint:
+    def test_returns_ok_contract(self) -> None:
+        with TestClient(app) as client:
+            response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["service"] == "feature-extraction"
+
+    def test_includes_version_from_feature_extraction_version(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FEATURE_EXTRACTION_VERSION", "0.9.0-test")
+        with TestClient(app) as client:
+            response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json()["version"] == "0.9.0-test"
+
+    def test_version_prefers_feature_extraction_over_git_commit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FEATURE_EXTRACTION_VERSION", "from-fe")
+        monkeypatch.setenv("GIT_COMMIT", "abc123")
+        with TestClient(app) as client:
+            response = client.get("/health")
+        assert response.json()["version"] == "from-fe"
+
+    def test_version_falls_back_to_railway_git_commit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FEATURE_EXTRACTION_VERSION", raising=False)
+        monkeypatch.delenv("GIT_COMMIT", raising=False)
+        monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "sha-railway")
+        with TestClient(app) as client:
+            response = client.get("/health")
+        assert response.json()["version"] == "sha-railway"

--- a/tests/ml_tooling/api/test_health.py
+++ b/tests/ml_tooling/api/test_health.py
@@ -44,3 +44,26 @@ class TestHealthEndpoint:
         with TestClient(app) as client:
             response = client.get("/health")
         assert response.json()["version"] == "sha-railway"
+
+    def test_version_prefers_git_commit_when_feature_extraction_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FEATURE_EXTRACTION_VERSION", raising=False)
+        monkeypatch.delenv("RAILWAY_GIT_COMMIT_SHA", raising=False)
+        monkeypatch.setenv("GIT_COMMIT", "git-commit-only")
+        with TestClient(app) as client:
+            response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json()["version"] == "git-commit-only"
+
+    def test_version_omitted_when_no_envs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FEATURE_EXTRACTION_VERSION", raising=False)
+        monkeypatch.delenv("GIT_COMMIT", raising=False)
+        monkeypatch.delenv("RAILWAY_GIT_COMMIT_SHA", raising=False)
+        with TestClient(app) as client:
+            response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert "version" not in data


### PR DESCRIPTION
## Overview

Ship the first slice of the Feature Extraction PRD: a standalone FastAPI service entrypoint under `ml_tooling/api/` with **GET /health** returning JSON suitable for Railway's HTTP health checks and future readiness fields (models, version). Include **pytest coverage** using `TestClient`, and **deployment artifacts** (slim Dockerfile + documented Railway service settings) so a **second** Railway service can run this app without altering the existing `Dockerfile` / `railway.json` used by `simulation.api.main`.

## Problem / motivation

The Feature Extraction PRD calls for a separate HTTP surface for model/feature work. The simulation API image and Railway `railway.json` must stay tied to the main app; we need a minimal, deployable health endpoint and a documented path for a second Railway service (Dockerfile + health check) without coupling to SQLite bootstrap or simulation startup.

## Solution

Add `ml_tooling.api.main:app` with a health router, freeze the JSON contract, ship `Dockerfile.feature-extraction` with uvicorn-only `CMD`, and document second-service Railway steps in `RAILWAY_DEPLOYMENT.md`. Root `Dockerfile` and `railway.json` are unchanged.

## Happy Flow

1. Operator runs the service locally: `PYTHONPATH=. uv run uvicorn ml_tooling.api.main:app --reload --host 127.0.0.1 --port 8010` (port `8010` avoids collision with the simulation API on `8000`).
2. Client calls `GET http://127.0.0.1:8010/health`.
3. FastAPI resolves the health router in `ml_tooling/api/routes/health.py` (included from `ml_tooling/api/main.py`).
4. Response is **HTTP 200** with JSON (`status`, `service`, optional `version`).
5. On Railway, the platform probes `/health`; the container binds `$PORT` with `--host 0.0.0.0`.

## Data Flow

Client or Railway health probe sends HTTP GET to Uvicorn; FastAPI dispatches to the health router; the handler returns a small JSON object (status, service, optional version from environment) with no database or model loading.

## Changes

- `ml_tooling/api/main.py`: FastAPI app and `include_router` for health.
- `ml_tooling/api/routes/health.py`: `GET /health` with frozen contract (`status`, `service`, optional `version` from `FEATURE_EXTRACTION_VERSION` / `GIT_COMMIT` / `RAILWAY_GIT_COMMIT_SHA`).
- `tests/ml_tooling/api/test_health.py`: `TestClient` coverage for contract and version precedence.
- `Dockerfile.feature-extraction`: health-only image; `uv sync` + `uvicorn ml_tooling.api.main:app`; optional `HEALTHCHECK` on `/health`.
- `docs/runbooks/RAILWAY_DEPLOYMENT.md`: subsection **Feature Extraction API (second Railway service)** (Dockerfile path, healthcheck path, `PORT`, optional env vars, local docker curl).
- `docs/plans/2026-03-25_feature_extraction_api_health_847291/plan.md`: implementation plan with YAML front matter.

## Manual Verification

- `uv run pytest tests/ml_tooling/api/test_health.py -v` — all passed.
- `PYTHONPATH=. uv run uvicorn ml_tooling.api.main:app --host 127.0.0.1 --port 8010` then `curl -sS http://127.0.0.1:8010/health` — HTTP 200 and JSON with `status` / `service`.
- `curl -sS http://127.0.0.1:8010/openapi.json` — OpenAPI schema.
- `uv run ruff check ml_tooling/api tests/ml_tooling/api` and `uv run pyright ml_tooling/api tests/ml_tooling/api` — clean.
- `uv run python scripts/check_docs_metadata.py docs/runbooks/RAILWAY_DEPLOYMENT.md docs/plans/2026-03-25_feature_extraction_api_health_847291/plan.md` — succeeded.
- **Railway (optional):** after deploy, `curl -sS "https://<railway-url>/health"` with `railway domain` for the new service — not run in this PR (no live deploy).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Feature Extraction API with a /health endpoint that reports service status and optional version info.

* **Tests**
  * Added tests ensuring the health endpoint returns HTTP 200 and validates version resolution from environment variables.

* **Chores**
  * Added Docker configuration to build and run the service in a production-focused container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->