### PR TITLE
Add SQLite-backed turn snapshot loading for simulation_v2 (PR6)

### DIFF
--- a/docs/plans/2026-05-26_simulation_v2_pr6_turn_snapshot_293847/contracts.md
+++ b/docs/plans/2026-05-26_simulation_v2_pr6_turn_snapshot_293847/contracts.md
@@ -1,0 +1,33 @@
+# PR 6 Turn Snapshot — Contract Freeze
+
+| Symbol | Location | Contract |
+|--------|----------|----------|
+| `TurnStateSnapshot` | `simulation_v2/worker/state.py` | Pydantic model with `run_id`, `turn_id`, `turn_number`, `config: LocalSimulationConfig`, `users: dict[str, UserRecord]`, `posts: dict[str, PostRecord]`, `likes: list[LikeRecord]`, `follows: list[FollowRecord]`, `comments: list[CommentRecord]`, `agent_memories: dict[str, AgentMemoryRecord]`, `prior_generated_feeds: list[GeneratedFeedRecord]` |
+| `PendingTurnDiffs` | `simulation_v2/worker/state.py` | Pydantic model with default-empty lists: `posts`, `likes`, `follows`, `comments`, `memory_diffs` using existing db record types |
+| `load_turn_snapshot` | `simulation_v2/worker/state.py` | `(run_id: str, turn_id: str, repos: SimulationRepositories, conn: sqlite3.Connection) -> TurnStateSnapshot` |
+| `list_users_for_run` | `simulation_v2/db/repositories.py` | `(run_id, conn) -> list[UserRecord]` |
+| `list_posts_for_run` | same | `(run_id, conn) -> list[PostRecord]` |
+| `list_likes_for_run` | same | `(run_id, conn) -> list[LikeRecord]` |
+| `list_follows_for_run` | same | `(run_id, conn) -> list[FollowRecord]` |
+| `list_comments_for_run` | same | `(run_id, conn) -> list[CommentRecord]` |
+| `list_agent_memories_for_run` | same | `(run_id, conn) -> list[AgentMemoryRecord]` |
+| `list_generated_feeds_for_run` | same | `(run_id, conn) -> list[GeneratedFeedRecord]` |
+| `execute_run` | `simulation_v2/worker/run_executor.py` | `(run_id, config, conn, repos) -> None`; preserves skip-completed-turn retry semantics |
+| `execute_turn` | `simulation_v2/worker/turn_executor.py` | `(run_id, turn_number, config, conn, repos) -> TurnStateSnapshot \| None`; loads snapshot, calls stub, completes turn; returns `None` when turn already completed |
+
+## Cumulative-state rule (frozen)
+
+- Include posts/likes/follows/comments where `created_at_turn < turn_number` (seed rows use `created_at_turn=0`, so turn 1 sees all seed social entities).
+- Include all users and agent memories for the run (not turn-filtered).
+- Include generated feeds whose turn has `turn_number < current_turn_number` (resolve via `repos.list_turns_for_run` + feed rows, or filter in `load_turn_snapshot` after listing feeds).
+
+## File-interaction invariants
+
+| Owner | Allowed callers | Forbidden |
+|-------|-----------------|-----------|
+| `worker.state` | `worker.turn_executor`, tests | Must not import feeds/actions/memory/eval; must not execute SQL directly |
+| `db.repositories` list helpers | `worker.state`, seed loader (future), tests | Must not import worker/feed/action/eval |
+| `worker.turn_executor` | `worker.run_executor`, tests | Must not build snapshots itself |
+| `worker.run_executor` | `worker.service`, tests | Must not load snapshots directly |
+
+**Important:** `load_turn_snapshot` lives in `worker/state.py`, not `repositories.py`. Repositories expose bulk reads; snapshot assembly/filtering lives in worker state.

--- a/simulation_v2/db/repositories.py
+++ b/simulation_v2/db/repositories.py
@@ -362,6 +362,26 @@ class SimulationRepositories:
             created_at=row["created_at"],
         )
 
