### PR TITLE
(simulation_v2) PR 8 — action LLM generation persistence

### DIFF
--- a/docs/plans/2026-05-26_simulation_v2_pr8_actions_llm_847296/contracts.md
+++ b/docs/plans/2026-05-26_simulation_v2_pr8_actions_llm_847296/contracts.md
@@ -1,0 +1,46 @@
+# PR 8 Actions LLM — Contract Freeze
+
+| Symbol | Location | Contract |
+|--------|----------|----------|
+| `ActionType` | `simulation_v2/actions/models.py` | `Literal["like_post", "write_post", "follow_user", "comment_on_post"]` |
+| Structured outputs | `simulation_v2/actions/models.py` | `LlmLikePostOutput(post_ids)`, `LlmWritePostOutput(content)`, `LlmFollowUserOutput(user_ids)`, `LlmCommentOnPostOutput(parent_post_id, content)` |
+| `GenerationStatus` | `simulation_v2/actions/models.py` | `Literal["completed", "failed", "schema_failed"]` |
+| `LlmGenerationResult` | `simulation_v2/actions/models.py` | Pydantic model: `status`, `parsed`, `latency_ms`, token/cost fields, `error`, `raw_response_json` |
+| Prompts | `simulation_v2/actions/prompts.py` | `LIKE_POSTS_PROMPT`, `WRITE_POST_PROMPT`, `FOLLOW_USERS_PROMPT` ported from legacy; `COMMENT_ON_POST_PROMPT` added |
+| `get_chat_model` | `simulation_v2/actions/llm.py` | `(llm_config: LlmConfig) -> ChatOpenAI` using `lib.load_env_vars` |
+| `invoke_structured_generation` | `simulation_v2/actions/llm.py` | LangChain + tenacity + Opik wrapper; returns `LlmGenerationResult`; retries transient failures (max 3, exponential jitter) |
+| `generate_and_persist_llm_actions` | `simulation_v2/actions/service.py` | `(snapshot, feed_records, action_config, llm_config, repos, conn, *, trace_ctx=None) -> list[GenerationRecord]` |
+| `list_generations_for_turn` | `simulation_v2/db/repositories.py` | `(run_id, turn_id, conn) -> list[GenerationRecord]` |
+| `list_llm_proposed_actions_for_turn` | `simulation_v2/db/repositories.py` | `(run_id, turn_id, conn) -> list[LlmProposedActionRecord]` |
+| `execute_turn` (behavior change) | `simulation_v2/worker/turn_executor.py` | After feeds, call `generate_and_persist_llm_actions` |
+
+## Data-model invariants (frozen)
+
+- Structured LLM schemas live in `actions/models.py`; DB rows use `GenerationRecord` / `LlmProposedActionRecord` from `simulation_v2/db/models/actions.py`.
+- One `GenerationRecord` per enabled action invocation per user per turn (not per retry attempt).
+- `action_type` column uses frozen `ActionType` strings (`like_post`, not legacy `like_posts`).
+- `LlmProposedActionRecord` mapping:
+  - `like_post`: one row per `post_id` (`target_type="post"`, `target_id=post_id`)
+  - `write_post`: one row (`target_type="post"`, `target_content=content`)
+  - `follow_user`: one row per `user_id` (`target_type="user"`, `target_id=user_id`)
+  - `comment_on_post`: one row (`target_type="post"`, `target_id=parent_post_id`, `target_content=content`)
+- Schema failures: `status="schema_failed"`, `parsed_response_json=None`, `error` populated; still insert the generation row.
+- Provider failures after retries: `status="failed"`, `error` populated.
+
+## File-interaction invariants (frozen)
+
+| Owner | Allowed callers | Forbidden |
+|-------|-----------------|-----------|
+| `actions.llm` | `actions.service`, tests | Must not import repositories or write SQLite |
+| `actions.service` | `worker.turn_executor`, tests | Must not import LangChain/Opik/tenacity directly |
+| `actions.models`, `actions.prompts` | `actions.llm`, `actions.service`, tests | No DB access |
+| `worker.turn_executor` | `run_executor`, tests | Must not call LangChain or map LLM outputs directly |
+| Legacy `simulation_v2/agents/*` | unchanged until PR 15 | Do not modify in PR 8 |
+
+## Out of scope (explicit)
+
+- `actions/validators.py`, `actions/executor.py`, `actions/noise.py` (PRs 9–10)
+- `memory/service.py` — inline `_format_memory_for_prompt` in `actions/service.py`
+- Stochastic action filtering
+- `proposed_actions` table writes
+- Eval plugins

--- a/simulation_v2/actions/__init__.py
+++ b/simulation_v2/actions/__init__.py
@@ -1,0 +1,5 @@
+"""Action LLM generation pipeline for simulation_v2."""
+
+from simulation_v2.actions.service import generate_and_persist_llm_actions
+
+__all__ = ["generate_and_persist_llm_actions"]

--- a/simulation_v2/actions/llm.py
+++ b/simulation_v2/actions/llm.py
@@ -1,0 +1,239 @@
+"""LangChain LLM wrapper with retry, Opik telemetry, and structured output."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, TypeVar
+
+from langchain_core.callbacks.base import BaseCallbackHandler
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableConfig
+from langchain_openai import ChatOpenAI
+from openai import AuthenticationError, PermissionDeniedError
+from pydantic import BaseModel, SecretStr, ValidationError
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+from lib.load_env_vars import EnvVarsContainer
+from simulation_v2.actions.models import ActionType, LlmGenerationResult
+from simulation_v2.config import LlmConfig
+from simulation_v2.models.telemetry import ActionType as TelemetryActionType
+from simulation_v2.telemetry.context import SimulationTraceContext
+from simulation_v2.telemetry.llm_callback import LlmMetricsCallbackHandler
+from simulation_v2.telemetry.llm_collector import LlmCallRecord
+from simulation_v2.telemetry.opik import get_opik_tracer, is_opik_enabled
+
+LOGGER = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+_NON_RETRYABLE_EXCEPTIONS = (
+    AuthenticationError,
+    PermissionDeniedError,
+    ValueError,
+    TypeError,
+    ValidationError,
+)
+
+
+def _should_retry(exception: BaseException) -> bool:
+    return not isinstance(exception, _NON_RETRYABLE_EXCEPTIONS)
+
+
+def _telemetry_action_type(action_type: ActionType) -> TelemetryActionType:
+    mapping: dict[ActionType, TelemetryActionType] = {
+        "like_post": "like_posts",
+        "write_post": "write_post",
+        "follow_user": "follow_users",
+        "comment_on_post": "comment_on_post",
+    }
+    return mapping[action_type]
+
+
+def get_chat_model(llm_config: LlmConfig) -> ChatOpenAI:
+    api_key = SecretStr(EnvVarsContainer.get_env_var("OPENAI_API_KEY", required=True))
+    return ChatOpenAI(
+        model=llm_config.model,
+        temperature=llm_config.temperature,
+        api_key=api_key,
+    )
+
+
+def _record_llm_call(
+    *,
+    trace_ctx: SimulationTraceContext,
+    action_type: ActionType,
+    user_id: str,
+    latency_ms: float,
+    metrics_handler: LlmMetricsCallbackHandler | None,
+    success: bool,
+    error_type: str | None = None,
+) -> None:
+    metrics = metrics_handler.get_metrics() if metrics_handler else {}
+    trace_ctx.turn_llm_collector.add(
+        LlmCallRecord(
+            run_id=trace_ctx.run_id,
+            turn_number=trace_ctx.turn_number,
+            user_id=user_id,
+            action_type=_telemetry_action_type(action_type),
+            latency_ms=latency_ms,
+            cost_usd=metrics.get("cost_usd"),  # type: ignore[arg-type]
+            prompt_tokens=metrics.get("prompt_tokens"),  # type: ignore[arg-type]
+            completion_tokens=metrics.get("completion_tokens"),  # type: ignore[arg-type]
+            success=success,
+            error_type=error_type,
+        )
+    )
+
+
+def _build_callbacks(
+    *,
+    trace_ctx: SimulationTraceContext | None,
+    action_type: ActionType,
+    user_id: str,
+) -> tuple[list[BaseCallbackHandler], LlmMetricsCallbackHandler | None, bool]:
+    telemetry_enabled = (
+        trace_ctx is not None and trace_ctx.enabled and is_opik_enabled()
+    )
+    callbacks: list[BaseCallbackHandler] = []
+    metrics_handler: LlmMetricsCallbackHandler | None = None
+    if not telemetry_enabled or trace_ctx is None:
+        return callbacks, metrics_handler, False
+
+    try:
+        callbacks.append(
+            get_opik_tracer(
+                trace_ctx=trace_ctx,
+                action_type=_telemetry_action_type(action_type),
+                user_id=user_id,
+            )
+        )
+        metrics_handler = LlmMetricsCallbackHandler()
+        callbacks.append(metrics_handler)
+    except Exception:
+        LOGGER.warning("Failed to initialize Opik telemetry", exc_info=True)
+        return [], None, False
+
+    return callbacks, metrics_handler, True
+
+
+@retry(
+    stop=stop_after_attempt(4),
+    wait=wait_exponential_jitter(initial=1, max=60),
+    retry=retry_if_exception(_should_retry),
+    before_sleep=before_sleep_log(LOGGER, logging.WARNING),
+    reraise=True,
+)
+def _invoke_chain(
+    chain: Any,
+    prompt_variables: dict[str, object],
+    invoke_config: RunnableConfig | None,
+) -> BaseModel:
+    if invoke_config:
+        return chain.invoke(prompt_variables, config=invoke_config)
+    return chain.invoke(prompt_variables)
+
+
+def invoke_structured_generation(
+    prompt: ChatPromptTemplate,
+    output_model: type[T],
+    *,
+    llm_config: LlmConfig,
+    prompt_variables: dict[str, object],
+    action_type: ActionType,
+    user_id: str,
+    trace_ctx: SimulationTraceContext | None = None,
+) -> LlmGenerationResult:
+    """Invoke structured LLM generation with retries and optional Opik telemetry."""
+    llm = get_chat_model(llm_config)
+    structured_llm = llm.with_structured_output(output_model)
+    chain = prompt | structured_llm
+
+    callbacks, metrics_handler, telemetry_enabled = _build_callbacks(
+        trace_ctx=trace_ctx,
+        action_type=action_type,
+        user_id=user_id,
+    )
+    invoke_config: RunnableConfig | None = (
+        {"callbacks": callbacks} if callbacks else None
+    )
+
+    start_time = time.perf_counter()
+    try:
+        result = _invoke_chain(chain, prompt_variables, invoke_config)
+    except ValidationError as exc:
+        latency_ms = (time.perf_counter() - start_time) * 1000
+        return LlmGenerationResult(
+            status="schema_failed",
+            latency_ms=latency_ms,
+            error=str(exc),
+        )
+    except Exception as exc:
+        latency_ms = (time.perf_counter() - start_time) * 1000
+        if telemetry_enabled and trace_ctx is not None:
+            try:
+                _record_llm_call(
+                    trace_ctx=trace_ctx,
+                    action_type=action_type,
+                    user_id=user_id,
+                    latency_ms=latency_ms,
+                    metrics_handler=metrics_handler,
+                    success=False,
+                    error_type=type(exc).__name__,
+                )
+            except Exception:
+                LOGGER.warning(
+                    "Failed to record failed LLM call metrics", exc_info=True
+                )
+        return LlmGenerationResult(
+            status="failed",
+            latency_ms=latency_ms,
+            error=str(exc),
+        )
+
+    latency_ms = (time.perf_counter() - start_time) * 1000
+    if not isinstance(result, output_model):
+        return LlmGenerationResult(
+            status="schema_failed",
+            latency_ms=latency_ms,
+            error=(f"Expected {output_model.__name__}, got {type(result).__name__}"),
+            raw_response_json=_serialize_raw(result),
+        )
+
+    metrics = metrics_handler.get_metrics() if metrics_handler else {}
+    if telemetry_enabled and trace_ctx is not None:
+        try:
+            _record_llm_call(
+                trace_ctx=trace_ctx,
+                action_type=action_type,
+                user_id=user_id,
+                latency_ms=latency_ms,
+                metrics_handler=metrics_handler,
+                success=True,
+            )
+        except Exception:
+            LOGGER.warning("Failed to record LLM call metrics", exc_info=True)
+
+    return LlmGenerationResult(
+        status="completed",
+        parsed=result,
+        latency_ms=metrics.get("latency_ms", latency_ms),  # type: ignore[arg-type]
+        prompt_tokens=metrics.get("prompt_tokens"),  # type: ignore[arg-type]
+        completion_tokens=metrics.get("completion_tokens"),  # type: ignore[arg-type]
+        cost_usd=metrics.get("cost_usd"),  # type: ignore[arg-type]
+        raw_response_json=result.model_dump(),
+    )
+
+
+def _serialize_raw(result: object) -> dict[str, Any] | None:
+    if isinstance(result, BaseModel):
+        return result.model_dump()
+    if isinstance(result, dict):
+        return result
+    return None

--- a/simulation_v2/actions/models.py
+++ b/simulation_v2/actions/models.py
@@ -1,0 +1,38 @@
+"""Structured LLM output models and generation result types."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+ActionType = Literal["like_post", "write_post", "follow_user", "comment_on_post"]
+GenerationStatus = Literal["completed", "failed", "schema_failed"]
+
+
+class LlmLikePostOutput(BaseModel):
+    post_ids: list[str] = Field(default_factory=list)
+
+
+class LlmWritePostOutput(BaseModel):
+    content: str
+
+
+class LlmFollowUserOutput(BaseModel):
+    user_ids: list[str] = Field(default_factory=list)
+
+
+class LlmCommentOnPostOutput(BaseModel):
+    parent_post_id: str
+    content: str
+
+
+class LlmGenerationResult(BaseModel):
+    status: GenerationStatus
+    parsed: BaseModel | None = None
+    latency_ms: float | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    cost_usd: float | None = None
+    error: str | None = None
+    raw_response_json: dict[str, Any] | None = None

--- a/simulation_v2/actions/prompts.py
+++ b/simulation_v2/actions/prompts.py
@@ -1,0 +1,93 @@
+"""LangChain prompts for action LLM generation."""
+
+from langchain_core.prompts import ChatPromptTemplate
+
+LIKE_POSTS_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "You are a social media user deciding which posts in your feed to like. "
+            "Return only post IDs from the feed that you genuinely want to like. "
+            "Do not like your own posts. Prefer posts that match your interests.",
+        ),
+        (
+            "human",
+            "Your profile:\n"
+            "- Name: {name}\n"
+            "- Username: @{username}\n"
+            "- Followers: {num_followers}\n"
+            "- Following: {num_follows}\n\n"
+            "Your memory:\n"
+            "{memory}\n\n"
+            "Your feed (each line is post_id | author | likes | excerpt):\n"
+            "{feed_posts}\n\n"
+            "Select up to {max_likes} post IDs to like.",
+        ),
+    ]
+)
+
+WRITE_POST_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "You are a social media user writing a new post. "
+            "Write one short, authentic post inspired by your feed and profile.",
+        ),
+        (
+            "human",
+            "Your profile:\n"
+            "- Name: {name}\n"
+            "- Username: @{username}\n\n"
+            "Your memory:\n"
+            "{memory}\n\n"
+            "Your feed (each line is post_id | author | likes | excerpt):\n"
+            "{feed_posts}\n\n"
+            "Write one new post (1-3 sentences).",
+        ),
+    ]
+)
+
+FOLLOW_USERS_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "You are a social media user deciding who to follow. "
+            "Return user IDs from the candidate list that you want to follow. "
+            "Do not follow yourself.",
+        ),
+        (
+            "human",
+            "Your profile:\n"
+            "- Name: {name}\n"
+            "- Username: @{username}\n"
+            "- Followers: {num_followers}\n"
+            "- Following: {num_follows}\n\n"
+            "Your memory:\n"
+            "{memory}\n\n"
+            "Candidate users from your feed (user_id | username | name):\n"
+            "{candidate_users}\n\n"
+            "Select up to {max_follows} user IDs to follow.",
+        ),
+    ]
+)
+
+COMMENT_ON_POST_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "You are a social media user commenting on a post in your feed. "
+            "Pick one post from your feed and write a short, authentic reply.",
+        ),
+        (
+            "human",
+            "Your profile:\n"
+            "- Name: {name}\n"
+            "- Username: @{username}\n\n"
+            "Your memory:\n"
+            "{memory}\n\n"
+            "Your feed (each line is post_id | author | likes | excerpt):\n"
+            "{feed_posts}\n\n"
+            "Select one post_id from the feed as parent_post_id and write a brief comment.",
+        ),
+    ]
+)