+    def list_users_for_run(
+        self, run_id: str, conn: sqlite3.Connection
+    ) -> list[UserRecord]:
+        rows = conn.execute(
+            "SELECT * FROM users WHERE run_id = ? ORDER BY user_id ASC",
+            (run_id,),
+        ).fetchall()
+        return [
+            UserRecord(
+                user_id=row["user_id"],
+                run_id=row["run_id"],
+                name=row["name"],
+                email=row["email"],
+                username=row["username"],
+                profile_json=_loads_json(row["profile_json"]),
+                created_at=row["created_at"],
+            )
+            for row in rows
+        ]
+
     def insert_post(self, record: PostRecord, conn: sqlite3.Connection) -> None:
         conn.execute(
             """
@@ -400,6 +420,26 @@ class SimulationRepositories:
             metadata_json=_loads_json(row["metadata_json"]),
         )
 
+    def list_posts_for_run(
+        self, run_id: str, conn: sqlite3.Connection
+    ) -> list[PostRecord]:
+        rows = conn.execute(
+            "SELECT * FROM posts WHERE run_id = ? ORDER BY post_id ASC",
+            (run_id,),
+        ).fetchall()
+        return [
+            PostRecord(
+                post_id=row["post_id"],
+                run_id=row["run_id"],
+                author_id=row["author_id"],
+                content=row["content"],
+                created_at=row["created_at"],
+                created_at_turn=row["created_at_turn"],
+                metadata_json=_loads_json(row["metadata_json"]),
+            )
+            for row in rows
+        ]
+
     def insert_like(self, record: LikeRecord, conn: sqlite3.Connection) -> None:
         conn.execute(
             """
@@ -435,6 +475,26 @@ class SimulationRepositories:
             created_at_turn=row["created_at_turn"],
             metadata_json=_loads_json(row["metadata_json"]),
         )
+
+    def list_likes_for_run(
+        self, run_id: str, conn: sqlite3.Connection
+    ) -> list[LikeRecord]:
+        rows = conn.execute(
+            "SELECT * FROM likes WHERE run_id = ? ORDER BY like_id ASC",
+            (run_id,),
+        ).fetchall()
+        return [
+            LikeRecord(
+                like_id=row["like_id"],
+                run_id=row["run_id"],
+                post_id=row["post_id"],
+                author_id=row["author_id"],
+                created_at=row["created_at"],
+                created_at_turn=row["created_at_turn"],
+                metadata_json=_loads_json(row["metadata_json"]),
+            )
+            for row in rows
+        ]
 
     def insert_follow(self, record: FollowRecord, conn: sqlite3.Connection) -> None:
         conn.execute(
@@ -473,6 +533,26 @@ class SimulationRepositories:
             created_at_turn=row["created_at_turn"],
             metadata_json=_loads_json(row["metadata_json"]),
         )
+
+    def list_follows_for_run(
+        self, run_id: str, conn: sqlite3.Connection
+    ) -> list[FollowRecord]:
+        rows = conn.execute(
+            "SELECT * FROM follows WHERE run_id = ? ORDER BY follow_id ASC",
+            (run_id,),
+        ).fetchall()
+        return [
+            FollowRecord(
+                follow_id=row["follow_id"],
+                run_id=row["run_id"],
+                follower_id=row["follower_id"],
+                followee_id=row["followee_id"],
+                created_at=row["created_at"],
+                created_at_turn=row["created_at_turn"],
+                metadata_json=_loads_json(row["metadata_json"]),
+            )
+            for row in rows
+        ]
 
     def insert_comment(self, record: CommentRecord, conn: sqlite3.Connection) -> None:
         conn.execute(
@@ -514,6 +594,27 @@ class SimulationRepositories:
             metadata_json=_loads_json(row["metadata_json"]),
         )
 
+    def list_comments_for_run(
+        self, run_id: str, conn: sqlite3.Connection
+    ) -> list[CommentRecord]:
+        rows = conn.execute(
+            "SELECT * FROM comments WHERE run_id = ? ORDER BY comment_id ASC",
+            (run_id,),
+        ).fetchall()
+        return [
+            CommentRecord(
+                comment_id=row["comment_id"],
+                run_id=row["run_id"],
+                parent_post_id=row["parent_post_id"],
+                author_id=row["author_id"],
+                content=row["content"],
+                created_at=row["created_at"],
+                created_at_turn=row["created_at_turn"],
+                metadata_json=_loads_json(row["metadata_json"]),
+            )
+            for row in rows
+        ]
+
     def insert_agent_memory(
         self, record: AgentMemoryRecord, conn: sqlite3.Connection
     ) -> None:
@@ -553,6 +654,26 @@ class SimulationRepositories:
             social=row["social"],
             updated_at=row["updated_at"],
         )