--- a/simulation_v2/actions/service.py
+++ b/simulation_v2/actions/service.py
@@ -63,160 +63,275 @@ def generate_and_persist_llm_actions(
         memory_text = _format_memory_for_prompt(memory)
         num_followers, num_follows = _follow_counts(user)
 
-        if action_config.enable_like_post:
-            result = invoke_structured_generation(
-                LIKE_POSTS_PROMPT,
-                LlmLikePostOutput,
-                llm_config=llm_config,
-                prompt_variables={
-                    "name": user.name,
-                    "username": user.username,
-                    "num_followers": num_followers,
-                    "num_follows": num_follows,
-                    "memory": memory_text,
-                    "feed_posts": _format_feed_posts(feed_posts),
-                    "max_likes": action_config.max_likes_per_turn,
-                },
-                action_type="like_post",
+        _append_generation(
+            generation_records,
+            _generate_and_persist_likes(
+                snapshot=snapshot,
                 user_id=user_id,
-                trace_ctx=trace_ctx,
-            )
-            generation = _persist_generation(
-                snapshot,
-                user_id,
-                "like_post",
-                result,
-                repos,
-                conn,
-            )
-            generation_records.append(generation)
-            if result.status == "completed" and isinstance(
-                result.parsed, LlmLikePostOutput
-            ):
-                _persist_llm_proposed_actions(
-                    snapshot,
-                    user_id,
-                    "like_post",
-                    generation.generation_id,
-                    result.parsed.post_ids,
-                    repos,
-                    conn,
-                )
-
-        if action_config.enable_write_post:
-            result = invoke_structured_generation(
-                WRITE_POST_PROMPT,
-                LlmWritePostOutput,
+                user=user,
+                feed_posts=feed_posts,
+                memory_text=memory_text,
+                num_followers=num_followers,
+                num_follows=num_follows,
+                action_config=action_config,
                 llm_config=llm_config,
-                prompt_variables={
-                    "name": user.name,
-                    "username": user.username,
-                    "memory": memory_text,
-                    "feed_posts": _format_feed_posts(feed_posts),
-                },
-                action_type="write_post",
-                user_id=user_id,
+                repos=repos,
+                conn=conn,
                 trace_ctx=trace_ctx,
-            )
-            generation = _persist_generation(
-                snapshot,
-                user_id,
-                "write_post",
-                result,
-                repos,
-                conn,
-            )
-            generation_records.append(generation)
-            if result.status == "completed" and isinstance(
-                result.parsed, LlmWritePostOutput
-            ):
-                _persist_llm_proposed_actions_write(
-                    snapshot,
-                    user_id,
-                    generation.generation_id,
-                    result.parsed.content,
-                    repos,
-                    conn,
-                )
-
-        if action_config.enable_follow_user:
-            candidates = _candidate_users_from_feed(user_id, feed_posts, snapshot.users)
-            result = invoke_structured_generation(
-                FOLLOW_USERS_PROMPT,
-                LlmFollowUserOutput,
+            ),
+        )
+        _append_generation(
+            generation_records,
+            _generate_and_persist_write_post(
+                snapshot=snapshot,
+                user_id=user_id,
+                user=user,
+                feed_posts=feed_posts,
+                memory_text=memory_text,
+                action_config=action_config,
                 llm_config=llm_config,
-                prompt_variables={
-                    "name": user.name,
-                    "username": user.username,
-                    "num_followers": num_followers,
-                    "num_follows": num_follows,
-                    "memory": memory_text,
-                    "candidate_users": _format_candidate_users(candidates),
-                    "max_follows": action_config.max_follows_per_turn,
-                },
-                action_type="follow_user",
-                user_id=user_id,
+                repos=repos,
+                conn=conn,
                 trace_ctx=trace_ctx,
-            )
-            generation = _persist_generation(
-                snapshot,
-                user_id,
-                "follow_user",
-                result,
-                repos,
-                conn,
-            )
-            generation_records.append(generation)
-            if result.status == "completed" and isinstance(
-                result.parsed, LlmFollowUserOutput
-            ):
-                _persist_llm_proposed_actions_follow(
-                    snapshot,
-                    user_id,
-                    generation.generation_id,
-                    result.parsed.user_ids,
-                    repos,
-                    conn,
-                )
-
-        if action_config.enable_comment_on_post:
-            result = invoke_structured_generation(
-                COMMENT_ON_POST_PROMPT,
-                LlmCommentOnPostOutput,
+            ),
+        )
+        _append_generation(
+            generation_records,
+            _generate_and_persist_follows(
+                snapshot=snapshot,
+                user_id=user_id,
+                user=user,
+                feed_posts=feed_posts,
+                memory_text=memory_text,
+                num_followers=num_followers,
+                num_follows=num_follows,
+                action_config=action_config,
                 llm_config=llm_config,
-                prompt_variables={
-                    "name": user.name,
-                    "username": user.username,
-                    "memory": memory_text,
-                    "feed_posts": _format_feed_posts(feed_posts),
-                },
-                action_type="comment_on_post",
-                user_id=user_id,
+                repos=repos,
+                conn=conn,
                 trace_ctx=trace_ctx,
-            )
-            generation = _persist_generation(
-                snapshot,
-                user_id,
-                "comment_on_post",
-                result,
-                repos,
-                conn,
-            )
-            generation_records.append(generation)
-            if result.status == "completed" and isinstance(
-                result.parsed, LlmCommentOnPostOutput
-            ):
-                _persist_llm_proposed_actions_comment(
-                    snapshot,
-                    user_id,
-                    generation.generation_id,
-                    result.parsed.parent_post_id,
-                    result.parsed.content,
-                    repos,
-                    conn,
-                )
+            ),
+        )
+        _append_generation(
+            generation_records,
+            _generate_and_persist_comments(
+                snapshot=snapshot,
+                user_id=user_id,
+                user=user,
+                feed_posts=feed_posts,
+                memory_text=memory_text,
+                action_config=action_config,
+                llm_config=llm_config,
+                repos=repos,
+                conn=conn,
+                trace_ctx=trace_ctx,
+            ),
+        )
 
     return generation_records
+
+
+def _append_generation(
+    records: list[GenerationRecord],
+    record: GenerationRecord | None,
+) -> None:
+    if record is not None:
+        records.append(record)
+
+
+def _generate_and_persist_likes(
+    *,
+    snapshot: TurnStateSnapshot,
+    user_id: str,
+    user: UserRecord,
+    feed_posts: list[FeedPostView],
+    memory_text: str,
+    num_followers: int,
+    num_follows: int,
+    action_config: ActionConfig,
+    llm_config: LlmConfig,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+    trace_ctx: SimulationTraceContext | None = None,
+) -> GenerationRecord | None:
+    if not action_config.enable_like_post:
+        return None
+
+    result = invoke_structured_generation(
+        LIKE_POSTS_PROMPT,
+        LlmLikePostOutput,
+        llm_config=llm_config,
+        prompt_variables={
+            "name": user.name,
+            "username": user.username,
+            "num_followers": num_followers,
+            "num_follows": num_follows,
+            "memory": memory_text,
+            "feed_posts": _format_feed_posts(feed_posts),
+            "max_likes": action_config.max_likes_per_turn,
+        },
+        action_type="like_post",
+        user_id=user_id,
+        trace_ctx=trace_ctx,
+    )
+    generation = _persist_generation(
+        snapshot, user_id, "like_post", result, repos, conn
+    )
+    if result.status == "completed" and isinstance(result.parsed, LlmLikePostOutput):
+        _persist_llm_proposed_actions(
+            snapshot,
+            user_id,
+            "like_post",
+            generation.generation_id,
+            result.parsed.post_ids,
+            repos,
+            conn,
+        )
+    return generation
+
+
+def _generate_and_persist_write_post(
+    *,
+    snapshot: TurnStateSnapshot,
+    user_id: str,
+    user: UserRecord,
+    feed_posts: list[FeedPostView],
+    memory_text: str,
+    action_config: ActionConfig,
+    llm_config: LlmConfig,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+    trace_ctx: SimulationTraceContext | None = None,
+) -> GenerationRecord | None:
+    if not action_config.enable_write_post:
+        return None
+
+    result = invoke_structured_generation(
+        WRITE_POST_PROMPT,
+        LlmWritePostOutput,
+        llm_config=llm_config,
+        prompt_variables={
+            "name": user.name,
+            "username": user.username,
+            "memory": memory_text,
+            "feed_posts": _format_feed_posts(feed_posts),
+        },
+        action_type="write_post",
+        user_id=user_id,
+        trace_ctx=trace_ctx,
+    )
+    generation = _persist_generation(
+        snapshot, user_id, "write_post", result, repos, conn
+    )
+    if result.status == "completed" and isinstance(result.parsed, LlmWritePostOutput):
+        _persist_llm_proposed_actions_write(
+            snapshot,
+            user_id,
+            generation.generation_id,
+            result.parsed.content,
+            repos,
+            conn,
+        )
+    return generation
+
+
+def _generate_and_persist_follows(
+    *,
+    snapshot: TurnStateSnapshot,
+    user_id: str,
+    user: UserRecord,
+    feed_posts: list[FeedPostView],
+    memory_text: str,
+    num_followers: int,
+    num_follows: int,
+    action_config: ActionConfig,
+    llm_config: LlmConfig,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+    trace_ctx: SimulationTraceContext | None = None,
+) -> GenerationRecord | None:
+    if not action_config.enable_follow_user:
+        return None
+
+    candidates = _candidate_users_from_feed(user_id, feed_posts, snapshot.users)
+    result = invoke_structured_generation(
+        FOLLOW_USERS_PROMPT,
+        LlmFollowUserOutput,
+        llm_config=llm_config,
+        prompt_variables={
+            "name": user.name,
+            "username": user.username,
+            "num_followers": num_followers,
+            "num_follows": num_follows,
+            "memory": memory_text,
+            "candidate_users": _format_candidate_users(candidates),
+            "max_follows": action_config.max_follows_per_turn,
+        },
+        action_type="follow_user",
+        user_id=user_id,
+        trace_ctx=trace_ctx,
+    )
+    generation = _persist_generation(
+        snapshot, user_id, "follow_user", result, repos, conn
+    )
+    if result.status == "completed" and isinstance(result.parsed, LlmFollowUserOutput):
+        _persist_llm_proposed_actions_follow(
+            snapshot,
+            user_id,
+            generation.generation_id,
+            result.parsed.user_ids,
+            repos,
+            conn,
+        )
+    return generation
+
+
+def _generate_and_persist_comments(
+    *,
+    snapshot: TurnStateSnapshot,
+    user_id: str,
+    user: UserRecord,
+    feed_posts: list[FeedPostView],
+    memory_text: str,
+    action_config: ActionConfig,
+    llm_config: LlmConfig,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+    trace_ctx: SimulationTraceContext | None = None,
+) -> GenerationRecord | None:
+    if not action_config.enable_comment_on_post:
+        return None
+
+    result = invoke_structured_generation(
+        COMMENT_ON_POST_PROMPT,
+        LlmCommentOnPostOutput,
+        llm_config=llm_config,
+        prompt_variables={
+            "name": user.name,
+            "username": user.username,
+            "memory": memory_text,
+            "feed_posts": _format_feed_posts(feed_posts),
+        },
+        action_type="comment_on_post",
+        user_id=user_id,
+        trace_ctx=trace_ctx,
+    )
+    generation = _persist_generation(
+        snapshot, user_id, "comment_on_post", result, repos, conn
+    )
+    if result.status == "completed" and isinstance(
+        result.parsed, LlmCommentOnPostOutput
+    ):
+        _persist_llm_proposed_actions_comment(
+            snapshot,
+            user_id,
+            generation.generation_id,
+            result.parsed.parent_post_id,
+            result.parsed.content,
+            repos,
+            conn,
+        )
+    return generation
 
 
 def _format_feed_posts(feed_posts: list[FeedPostView]) -> str:

--- a/simulation_v2/actions/service.py
+++ b/simulation_v2/actions/service.py
@@ -1,0 +1,423 @@
+"""Action LLM generation orchestration and persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from simulation_v2.actions.llm import invoke_structured_generation
+from simulation_v2.actions.models import (
+    ActionType,
+    LlmCommentOnPostOutput,
+    LlmFollowUserOutput,
+    LlmGenerationResult,
+    LlmLikePostOutput,
+    LlmWritePostOutput,
+)
+from simulation_v2.actions.prompts import (
+    COMMENT_ON_POST_PROMPT,
+    FOLLOW_USERS_PROMPT,
+    LIKE_POSTS_PROMPT,
+    WRITE_POST_PROMPT,
+)
+from simulation_v2.config import ActionConfig, LlmConfig
+from simulation_v2.db.models import (
+    AgentMemoryRecord,
+    FeedPostView,
+    GeneratedFeedRecord,
+    GenerationRecord,
+    LlmProposedActionRecord,
+    UserRecord,
+)
+from simulation_v2.db.repositories import SimulationRepositories
+from simulation_v2.ids import new_generation_id, new_llm_proposed_action_id
+from simulation_v2.lib.decorators import progress_items
+from simulation_v2.telemetry.context import SimulationTraceContext
+from simulation_v2.time import get_current_timestamp
+from simulation_v2.worker.state import TurnStateSnapshot
+
+
+def generate_and_persist_llm_actions(
+    snapshot: TurnStateSnapshot,
+    feed_records: list[GeneratedFeedRecord],
+    action_config: ActionConfig,
+    llm_config: LlmConfig,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+    *,
+    trace_ctx: SimulationTraceContext | None = None,
+) -> list[GenerationRecord]:
+    feeds_by_user = {record.user_id: record.feed_posts for record in feed_records}
+    generation_records: list[GenerationRecord] = []
+    user_ids = list(snapshot.users.keys())
+
+    for user_id in progress_items(
+        user_ids,
+        desc=f"Turn {snapshot.turn_number} (actions)",
+        unit="user",
+        leave=False,
+    ):
+        user = snapshot.users[user_id]
+        feed_posts = feeds_by_user.get(user_id, [])
+        memory = snapshot.agent_memories.get(user_id)
+        memory_text = _format_memory_for_prompt(memory)
+        num_followers, num_follows = _follow_counts(user)
+
+        if action_config.enable_like_post:
+            result = invoke_structured_generation(
+                LIKE_POSTS_PROMPT,
+                LlmLikePostOutput,
+                llm_config=llm_config,
+                prompt_variables={
+                    "name": user.name,
+                    "username": user.username,
+                    "num_followers": num_followers,
+                    "num_follows": num_follows,
+                    "memory": memory_text,
+                    "feed_posts": _format_feed_posts(feed_posts),
+                    "max_likes": action_config.max_likes_per_turn,
+                },
+                action_type="like_post",
+                user_id=user_id,
+                trace_ctx=trace_ctx,
+            )
+            generation = _persist_generation(
+                snapshot,
+                user_id,
+                "like_post",
+                result,
+                repos,
+                conn,
+            )
+            generation_records.append(generation)
+            if result.status == "completed" and isinstance(
+                result.parsed, LlmLikePostOutput
+            ):
+                _persist_llm_proposed_actions(
+                    snapshot,
+                    user_id,
+                    "like_post",
+                    generation.generation_id,
+                    result.parsed.post_ids,
+                    repos,
+                    conn,
+                )
+
+        if action_config.enable_write_post:
+            result = invoke_structured_generation(
+                WRITE_POST_PROMPT,
+                LlmWritePostOutput,
+                llm_config=llm_config,
+                prompt_variables={
+                    "name": user.name,
+                    "username": user.username,
+                    "memory": memory_text,
+                    "feed_posts": _format_feed_posts(feed_posts),
+                },
+                action_type="write_post",
+                user_id=user_id,
+                trace_ctx=trace_ctx,
+            )
+            generation = _persist_generation(
+                snapshot,
+                user_id,
+                "write_post",
+                result,
+                repos,
+                conn,
+            )
+            generation_records.append(generation)
+            if result.status == "completed" and isinstance(
+                result.parsed, LlmWritePostOutput
+            ):
+                _persist_llm_proposed_actions_write(
+                    snapshot,
+                    user_id,
+                    generation.generation_id,
+                    result.parsed.content,
+                    repos,
+                    conn,
+                )
+
+        if action_config.enable_follow_user:
+            candidates = _candidate_users_from_feed(user_id, feed_posts, snapshot.users)
+            result = invoke_structured_generation(
+                FOLLOW_USERS_PROMPT,
+                LlmFollowUserOutput,
+                llm_config=llm_config,
+                prompt_variables={
+                    "name": user.name,
+                    "username": user.username,
+                    "num_followers": num_followers,
+                    "num_follows": num_follows,
+                    "memory": memory_text,
+                    "candidate_users": _format_candidate_users(candidates),
+                    "max_follows": action_config.max_follows_per_turn,
+                },
+                action_type="follow_user",
+                user_id=user_id,
+                trace_ctx=trace_ctx,
+            )
+            generation = _persist_generation(
+                snapshot,
+                user_id,
+                "follow_user",
+                result,
+                repos,
+                conn,
+            )
+            generation_records.append(generation)
+            if result.status == "completed" and isinstance(
+                result.parsed, LlmFollowUserOutput
+            ):
+                _persist_llm_proposed_actions_follow(
+                    snapshot,
+                    user_id,
+                    generation.generation_id,
+                    result.parsed.user_ids,
+                    repos,
+                    conn,
+                )
+
+        if action_config.enable_comment_on_post:
+            result = invoke_structured_generation(
+                COMMENT_ON_POST_PROMPT,
+                LlmCommentOnPostOutput,
+                llm_config=llm_config,
+                prompt_variables={
+                    "name": user.name,
+                    "username": user.username,
+                    "memory": memory_text,
+                    "feed_posts": _format_feed_posts(feed_posts),
+                },
+                action_type="comment_on_post",
+                user_id=user_id,
+                trace_ctx=trace_ctx,
+            )
+            generation = _persist_generation(
+                snapshot,
+                user_id,
+                "comment_on_post",
+                result,
+                repos,
+                conn,
+            )
+            generation_records.append(generation)
+            if result.status == "completed" and isinstance(
+                result.parsed, LlmCommentOnPostOutput
+            ):
+                _persist_llm_proposed_actions_comment(
+                    snapshot,
+                    user_id,
+                    generation.generation_id,
+                    result.parsed.parent_post_id,
+                    result.parsed.content,
+                    repos,
+                    conn,
+                )
+
+    return generation_records
+
+
+def _format_feed_posts(feed_posts: list[FeedPostView]) -> str:
+    lines: list[str] = []
+    for post in feed_posts:
+        excerpt = post.content[:120]
+        num_likes = post.metadata.get("num_likes", 0)
+        lines.append(
+            f"{post.post_id} | {post.author_id} | {num_likes} likes | {excerpt}"
+        )
+    return "\n".join(lines) if lines else "No posts in feed."
+
+
+def _format_candidate_users(users: list[UserRecord]) -> str:
+    lines: list[str] = []
+    for user in users:
+        lines.append(f"{user.user_id} | @{user.username} | {user.name}")
+    return "\n".join(lines) if lines else "No candidate users."
+
+
+def _format_memory_for_prompt(memory: AgentMemoryRecord | None) -> str:
+    episodic = memory.episodic if memory is not None else ""
+    personalized = memory.personalized if memory is not None else ""
+    social = memory.social if memory is not None else ""
+    return f"""
+
+    Episodic memory: experiences you've had recently
+    ```markdown
+    {episodic or ""}
+    ```
+
+    Personalized profile memory: A list of the agent's interests, liked/disliked topics, posting style, favorite accounts, political/technical/social tendencies and recent mood.
+
+    ```markdown
+    {personalized or ""}
+    ```
+
+    Social relationships memory: What the agent thinks about other users in the network.
+
+    ```markdown
+    {social or ""}
+    ```
+    """
+
+
+def _follow_counts(user: UserRecord) -> tuple[int, int]:
+    profile = user.profile_json or {}
+    return (
+        int(profile.get("num_followers", 0)),
+        int(profile.get("num_follows", 0)),
+    )
+
+
+def _candidate_users_from_feed(
+    user_id: str,
+    feed_posts: list[FeedPostView],
+    users: dict[str, UserRecord],
+) -> list[UserRecord]:
+    seen: set[str] = set()
+    candidates: list[UserRecord] = []
+    for post in feed_posts:
+        author_id = post.author_id
+        if author_id == user_id or author_id in seen:
+            continue
+        seen.add(author_id)
+        author = users.get(author_id)
+        if author is not None:
+            candidates.append(author)
+    return candidates
+
+
+def _persist_generation(
+    snapshot: TurnStateSnapshot,
+    user_id: str,
+    action_type: ActionType,
+    result: LlmGenerationResult,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+) -> GenerationRecord:
+    parsed_json: dict[str, Any] | None = None
+    if result.status == "completed" and result.parsed is not None:
+        parsed_json = result.parsed.model_dump()
+
+    record = GenerationRecord(
+        generation_id=new_generation_id(),
+        run_id=snapshot.run_id,
+        turn_id=snapshot.turn_id,
+        user_id=user_id,
+        action_type=action_type,
+        parsed_response_json=parsed_json,
+        raw_response_json=result.raw_response_json,
+        status=result.status,
+        latency_ms=result.latency_ms,
+        prompt_tokens=result.prompt_tokens,
+        completion_tokens=result.completion_tokens,
+        cost_usd=result.cost_usd,
+        created_at=get_current_timestamp(),
+        error=result.error,
+    )
+    repos.insert_generation(record, conn)
+    return record
+
+
+def _persist_llm_proposed_actions(
+    snapshot: TurnStateSnapshot,
+    user_id: str,
+    action_type: ActionType,
+    generation_id: str,
+    post_ids: list[str],
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+) -> None:
+    created_at = get_current_timestamp()
+    for post_id in post_ids:
+        repos.insert_llm_proposed_action(
+            LlmProposedActionRecord(
+                llm_proposed_action_id=new_llm_proposed_action_id(),
+                generation_id=generation_id,
+                run_id=snapshot.run_id,
+                turn_id=snapshot.turn_id,
+                user_id=user_id,
+                action_type=action_type,
+                target_type="post",
+                target_id=post_id,
+                created_at=created_at,
+            ),
+            conn,
+        )
+
+
+def _persist_llm_proposed_actions_write(
+    snapshot: TurnStateSnapshot,
+    user_id: str,
+    generation_id: str,
+    content: str,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+) -> None:
+    repos.insert_llm_proposed_action(
+        LlmProposedActionRecord(
+            llm_proposed_action_id=new_llm_proposed_action_id(),
+            generation_id=generation_id,
+            run_id=snapshot.run_id,
+            turn_id=snapshot.turn_id,
+            user_id=user_id,
+            action_type="write_post",
+            target_type="post",
+            target_content=content,
+            created_at=get_current_timestamp(),
+        ),
+        conn,
+    )
+
+
+def _persist_llm_proposed_actions_follow(
+    snapshot: TurnStateSnapshot,
+    user_id: str,
+    generation_id: str,
+    followee_ids: list[str],
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+) -> None:
+    created_at = get_current_timestamp()
+    for followee_id in followee_ids:
+        repos.insert_llm_proposed_action(
+            LlmProposedActionRecord(
+                llm_proposed_action_id=new_llm_proposed_action_id(),
+                generation_id=generation_id,
+                run_id=snapshot.run_id,
+                turn_id=snapshot.turn_id,
+                user_id=user_id,
+                action_type="follow_user",
+                target_type="user",
+                target_id=followee_id,
+                created_at=created_at,
+            ),
+            conn,
+        )
+
+
+def _persist_llm_proposed_actions_comment(
+    snapshot: TurnStateSnapshot,
+    user_id: str,
+    generation_id: str,
+    parent_post_id: str,
+    content: str,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+) -> None:
+    repos.insert_llm_proposed_action(
+        LlmProposedActionRecord(
+            llm_proposed_action_id=new_llm_proposed_action_id(),
+            generation_id=generation_id,
+            run_id=snapshot.run_id,
+            turn_id=snapshot.turn_id,
+            user_id=user_id,
+            action_type="comment_on_post",
+            target_type="post",
+            target_id=parent_post_id,
+            target_content=content,
+            created_at=get_current_timestamp(),
+        ),
+        conn,
+    )

--- a/simulation_v2/db/repositories.py
+++ b/simulation_v2/db/repositories.py
@@ -838,6 +838,37 @@ class SimulationRepositories:
             error=row["error"],
         )
 
+    def list_generations_for_turn(
+        self, run_id: str, turn_id: str, conn: sqlite3.Connection
+    ) -> list[GenerationRecord]:
+        rows = conn.execute(
+            """
+            SELECT * FROM generations
+            WHERE run_id = ? AND turn_id = ?
+            ORDER BY created_at
+            """,
+            (run_id, turn_id),
+        ).fetchall()
+        return [
+            GenerationRecord(
+                generation_id=row["generation_id"],
+                run_id=row["run_id"],
+                turn_id=row["turn_id"],
+                user_id=row["user_id"],
+                action_type=row["action_type"],
+                parsed_response_json=_loads_json(row["parsed_response_json"]),
+                raw_response_json=_loads_json(row["raw_response_json"]),
+                status=row["status"],
+                latency_ms=row["latency_ms"],
+                prompt_tokens=row["prompt_tokens"],
+                completion_tokens=row["completion_tokens"],
+                cost_usd=row["cost_usd"],
+                created_at=row["created_at"],
+                error=row["error"],
+            )
+            for row in rows
+        ]
+
     def insert_llm_proposed_action(
         self, record: LlmProposedActionRecord, conn: sqlite3.Connection
     ) -> None:
@@ -886,6 +917,34 @@ class SimulationRepositories:
             metadata_json=_loads_json(row["metadata_json"]),
             created_at=row["created_at"],
         )
+
+    def list_llm_proposed_actions_for_turn(
+        self, run_id: str, turn_id: str, conn: sqlite3.Connection
+    ) -> list[LlmProposedActionRecord]:
+        rows = conn.execute(
+            """
+            SELECT * FROM llm_proposed_actions
+            WHERE run_id = ? AND turn_id = ?
+            ORDER BY created_at
+            """,
+            (run_id, turn_id),
+        ).fetchall()
+        return [
+            LlmProposedActionRecord(
+                llm_proposed_action_id=row["llm_proposed_action_id"],
+                generation_id=row["generation_id"],
+                run_id=row["run_id"],
+                turn_id=row["turn_id"],
+                user_id=row["user_id"],
+                action_type=row["action_type"],
+                target_type=row["target_type"],
+                target_id=row["target_id"],
+                target_content=row["target_content"],
+                metadata_json=_loads_json(row["metadata_json"]),
+                created_at=row["created_at"],
+            )
+            for row in rows
+        ]
 
     def insert_proposed_action(
         self, record: ProposedActionRecord, conn: sqlite3.Connection

--- a/simulation_v2/models/telemetry.py
+++ b/simulation_v2/models/telemetry.py
@@ -6,7 +6,12 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-ActionType = Literal["like_posts", "write_post", "follow_users"]
+ActionType = Literal[
+    "like_posts",
+    "write_post",
+    "follow_users",
+    "comment_on_post",
+]
 
 
 class LatencyPercentiles(BaseModel):

--- a/simulation_v2/telemetry/llm_collector.py
+++ b/simulation_v2/telemetry/llm_collector.py
@@ -12,7 +12,12 @@ from simulation_v2.models.telemetry import (
     TurnLlmMetricsSummary,
 )
 
-_ACTION_TYPES: tuple[ActionType, ...] = ("like_posts", "write_post", "follow_users")
+_ACTION_TYPES: tuple[ActionType, ...] = (
+    "like_posts",
+    "write_post",
+    "follow_users",
+    "comment_on_post",
+)
 
 
 @dataclass

--- a/simulation_v2/worker/run_executor.py
+++ b/simulation_v2/worker/run_executor.py
@@ -6,6 +6,7 @@ import sqlite3
 
 from simulation_v2.config import LocalSimulationConfig
 from simulation_v2.db.repositories import SimulationRepositories
+from simulation_v2.telemetry.opik import configure_opik
 from simulation_v2.worker.turn_executor import execute_turn
 
 
@@ -15,5 +16,6 @@ def execute_run(
     conn: sqlite3.Connection,
     repos: SimulationRepositories,
 ) -> None:
+    configure_opik()
     for turn_number in range(1, config.total_turns + 1):
         execute_turn(run_id, turn_number, config, conn, repos)

--- a/simulation_v2/worker/turn_executor.py
+++ b/simulation_v2/worker/turn_executor.py
@@ -1,14 +1,16 @@
-"""Single-turn execution: status transitions, snapshot load, feed generation."""
+"""Single-turn execution: status transitions, snapshot load, feed and action generation."""
 
 from __future__ import annotations
 
 import sqlite3
 
+from simulation_v2.actions.service import generate_and_persist_llm_actions
 from simulation_v2.config import LocalSimulationConfig
 from simulation_v2.db.models import TurnRecord
 from simulation_v2.db.repositories import SimulationRepositories
 from simulation_v2.feeds.service import generate_and_persist_feeds
 from simulation_v2.ids import new_turn_id
+from simulation_v2.telemetry.context import SimulationTraceContext
 from simulation_v2.time import get_current_timestamp
 from simulation_v2.worker.state import TurnStateSnapshot, load_turn_snapshot
 
@@ -39,6 +41,21 @@ def execute_turn(
 
     repos.update_turn_status(turn_id, "running", conn)
     snapshot = load_turn_snapshot(run_id, turn_id, repos, conn)
-    generate_and_persist_feeds(snapshot, snapshot.config.feed, repos, conn)
+    feed_records = generate_and_persist_feeds(
+        snapshot, snapshot.config.feed, repos, conn
+    )
+    trace_ctx = SimulationTraceContext(
+        run_id=run_id,
+        turn_number=snapshot.turn_number,
+    )
+    generate_and_persist_llm_actions(
+        snapshot,
+        feed_records,
+        snapshot.config.action,
+        snapshot.config.llm,
+        repos,
+        conn,
+        trace_ctx=trace_ctx,
+    )
     repos.update_turn_status(turn_id, "completed", conn)
     return snapshot

--- a/tests/simulation_v2/actions/test_action_service.py
+++ b/tests/simulation_v2/actions/test_action_service.py
@@ -1,0 +1,217 @@
+"""Integration tests for action LLM generation persistence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from simulation_v2.actions.models import LlmGenerationResult, LlmLikePostOutput
+from simulation_v2.actions.service import generate_and_persist_llm_actions
+from simulation_v2.config import ActionConfig, FeedConfig, LocalSimulationConfig
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from simulation_v2.feeds.service import generate_and_persist_feeds
+from simulation_v2.models.seed_data import LoadedPostModel, LoadedUserModel
+from simulation_v2.seed.loader import persist_seed_for_run
+from simulation_v2.seed.models import SeedDataset
+from simulation_v2.worker.state import load_turn_snapshot
+from tests.simulation_v2.db import factories
+
+FIXED_TS = "2026-01-01T00:00:00.000000+00:00"
+
+
+def _tiny_dataset() -> SeedDataset:
+    return SeedDataset(
+        users={
+            "u1": LoadedUserModel(
+                user_id="u1",
+                name="Alice",
+                email="a@example.com",
+                username="alice",
+                created_at=FIXED_TS,
+                num_followers=0,
+                num_follows=0,
+            ),
+            "u2": LoadedUserModel(
+                user_id="u2",
+                name="Bob",
+                email="b@example.com",
+                username="bob",
+                created_at=FIXED_TS,
+                num_followers=0,
+                num_follows=0,
+            ),
+        },
+        posts={
+            "p1": LoadedPostModel(
+                post_id="p1",
+                user_id="u1",
+                content="hello",
+                created_at=FIXED_TS,
+                num_likes=1,
+            ),
+            "p2": LoadedPostModel(
+                post_id="p2",
+                user_id="u2",
+                content="world",
+                created_at=FIXED_TS,
+                num_likes=0,
+            ),
+        },
+        likes={},
+        follows={},
+    )
+
+
+class TestGenerateAndPersistLlmActions:
+    def test_persists_generation_and_llm_proposed_actions(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "test.sqlite3"
+        db = SimulationDatabase(db_path)
+        db.initialize()
+        config = LocalSimulationConfig.default().model_copy(
+            update={
+                "feed": FeedConfig(include_probability=1.0, max_posts=10),
+                "action": ActionConfig(
+                    enable_like_post=True,
+                    enable_write_post=False,
+                    enable_follow_user=False,
+                    enable_comment_on_post=False,
+                ),
+            }
+        )
+        run = factories.RunRecordFactory.create(
+            config_json=config.model_dump(mode="json"),
+            seed_metadata_json=None,
+        )
+        dataset = _tiny_dataset()
+
+        mock_result = LlmGenerationResult(
+            status="completed",
+            parsed=LlmLikePostOutput(post_ids=["p2"]),
+            latency_ms=12.5,
+            prompt_tokens=10,
+            completion_tokens=5,
+            raw_response_json={"post_ids": ["p2"]},
+        )
+
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            persist_seed_for_run(run.run_id, dataset, db.repos, conn)
+            turn = factories.TurnRecordFactory.create(
+                run_id=run.run_id,
+                turn_number=1,
+                status="pending",
+            )
+            db.repos.insert_turn(turn, conn)
+            snapshot = load_turn_snapshot(run.run_id, turn.turn_id, db.repos, conn)
+            feed_records = generate_and_persist_feeds(
+                snapshot,
+                config.feed,
+                db.repos,
+                conn,
+            )
+
+            with patch(
+                "simulation_v2.actions.service.invoke_structured_generation",
+                return_value=mock_result,
+            ) as mock_invoke:
+                generations = generate_and_persist_llm_actions(
+                    snapshot,
+                    feed_records,
+                    config.action,
+                    config.llm,
+                    db.repos,
+                    conn,
+                )
+
+        assert mock_invoke.call_count == 2
+        assert len(generations) == 2
+        assert all(gen.status == "completed" for gen in generations)
+        assert all(gen.action_type == "like_post" for gen in generations)
+
+        with transaction(db_path) as conn:
+            loaded_generations = db.repos.list_generations_for_turn(
+                run.run_id, turn.turn_id, conn
+            )
+            loaded_actions = db.repos.list_llm_proposed_actions_for_turn(
+                run.run_id, turn.turn_id, conn
+            )
+
+        assert len(loaded_generations) == 2
+        assert len(loaded_actions) == 2
+        assert {action.generation_id for action in loaded_actions} == {
+            gen.generation_id for gen in loaded_generations
+        }
+        assert all(action.action_type == "like_post" for action in loaded_actions)
+        assert all(action.target_id == "p2" for action in loaded_actions)
+
+    def test_persists_failed_generation_without_proposed_actions(
+        self, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "test.sqlite3"
+        db = SimulationDatabase(db_path)
+        db.initialize()
+        config = LocalSimulationConfig.default().model_copy(
+            update={
+                "feed": FeedConfig(include_probability=1.0, max_posts=10),
+                "action": ActionConfig(
+                    enable_like_post=True,
+                    enable_write_post=False,
+                    enable_follow_user=False,
+                    enable_comment_on_post=False,
+                ),
+            }
+        )
+        run = factories.RunRecordFactory.create(
+            config_json=config.model_dump(mode="json"),
+            seed_metadata_json=None,
+        )
+        dataset = _tiny_dataset()
+
+        failed_result = LlmGenerationResult(
+            status="failed",
+            error="provider down",
+            latency_ms=1.0,
+        )
+
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            persist_seed_for_run(run.run_id, dataset, db.repos, conn)
+            turn = factories.TurnRecordFactory.create(
+                run_id=run.run_id,
+                turn_number=1,
+                status="pending",
+            )
+            db.repos.insert_turn(turn, conn)
+            snapshot = load_turn_snapshot(run.run_id, turn.turn_id, db.repos, conn)
+            feed_records = generate_and_persist_feeds(
+                snapshot,
+                config.feed,
+                db.repos,
+                conn,
+            )
+
+            with patch(
+                "simulation_v2.actions.service.invoke_structured_generation",
+                return_value=failed_result,
+            ):
+                generate_and_persist_llm_actions(
+                    snapshot,
+                    feed_records,
+                    config.action,
+                    config.llm,
+                    db.repos,
+                    conn,
+                )
+
+        with transaction(db_path) as conn:
+            loaded_generations = db.repos.list_generations_for_turn(
+                run.run_id, turn.turn_id, conn
+            )
+            loaded_actions = db.repos.list_llm_proposed_actions_for_turn(
+                run.run_id, turn.turn_id, conn
+            )
+
+        assert len(loaded_generations) == 2
+        assert all(gen.status == "failed" for gen in loaded_generations)
+        assert loaded_actions == []

--- a/tests/simulation_v2/actions/test_llm.py
+++ b/tests/simulation_v2/actions/test_llm.py
@@ -1,0 +1,180 @@
+"""Unit tests for actions.llm structured generation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import ValidationError
+
+from simulation_v2.actions.llm import invoke_structured_generation
+from simulation_v2.actions.models import (
+    ActionType,
+    LlmGenerationResult,
+    LlmLikePostOutput,
+    LlmWritePostOutput,
+)
+from simulation_v2.actions.prompts import LIKE_POSTS_PROMPT, WRITE_POST_PROMPT
+from simulation_v2.config import LlmConfig
+from simulation_v2.telemetry.context import SimulationTraceContext
+
+
+@pytest.fixture
+def llm_config() -> LlmConfig:
+    return LlmConfig(model="gpt-5-nano", temperature=0.0)
+
+
+@pytest.fixture
+def trace_ctx() -> SimulationTraceContext:
+    return SimulationTraceContext(run_id="run-1", turn_number=1)
+
+
+def _invoke_with_mock_chain(
+    *,
+    prompt: ChatPromptTemplate,
+    output_model: type,
+    llm_config: LlmConfig,
+    side_effect: object,
+    action_type: ActionType = "like_post",
+    trace_ctx: SimulationTraceContext | None = None,
+) -> LlmGenerationResult:
+    mock_llm = MagicMock()
+    mock_chain = MagicMock()
+    mock_chain.invoke = MagicMock(side_effect=side_effect)
+
+    with (
+        patch("simulation_v2.actions.llm.get_chat_model", return_value=mock_llm),
+        patch.object(ChatPromptTemplate, "__or__", return_value=mock_chain),
+    ):
+        return invoke_structured_generation(
+            prompt,
+            output_model,
+            llm_config=llm_config,
+            prompt_variables={"name": "Alice"},
+            action_type=action_type,
+            user_id="u1",
+            trace_ctx=trace_ctx,
+        )
+
+
+class TestInvokeStructuredGeneration:
+    def test_success_returns_completed_result(self, llm_config: LlmConfig) -> None:
+        parsed = LlmLikePostOutput(post_ids=["p1"])
+        result = _invoke_with_mock_chain(
+            prompt=LIKE_POSTS_PROMPT,
+            output_model=LlmLikePostOutput,
+            llm_config=llm_config,
+            side_effect=[parsed],
+        )
+
+        assert result.status == "completed"
+        assert isinstance(result.parsed, LlmLikePostOutput)
+        assert result.parsed.post_ids == ["p1"]
+        assert result.latency_ms is not None
+        assert result.error is None
+
+    def test_retryable_failure_then_succeeds(self, llm_config: LlmConfig) -> None:
+        parsed = LlmWritePostOutput(content="hello")
+        mock_llm = MagicMock()
+        mock_chain = MagicMock()
+        mock_chain.invoke = MagicMock(
+            side_effect=[TimeoutError("timeout"), TimeoutError("timeout"), parsed]
+        )
+
+        with (
+            patch("simulation_v2.actions.llm.get_chat_model", return_value=mock_llm),
+            patch.object(ChatPromptTemplate, "__or__", return_value=mock_chain),
+        ):
+            result = invoke_structured_generation(
+                WRITE_POST_PROMPT,
+                LlmWritePostOutput,
+                llm_config=llm_config,
+                prompt_variables={"name": "Alice"},
+                action_type="write_post",
+                user_id="u1",
+            )
+
+        assert result.status == "completed"
+        assert mock_chain.invoke.call_count == 3
+
+    def test_retryable_failure_exhausted(self, llm_config: LlmConfig) -> None:
+        mock_llm = MagicMock()
+        mock_chain = MagicMock()
+        mock_chain.invoke = MagicMock(side_effect=TimeoutError("timeout"))
+
+        with (
+            patch("simulation_v2.actions.llm.get_chat_model", return_value=mock_llm),
+            patch.object(ChatPromptTemplate, "__or__", return_value=mock_chain),
+        ):
+            result = invoke_structured_generation(
+                WRITE_POST_PROMPT,
+                LlmWritePostOutput,
+                llm_config=llm_config,
+                prompt_variables={"name": "Alice"},
+                action_type="write_post",
+                user_id="u1",
+            )
+
+        assert result.status == "failed"
+        assert result.error is not None
+        assert mock_chain.invoke.call_count == 4
+
+    def test_schema_failure_wrong_shape(self, llm_config: LlmConfig) -> None:
+        result = _invoke_with_mock_chain(
+            prompt=LIKE_POSTS_PROMPT,
+            output_model=LlmLikePostOutput,
+            llm_config=llm_config,
+            side_effect=[{"unexpected": "shape"}],
+        )
+
+        assert result.status == "schema_failed"
+        assert result.parsed is None
+        assert result.error is not None
+
+    def test_schema_failure_validation_error(self, llm_config: LlmConfig) -> None:
+        validation_error = ValidationError.from_exception_data(
+            "LlmLikePostOutput",
+            [{"type": "missing", "loc": ("post_ids",), "input": {}}],
+        )
+        result = _invoke_with_mock_chain(
+            prompt=LIKE_POSTS_PROMPT,
+            output_model=LlmLikePostOutput,
+            llm_config=llm_config,
+            side_effect=[validation_error],
+        )
+
+        assert result.status == "schema_failed"
+
+    @patch("simulation_v2.actions.llm.is_opik_enabled", return_value=False)
+    @patch("simulation_v2.actions.llm.get_opik_tracer")
+    def test_opik_disabled_skips_callbacks(
+        self,
+        mock_get_opik_tracer: MagicMock,
+        mock_is_opik_enabled: MagicMock,
+        llm_config: LlmConfig,
+        trace_ctx: SimulationTraceContext,
+    ) -> None:
+        assert mock_is_opik_enabled.return_value is False
+        parsed = LlmLikePostOutput(post_ids=["p1"])
+        mock_llm = MagicMock()
+        mock_chain = MagicMock()
+        mock_chain.invoke = MagicMock(return_value=parsed)
+
+        with (
+            patch("simulation_v2.actions.llm.get_chat_model", return_value=mock_llm),
+            patch.object(ChatPromptTemplate, "__or__", return_value=mock_chain),
+        ):
+            result = invoke_structured_generation(
+                LIKE_POSTS_PROMPT,
+                LlmLikePostOutput,
+                llm_config=llm_config,
+                prompt_variables={"name": "Alice"},
+                action_type="like_post",
+                user_id="u1",
+                trace_ctx=trace_ctx,
+            )
+
+        assert result.status == "completed"
+        mock_get_opik_tracer.assert_not_called()
+        assert mock_chain.invoke.call_args.kwargs.get("config") is None

--- a/tests/simulation_v2/actions/test_models.py
+++ b/tests/simulation_v2/actions/test_models.py
@@ -1,0 +1,38 @@
+"""Smoke tests for action LLM output models."""
+
+from __future__ import annotations
+
+from simulation_v2.actions.models import (
+    LlmCommentOnPostOutput,
+    LlmFollowUserOutput,
+    LlmGenerationResult,
+    LlmLikePostOutput,
+    LlmWritePostOutput,
+)
+
+
+class TestActionOutputModels:
+    def test_like_post_round_trip(self) -> None:
+        model = LlmLikePostOutput(post_ids=["p1", "p2"])
+        assert model.model_dump() == {"post_ids": ["p1", "p2"]}
+        assert LlmLikePostOutput.model_validate({"post_ids": []}).post_ids == []
+
+    def test_write_post_round_trip(self) -> None:
+        model = LlmWritePostOutput(content="hello world")
+        assert model.content == "hello world"
+
+    def test_follow_user_round_trip(self) -> None:
+        model = LlmFollowUserOutput(user_ids=["u2"])
+        assert model.user_ids == ["u2"]
+
+    def test_comment_on_post_round_trip(self) -> None:
+        model = LlmCommentOnPostOutput(parent_post_id="p1", content="nice post")
+        assert model.parent_post_id == "p1"
+        assert model.content == "nice post"
+
+    def test_generation_result_defaults(self) -> None:
+        result = LlmGenerationResult(
+            status="completed", parsed=LlmWritePostOutput(content="x")
+        )
+        assert result.error is None
+        assert result.latency_ms is None

--- a/tests/simulation_v2/feeds/test_most_liked.py
+++ b/tests/simulation_v2/feeds/test_most_liked.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from simulation_v2.config import FeedConfig, LocalSimulationConfig
 from simulation_v2.feeds.most_liked import MostLikedFeedGenerator
@@ -92,7 +92,10 @@ class TestMostLikedFeedGenerator:
         assert feed[0].post_id == "p2"
 
     @patch("simulation_v2.feeds.most_liked.random.random", return_value=1.0)
-    def test_include_probability_gate_excludes_post(self) -> None:
+    def test_include_probability_gate_excludes_post(
+        self, mock_random: MagicMock
+    ) -> None:
+        assert mock_random.return_value == 1.0
         snapshot = _snapshot()
         config = FeedConfig(include_probability=0.5, max_posts=10)
         generator = MostLikedFeedGenerator()

--- a/tests/simulation_v2/test_worker_service.py
+++ b/tests/simulation_v2/test_worker_service.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from simulation_v2.config import LocalSimulationConfig
+from simulation_v2.config import ActionConfig, LocalSimulationConfig
 from simulation_v2.db.connection import transaction
 from simulation_v2.db.database import SimulationDatabase
 from simulation_v2.seed.loader import import_seed_if_needed
@@ -29,7 +29,16 @@ def db_path(tmp_path: Path) -> Path:
 
 def _small_config(**overrides: object) -> LocalSimulationConfig:
     return LocalSimulationConfig.default().model_copy(
-        update={"total_turns": 3, **overrides}
+        update={
+            "total_turns": 3,
+            "action": ActionConfig(
+                enable_like_post=False,
+                enable_write_post=False,
+                enable_follow_user=False,
+                enable_comment_on_post=False,
+            ),
+            **overrides,
+        }
     )
 
 


### PR DESCRIPTION
## Overview

PR 8 introduces the first slice of the action pipeline for `simulation_v2`: structured LLM output models, LangChain prompts, a retry/Opik-aware LLM wrapper, and a service that persists every generation attempt (including failures) to `generations` and raw outputs to `llm_proposed_actions`. It wires into `simulation_v2/worker/turn_executor.py` right after `generate_and_persist_feeds`. Business validators, `proposed_actions`, diff execution, and the memory service remain out of scope (PRs 9–11).

Depends on merged PR #318 (feed service).

Contract: [`docs/plans/2026-05-26_simulation_v2_pr8_actions_llm_847296/contracts.md`](docs/plans/2026-05-26_simulation_v2_pr8_actions_llm_847296/contracts.md)

## Problem / motivation

After PR 7, turns generate and persist feeds but do not record LLM action proposals. The worker path needs a SQLite-backed action generation step before validators and executors land in PRs 9–10.

## Solution

Add `simulation_v2/actions/{models,prompts,llm,service}.py` following the PR 7 feed-service pattern, persist one `GenerationRecord` per enabled action per user per turn, map parsed outputs to `llm_proposed_actions`, and call the service from `turn_executor` after feed generation. Worker smoke tests disable all actions to stay offline.

## Happy Flow

1. `worker/turn_executor.execute_turn` loads `TurnStateSnapshot` (PR 6 contract unchanged).
2. `feeds.service.generate_and_persist_feeds` writes one `GeneratedFeedRecord` per user (PR 7 contract unchanged).
3. **New:** `actions.service.generate_and_persist_llm_actions` runs for each user:
   - Resolve that user's feed from the feed records just written.
   - Format prompt inputs from `UserRecord`, `AgentMemoryRecord`, and `FeedPostView` list.
   - For each enabled action in `ActionConfig`, call `actions.llm.invoke_structured_generation`.
   - Insert one `GenerationRecord` per logical LLM call (success or failure).
   - Insert one or more `LlmProposedActionRecord` rows when parse succeeded.
4. Turn completes as today; no social diffs or `proposed_actions` rows yet.

## Data Flow

```
turn_executor → feeds.service → actions.service → actions.llm → repositories (generations, llm_proposed_actions)
```

## Changes

- `docs/plans/2026-05-26_simulation_v2_pr8_actions_llm_847296/contracts.md`: frozen PR 8 contract
- `simulation_v2/actions/models.py`, `prompts.py`, `llm.py`, `service.py`: action LLM pipeline
- `simulation_v2/db/repositories.py`: `list_generations_for_turn`, `list_llm_proposed_actions_for_turn`
- `simulation_v2/worker/turn_executor.py`: wire action generation after feeds
- `simulation_v2/worker/run_executor.py`: call `configure_opik()` once per run
- `simulation_v2/models/telemetry.py`, `telemetry/llm_collector.py`: add `comment_on_post` telemetry type
- `tests/simulation_v2/actions/`: models, LLM wrapper, and service integration tests
- `tests/simulation_v2/test_worker_service.py`: disable actions in smoke config
- `tests/simulation_v2/feeds/test_most_liked.py`: fix `@patch` signature (pre-existing)

## Manual Verification

- [x] `uv run pytest tests/simulation_v2/actions/ -v` — 13 passed (success, retry, schema failure, Opik-disabled)
- [x] `uv run pytest tests/simulation_v2/feeds/ tests/simulation_v2/test_worker_service.py -v` — 19 passed, no regressions
- [ ] Optional live smoke (requires `OPENAI_API_KEY`): run with default config on 1 turn / 2 users; inspect `generations` and `llm_proposed_actions` in SQLite

## Test plan

- [x] Contract file at `docs/plans/2026-05-26_simulation_v2_pr8_actions_llm_847296/contracts.md`
- [x] Unit tests for structured output models
- [x] Mocked LLM tests: success, retry-then-success, retry exhausted, schema failure, Opik disabled
- [x] Service integration test: temp SQLite + mocked LLM → generation and `llm_proposed_action` rows with FK linkage
- [x] Worker smoke tests remain offline (all actions disabled in `_small_config()`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated LLM-driven social action generation with structured outputs for liking posts, writing posts, following users, and commenting on posts. Added automatic metrics collection including latency, token usage, and cost tracking.

* **Tests**
  * Added comprehensive test coverage for action generation, persistence, and telemetry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/METResearchGroup/social_agent_simulation_platform/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->