+
+    def list_agent_memories_for_run(
+        self, run_id: str, conn: sqlite3.Connection
+    ) -> list[AgentMemoryRecord]:
+        rows = conn.execute(
+            "SELECT * FROM agent_memories WHERE run_id = ? ORDER BY user_id ASC",
+            (run_id,),
+        ).fetchall()
+        return [
+            AgentMemoryRecord(
+                run_id=row["run_id"],
+                user_id=row["user_id"],
+                preferences_json=_loads_json(row["preferences_json"]),
+                episodic=row["episodic"],
+                personalized=row["personalized"],
+                social=row["social"],
+                updated_at=row["updated_at"],
+            )
+            for row in rows
+        ]
 
     def insert_memory_diff(
         self, record: MemoryDiffRecord, conn: sqlite3.Connection
@@ -636,6 +757,30 @@ class SimulationRepositories:
             feed_posts=[FeedPostView.model_validate(item) for item in feed_posts_raw],
             created_at=row["created_at"],
         )
+
+    def list_generated_feeds_for_run(
+        self, run_id: str, conn: sqlite3.Connection
+    ) -> list[GeneratedFeedRecord]:
+        rows = conn.execute(
+            "SELECT * FROM generated_feeds WHERE run_id = ? ORDER BY feed_id ASC",
+            (run_id,),
+        ).fetchall()
+        return [
+            GeneratedFeedRecord(
+                feed_id=row["feed_id"],
+                run_id=row["run_id"],
+                turn_id=row["turn_id"],
+                user_id=row["user_id"],
+                algorithm=row["algorithm"],
+                feed_post_ids=json.loads(row["feed_post_ids_json"]),
+                feed_posts=[
+                    FeedPostView.model_validate(item)
+                    for item in json.loads(row["feed_posts_json"])
+                ],
+                created_at=row["created_at"],
+            )
+            for row in rows
+        ]
 
     def insert_generation(
         self, record: GenerationRecord, conn: sqlite3.Connection

--- a/simulation_v2/main.py
+++ b/simulation_v2/main.py
@@ -1,8 +1,8 @@
 """Runs a full run of the simulation via the local control plane.
 
 Seed users, posts, likes, follows, and agent memories are persisted to SQLite
-before the turn loop. Turn execution (feeds, actions, memory updates) remains
-stubbed until PR 6/7+.
+before the turn loop. Each turn loads a SQLite-backed snapshot; feed generation
+and LLM actions remain stubbed until PR 7+.
 
 To run:
 

--- a/simulation_v2/worker/run_executor.py
+++ b/simulation_v2/worker/run_executor.py
@@ -1,0 +1,19 @@
+"""Run-level turn loop orchestration."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from simulation_v2.config import LocalSimulationConfig
+from simulation_v2.db.repositories import SimulationRepositories
+from simulation_v2.worker.turn_executor import execute_turn
+
+
+def execute_run(
+    run_id: str,
+    config: LocalSimulationConfig,
+    conn: sqlite3.Connection,
+    repos: SimulationRepositories,
+) -> None:
+    for turn_number in range(1, config.total_turns + 1):
+        execute_turn(run_id, turn_number, config, conn, repos)

--- a/simulation_v2/worker/service.py
+++ b/simulation_v2/worker/service.py
@@ -2,66 +2,16 @@
 
 from __future__ import annotations
 
-import sqlite3
 from pathlib import Path
 
 from simulation_v2.config import LocalSimulationConfig
 from simulation_v2.db.connection import transaction
 from simulation_v2.db.database import SimulationDatabase
 from simulation_v2.db.errors import RunNotFoundError
-from simulation_v2.db.models import TurnRecord
-from simulation_v2.db.repositories import SimulationRepositories
-from simulation_v2.ids import new_turn_id
 from simulation_v2.seed.loader import import_seed_if_needed
-from simulation_v2.time import get_current_timestamp
 from simulation_v2.worker.errors import RunNotRetryableError
 from simulation_v2.worker.models import RunJob
-
-
-def _execute_turn_stub() -> None:
-    """Placeholder for PR 6/7+ turn execution (feeds, actions, memory).
-
-    Seed import is handled before the turn loop in PR 5.
-    """
-    pass
-
-
-def _run_single_turn(
-    run_id: str,
-    turn_number: int,
-    conn: sqlite3.Connection,
-    repos: SimulationRepositories,
-) -> None:
-    existing = repos.get_turn_by_run_and_number(run_id, turn_number, conn)
-    if existing is not None and existing.status == "completed":
-        return
-
-    if existing is None:
-        turn = TurnRecord(
-            turn_id=new_turn_id(),
-            run_id=run_id,
-            turn_number=turn_number,
-            status="pending",
-            created_at=get_current_timestamp(),
-        )
-        repos.insert_turn(turn, conn)
-        turn_id = turn.turn_id
-    else:
-        turn_id = existing.turn_id
-
-    repos.update_turn_status(turn_id, "running", conn)
-    _execute_turn_stub()
-    repos.update_turn_status(turn_id, "completed", conn)
-
-
-def _run_turns_for_run(
-    run_id: str,
-    config: LocalSimulationConfig,
-    conn: sqlite3.Connection,
-    repos: SimulationRepositories,
-) -> None:
-    for turn_number in range(1, config.total_turns + 1):
-        _run_single_turn(run_id, turn_number, conn, repos)
+from simulation_v2.worker.run_executor import execute_run
 
 
 def run_job(job: RunJob, *, db_path: Path) -> None:
@@ -85,7 +35,7 @@ def run_job(job: RunJob, *, db_path: Path) -> None:
 
             config = LocalSimulationConfig.model_validate(run.config_json)
             import_seed_if_needed(job.run_id, config, repos, conn)
-            _run_turns_for_run(job.run_id, config, conn, repos)
+            execute_run(job.run_id, config, conn, repos)
             repos.update_run_status(job.run_id, "completed", conn)
     except (RunNotRetryableError, RunNotFoundError):
         raise

--- a/simulation_v2/worker/state.py
+++ b/simulation_v2/worker/state.py
@@ -1,0 +1,114 @@
+"""Turn snapshot loading from SQLite-backed run state."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from pydantic import BaseModel, Field
+
+from simulation_v2.config import LocalSimulationConfig
+from simulation_v2.db.errors import RunNotFoundError, TurnNotFoundError
+from simulation_v2.db.models import (
+    AgentMemoryRecord,
+    CommentRecord,
+    FollowRecord,
+    GeneratedFeedRecord,
+    LikeRecord,
+    MemoryDiffRecord,
+    PostRecord,
+    UserRecord,
+)
+from simulation_v2.db.repositories import SimulationRepositories
+
+
+class TurnStateSnapshot(BaseModel):
+    run_id: str
+    turn_id: str
+    turn_number: int
+    config: LocalSimulationConfig
+    users: dict[str, UserRecord]
+    posts: dict[str, PostRecord]
+    likes: list[LikeRecord]
+    follows: list[FollowRecord]
+    comments: list[CommentRecord]
+    agent_memories: dict[str, AgentMemoryRecord]
+    prior_generated_feeds: list[GeneratedFeedRecord]
+
+
+class PendingTurnDiffs(BaseModel):
+    posts: list[PostRecord] = Field(default_factory=list)
+    likes: list[LikeRecord] = Field(default_factory=list)
+    follows: list[FollowRecord] = Field(default_factory=list)
+    comments: list[CommentRecord] = Field(default_factory=list)
+    memory_diffs: list[MemoryDiffRecord] = Field(default_factory=list)
+
+
+def load_turn_snapshot(
+    run_id: str,
+    turn_id: str,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+) -> TurnStateSnapshot:
+    turn = repos.get_turn(turn_id, conn)
+    if turn is None:
+        raise TurnNotFoundError(turn_id)
+    if turn.run_id != run_id:
+        raise ValueError(
+            f"turn {turn_id!r} belongs to run {turn.run_id!r}, not {run_id!r}"
+        )
+
+    run = repos.get_run(run_id, conn)
+    if run is None:
+        raise RunNotFoundError(run_id)
+    config = LocalSimulationConfig.model_validate(run.config_json)
+
+    users = {user.user_id: user for user in repos.list_users_for_run(run_id, conn)}
+    all_posts = repos.list_posts_for_run(run_id, conn)
+    posts = {
+        post.post_id: post
+        for post in all_posts
+        if post.created_at_turn < turn.turn_number
+    }
+    likes = [
+        like
+        for like in repos.list_likes_for_run(run_id, conn)
+        if like.created_at_turn < turn.turn_number
+    ]
+    follows = [
+        follow
+        for follow in repos.list_follows_for_run(run_id, conn)
+        if follow.created_at_turn < turn.turn_number
+    ]
+    comments = [
+        comment
+        for comment in repos.list_comments_for_run(run_id, conn)
+        if comment.created_at_turn < turn.turn_number
+    ]
+    agent_memories = {
+        memory.user_id: memory
+        for memory in repos.list_agent_memories_for_run(run_id, conn)
+    }
+
+    turn_number_by_id = {
+        prior_turn.turn_id: prior_turn.turn_number
+        for prior_turn in repos.list_turns_for_run(run_id, conn)
+    }
+    prior_generated_feeds = [
+        feed
+        for feed in repos.list_generated_feeds_for_run(run_id, conn)
+        if turn_number_by_id.get(feed.turn_id, 0) < turn.turn_number
+    ]
+
+    return TurnStateSnapshot(
+        run_id=run_id,
+        turn_id=turn_id,
+        turn_number=turn.turn_number,
+        config=config,
+        users=users,
+        posts=posts,
+        likes=likes,
+        follows=follows,
+        comments=comments,
+        agent_memories=agent_memories,
+        prior_generated_feeds=prior_generated_feeds,
+    )

--- a/simulation_v2/worker/turn_executor.py
+++ b/simulation_v2/worker/turn_executor.py
@@ -1,0 +1,51 @@
+"""Single-turn execution: status transitions, snapshot load, stub body."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from simulation_v2.config import LocalSimulationConfig
+from simulation_v2.db.models import TurnRecord
+from simulation_v2.db.repositories import SimulationRepositories
+from simulation_v2.ids import new_turn_id
+from simulation_v2.time import get_current_timestamp
+from simulation_v2.worker.state import TurnStateSnapshot, load_turn_snapshot
+
+
+def _execute_turn_stub(_snapshot: TurnStateSnapshot) -> None:
+    """Placeholder for PR 7+ turn execution (feeds, actions, memory).
+
+    Snapshot loading is wired in PR 6; feed generation and LLM actions follow in PR 7+.
+    """
+    pass
+
+
+def execute_turn(
+    run_id: str,
+    turn_number: int,
+    _config: LocalSimulationConfig,
+    conn: sqlite3.Connection,
+    repos: SimulationRepositories,
+) -> TurnStateSnapshot | None:
+    existing = repos.get_turn_by_run_and_number(run_id, turn_number, conn)
+    if existing is not None and existing.status == "completed":
+        return None
+
+    if existing is None:
+        turn = TurnRecord(
+            turn_id=new_turn_id(),
+            run_id=run_id,
+            turn_number=turn_number,
+            status="pending",
+            created_at=get_current_timestamp(),
+        )
+        repos.insert_turn(turn, conn)
+        turn_id = turn.turn_id
+    else:
+        turn_id = existing.turn_id
+
+    repos.update_turn_status(turn_id, "running", conn)
+    snapshot = load_turn_snapshot(run_id, turn_id, repos, conn)
+    _execute_turn_stub(snapshot)
+    repos.update_turn_status(turn_id, "completed", conn)
+    return snapshot

--- a/tests/simulation_v2/db/test_repositories_snapshot_reads.py
+++ b/tests/simulation_v2/db/test_repositories_snapshot_reads.py
@@ -1,0 +1,87 @@
+"""Tests for run-scoped repository list helpers used by turn snapshots."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from tests.simulation_v2.db import factories
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "test.sqlite3"
+    SimulationDatabase(path).initialize()
+    return path
+
+
+class TestListEntitiesForRun:
+    def test_list_methods_return_inserted_records_for_run(self, db_path: Path) -> None:
+        run = factories.RunRecordFactory.create()
+        other_run = factories.RunRecordFactory.create()
+        user = factories.UserRecordFactory.create(run_id=run.run_id, user_id="u1")
+        post = factories.PostRecordFactory.create(
+            run_id=run.run_id, post_id="p1", author_id="u1", created_at_turn=0
+        )
+        like = factories.LikeRecordFactory.create(
+            run_id=run.run_id,
+            like_id="l1",
+            post_id="p1",
+            author_id="u1",
+            created_at_turn=0,
+        )
+        follow = factories.FollowRecordFactory.create(
+            run_id=run.run_id,
+            follow_id="f1",
+            follower_id="u1",
+            followee_id="u2",
+            created_at_turn=0,
+        )
+        comment = factories.CommentRecordFactory.create(
+            run_id=run.run_id,
+            comment_id="c1",
+            parent_post_id="p1",
+            author_id="u1",
+            created_at_turn=0,
+        )
+        memory = factories.AgentMemoryRecordFactory.create(
+            run_id=run.run_id, user_id="u1"
+        )
+        turn = factories.TurnRecordFactory.create(run_id=run.run_id, turn_number=1)
+        feed = factories.GeneratedFeedRecordFactory.create(
+            run_id=run.run_id, turn_id=turn.turn_id
+        )
+        other_user = factories.UserRecordFactory.create(run_id=other_run.run_id)
+
+        db = SimulationDatabase(db_path)
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            db.repos.insert_run(other_run, conn)
+            db.repos.insert_user(user, conn)
+            db.repos.insert_user(other_user, conn)
+            db.repos.insert_post(post, conn)
+            db.repos.insert_like(like, conn)
+            db.repos.insert_follow(follow, conn)
+            db.repos.insert_comment(comment, conn)
+            db.repos.insert_agent_memory(memory, conn)
+            db.repos.insert_turn(turn, conn)
+            db.repos.insert_generated_feed(feed, conn)
+
+            users = db.repos.list_users_for_run(run.run_id, conn)
+            posts = db.repos.list_posts_for_run(run.run_id, conn)
+            likes = db.repos.list_likes_for_run(run.run_id, conn)
+            follows = db.repos.list_follows_for_run(run.run_id, conn)
+            comments = db.repos.list_comments_for_run(run.run_id, conn)
+            memories = db.repos.list_agent_memories_for_run(run.run_id, conn)
+            feeds = db.repos.list_generated_feeds_for_run(run.run_id, conn)
+
+        assert users == [user]
+        assert posts == [post]
+        assert likes == [like]
+        assert follows == [follow]
+        assert comments == [comment]
+        assert memories == [memory]
+        assert feeds == [feed]

--- a/tests/simulation_v2/test_worker_service.py
+++ b/tests/simulation_v2/test_worker_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -154,3 +155,29 @@ class TestRunJob:
 
         assert loaded_run is not None
         assert loaded_run.status == "failed"
+
+    def test_run_job_loads_turn_snapshot_for_each_executed_turn(
+        self, db_path: Path
+    ) -> None:
+        config = _small_config(total_turns=2)
+        run = _queued_run(config)
+        db = SimulationDatabase(db_path)
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+
+        captured_turn_ids: list[str] = []
+
+        def _capture_snapshot(run_id: str, turn_id: str, repos, conn):  # noqa: ANN001
+            from simulation_v2.worker.state import load_turn_snapshot as real_loader
+
+            snapshot = real_loader(run_id, turn_id, repos, conn)
+            captured_turn_ids.append(turn_id)
+            return snapshot
+
+        with patch(
+            "simulation_v2.worker.turn_executor.load_turn_snapshot",
+            side_effect=_capture_snapshot,
+        ):
+            run_job(RunJob(run_id=run.run_id), db_path=db_path)
+
+        assert len(captured_turn_ids) == config.total_turns

--- a/tests/simulation_v2/worker/test_state.py
+++ b/tests/simulation_v2/worker/test_state.py
@@ -1,0 +1,180 @@
+"""Tests for turn snapshot loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from simulation_v2.config import LocalSimulationConfig
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from simulation_v2.models.seed_data import (
+    FollowModel,
+    LikeModel,
+    LoadedPostModel,
+    LoadedUserModel,
+)
+from simulation_v2.seed.loader import persist_seed_for_run
+from simulation_v2.seed.models import SeedDataset
+from simulation_v2.worker.state import load_turn_snapshot
+from tests.simulation_v2.db import factories
+
+FIXED_TS = "2026-01-01T00:00:00.000000+00:00"
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "test.sqlite3"
+    SimulationDatabase(path).initialize()
+    return path
+
+
+def _tiny_dataset() -> SeedDataset:
+    return SeedDataset(
+        users={
+            "u1": LoadedUserModel(
+                user_id="u1",
+                name="Alice",
+                email="a@example.com",
+                username="alice",
+                created_at=FIXED_TS,
+                num_followers=1,
+                num_follows=1,
+            ),
+            "u2": LoadedUserModel(
+                user_id="u2",
+                name="Bob",
+                email="b@example.com",
+                username="bob",
+                created_at=FIXED_TS,
+                num_followers=0,
+                num_follows=0,
+            ),
+        },
+        posts={
+            "p1": LoadedPostModel(
+                post_id="p1",
+                user_id="u1",
+                content="hello",
+                created_at=FIXED_TS,
+                num_likes=1,
+            ),
+            "p2": LoadedPostModel(
+                post_id="p2",
+                user_id="u2",
+                content="world",
+                created_at=FIXED_TS,
+                num_likes=0,
+            ),
+        },
+        likes={
+            "l1": LikeModel(
+                like_id="l1",
+                user_id="u2",
+                post_id="p1",
+                created_at=FIXED_TS,
+            ),
+        },
+        follows={
+            "u1:u2": FollowModel(follower_id="u1", followee_id="u2"),
+        },
+    )
+
+
+def _make_turn(*, run_id: str, turn_number: int):
+    return factories.TurnRecordFactory.create(
+        run_id=run_id,
+        turn_number=turn_number,
+        status="pending",
+    )
+
+
+class TestLoadTurnSnapshot:
+    def test_turn_one_snapshot_matches_seed_entities(self, db_path: Path) -> None:
+        config = LocalSimulationConfig.default()
+        run = factories.RunRecordFactory.create(
+            config_json=config.model_dump(mode="json"),
+            seed_metadata_json=None,
+        )
+        db = SimulationDatabase(db_path)
+        dataset = _tiny_dataset()
+
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            persist_seed_for_run(run.run_id, dataset, db.repos, conn)
+            turn = _make_turn(run_id=run.run_id, turn_number=1)
+            db.repos.insert_turn(turn, conn)
+            turn_id = turn.turn_id
+
+        with transaction(db_path) as conn:
+            snapshot = load_turn_snapshot(run.run_id, turn_id, db.repos, conn)
+
+        assert snapshot.run_id == run.run_id
+        assert snapshot.turn_id == turn_id
+        assert snapshot.turn_number == 1
+        assert len(snapshot.users) == 2
+        assert len(snapshot.posts) == 2
+        assert len(snapshot.likes) == 1
+        assert len(snapshot.follows) == 1
+        assert len(snapshot.agent_memories) == 2
+        assert snapshot.prior_generated_feeds == []
+
+    def test_turn_two_excludes_current_turn_entities(self, db_path: Path) -> None:
+        config = LocalSimulationConfig.default()
+        run = factories.RunRecordFactory.create(
+            config_json=config.model_dump(mode="json"),
+            seed_metadata_json=None,
+        )
+        db = SimulationDatabase(db_path)
+        dataset = _tiny_dataset()
+        turn_one_post = factories.PostRecordFactory.create(
+            run_id=run.run_id,
+            post_id="turn1-post",
+            author_id="u1",
+            created_at_turn=1,
+        )
+        turn_two_post = factories.PostRecordFactory.create(
+            run_id=run.run_id,
+            post_id="turn2-post",
+            author_id="u1",
+            created_at_turn=2,
+        )
+
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            persist_seed_for_run(run.run_id, dataset, db.repos, conn)
+            db.repos.insert_post(turn_one_post, conn)
+            db.repos.insert_post(turn_two_post, conn)
+            turn = _make_turn(run_id=run.run_id, turn_number=2)
+            db.repos.insert_turn(turn, conn)
+            turn_id = turn.turn_id
+
+        with transaction(db_path) as conn:
+            snapshot = load_turn_snapshot(run.run_id, turn_id, db.repos, conn)
+
+        post_ids = set(snapshot.posts)
+        assert "p1" in post_ids
+        assert "p2" in post_ids
+        assert "turn1-post" in post_ids
+        assert "turn2-post" not in post_ids
+
+    def test_agent_memories_include_one_record_per_user(self, db_path: Path) -> None:
+        config = LocalSimulationConfig.default()
+        run = factories.RunRecordFactory.create(
+            config_json=config.model_dump(mode="json"),
+            seed_metadata_json=None,
+        )
+        db = SimulationDatabase(db_path)
+
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            persist_seed_for_run(run.run_id, _tiny_dataset(), db.repos, conn)
+            turn = _make_turn(run_id=run.run_id, turn_number=1)
+            db.repos.insert_turn(turn, conn)
+            turn_id = turn.turn_id
+
+        with transaction(db_path) as conn:
+            snapshot = load_turn_snapshot(run.run_id, turn_id, db.repos, conn)
+
+        assert set(snapshot.agent_memories) == {"u1", "u2"}


### PR DESCRIPTION
## Overview

PR 6 replaces the in-memory `TurnInputsModel` concept with a durable, SQLite-backed **`TurnStateSnapshot`** loaded at the start of each turn. The worker reads cumulative run state (users, posts, likes, follows, comments, agent memories, and prior generated feeds) through repository methods only, exposes an in-memory **`PendingTurnDiffs`** container for later PRs, and wires snapshot loading into the turn execution path while keeping `_execute_turn_stub()` a no-op for feeds/LLM.

## Problem / motivation

Turn execution in PR 5 persists seed data but still runs a stub turn body with no access to cumulative SQLite state. PR 7 needs a typed snapshot of everything visible at the start of each turn (seed plus prior-turn diffs) before feed generation can run from persisted state.

## Solution

Add run-scoped repository list helpers, assemble `TurnStateSnapshot` in `worker/state.py`, and extract `run_executor` / `turn_executor` so every non-skipped turn loads a snapshot before the stub body.

## Happy Flow

1. `simulation_v2/worker/service.py` `run_job()` imports seed (PR 5), then calls `simulation_v2/worker/run_executor.py` `execute_run(...)`.
2. `execute_run()` loops `turn_number` 1..N, delegating each turn to `simulation_v2/worker/turn_executor.py` `execute_turn(...)`.
3. `execute_turn()` creates/skips turn rows and status transitions (existing PR 4 semantics preserved).
4. Before the stub body, `execute_turn()` calls `simulation_v2/worker/state.py` `load_turn_snapshot(run_id, turn_id, repos, conn)`.
5. `load_turn_snapshot()` resolves the turn via `repos.get_turn(turn_id)`, loads run config via `repos.get_run(run_id)`, bulk-reads entities via new `repos.list_*_for_run(...)` helpers, and filters cumulative social entities to `created_at_turn < turn_number`.
6. `execute_turn()` still calls `_execute_turn_stub()` (no feeds/LLM yet) and marks the turn completed.
7. PR 7+ will consume the returned `TurnStateSnapshot`; PR 10+ will populate `PendingTurnDiffs`.

## Changes

- `docs/plans/2026-05-26_simulation_v2_pr6_turn_snapshot_293847/contracts.md`: frozen symbols, filter rules, file-interaction invariants
- `simulation_v2/db/repositories.py`: seven `list_*_for_run` bulk-read helpers with deterministic ordering
- `simulation_v2/worker/state.py`: `TurnStateSnapshot`, `PendingTurnDiffs`, `load_turn_snapshot`
- `simulation_v2/worker/run_executor.py`: extracted turn loop (`execute_run`)
- `simulation_v2/worker/turn_executor.py`: extracted single-turn path; loads snapshot before stub
- `simulation_v2/worker/service.py`: slimmed to seed import + `execute_run`
- `simulation_v2/main.py`: docstring reflects snapshot loading (feeds/actions still stubbed)
- `tests/simulation_v2/db/test_repositories_snapshot_reads.py`: list helper round-trip tests
- `tests/simulation_v2/worker/test_state.py`: seed parity, prior-diff filtering, memory coverage
- `tests/simulation_v2/test_worker_service.py`: asserts snapshot loader invoked once per executed turn

## Manual Verification

- [x] `uv run pytest tests/simulation_v2/db/test_repositories_snapshot_reads.py tests/simulation_v2/worker/test_state.py tests/simulation_v2/test_worker_service.py -q` — 9 passed
- [x] `uv run pytest tests/simulation_v2/ -q` — 137 passed
- [x] `PYTHONPATH=. uv run python -c "from simulation_v2.main import main; main()"` — run completes with completed turns and seed row counts (direct `python simulation_v2/main.py` still hits pre-existing `lib` package shadowing when run as a script path)
- [x] `load_turn_snapshot` / `TurnStateSnapshot` / `PendingTurnDiffs` exist in `worker/state.py` and are referenced from `turn_executor`
- [x] no `SELECT` in `simulation_v2/worker/state.py` (repository-only reads)


Made with [Cursor](https://cursor.com)