### PR TITLE
Add business-rule validators and proposed action persistence (PR 9)

### DIFF
--- a/docs/plans/2026-05-26_simulation_v2_pr9_action_validators_847297/contracts.md
+++ b/docs/plans/2026-05-26_simulation_v2_pr9_action_validators_847297/contracts.md
@@ -1,0 +1,53 @@
+# PR 9 Contract Freeze — Action Validators
+
+## Frozen Symbols
+
+| Symbol | Location | Contract |
+| --- | --- | --- |
+| `FilterId` | `simulation_v2/actions/validators.py` | Stable string literals for eval grouping (see table below) |
+| `ActionValidationOutcome` | `simulation_v2/actions/validators.py` | `accepted: bool`, optional `filter_id: FilterId`, optional `filter_reason: str` |
+| `validate_like_post_action` | `simulation_v2/actions/validators.py` | Pure function; one LLM like row in, outcome out |
+| `validate_follow_user_action` | `simulation_v2/actions/validators.py` | Pure function; follow row in, outcome out |
+| `validate_write_post_action` | `simulation_v2/actions/validators.py` | Pure function; write row in, outcome out |
+| `validate_comment_on_post_action` | `simulation_v2/actions/validators.py` | Pure function; comment row in, outcome out |
+| `validate_and_persist_proposed_actions` | `simulation_v2/actions/service.py` | `(snapshot, feed_records, action_config, repos, conn) -> list[ProposedActionRecord]` |
+| `list_proposed_actions_for_turn` | `simulation_v2/db/repositories.py` | `(run_id, turn_id, conn) -> list[ProposedActionRecord]` ordered by `created_at`, `action_id` |
+| `execute_turn` (behavior change) | `simulation_v2/worker/turn_executor.py` | After `generate_and_persist_llm_actions`, call `validate_and_persist_proposed_actions` |
+
+## Frozen `FilterId` Values
+
+| filter_id | When | filter_reason (example) |
+| --- | --- | --- |
+| `no_self_like` | like target authored by acting user | `Cannot like your own post` |
+| `duplicate_like` | same post already liked (snapshot or earlier accepted this turn) | `Duplicate like for post {post_id}` |
+| `missing_target_post` | like/comment target not in user's generated feed | `Post {post_id} not in feed` |
+| `no_self_follow` | follow target is acting user | `Cannot follow yourself` |
+| `duplicate_follow` | already following (snapshot or earlier accepted this turn) | `Duplicate follow for user {user_id}` |
+| `missing_target_user` | follow target not in feed-derived candidate set | `User {user_id} not in follow candidates` |
+| `empty_content` | write/comment content blank after strip | `Action content is empty` |
+| `missing_parent_post` | comment parent not in feed | `Parent post {post_id} not in feed` |
+| `max_actions_per_turn` | per-type cap from `ActionConfig` exceeded | `Exceeded max {action_type} per turn ({max})` |
+
+## Data-Model Invariants
+
+- One `ProposedActionRecord` per `LlmProposedActionRecord` processed (1:1 for this PR).
+- Rejected rows still populate `target_type`, `target_id`, `target_content` from the LLM row.
+- `generation_id` copied from source LLM row.
+- Only business-rule rejections in this PR (`rejection_stage="business_rules"`).
+
+## File-Interaction Invariants
+
+| Owner | Allowed callers | Forbidden |
+| --- | --- | --- |
+| `actions.validators` | `actions.service`, tests | No repository imports, no SQLite |
+| `actions.service` (validation path) | `worker.turn_executor`, tests | Must not import LangChain/Opik/tenacity |
+| `worker.turn_executor` | `run_executor`, tests | Must not implement validator rules inline |
+| Legacy `simulation_v2/agents/*` | unchanged | Do not modify |
+
+## Out of Scope
+
+- `actions/executor.py`, `actions/noise.py` (PR 10–11)
+- Stochastic action filtering
+- Eval plugins
+- Schema-failure → `proposed_actions` rows (`rejection_stage="llm_schema"`)
+- Modifying PR 8 frozen LLM contracts

--- a/simulation_v2/actions/__init__.py
+++ b/simulation_v2/actions/__init__.py
@@ -1,5 +1,8 @@
 """Action LLM generation pipeline for simulation_v2."""
 
-from simulation_v2.actions.service import generate_and_persist_llm_actions
+from simulation_v2.actions.service import (
+    generate_and_persist_llm_actions,
+    validate_and_persist_proposed_actions,
+)
 
-__all__ = ["generate_and_persist_llm_actions"]
+__all__ = ["generate_and_persist_llm_actions", "validate_and_persist_proposed_actions"]

--- a/simulation_v2/actions/service.py
+++ b/simulation_v2/actions/service.py
@@ -261,7 +261,7 @@ def _validate_llm_row(
         )
     return ActionValidationOutcome(
         accepted=False,
-        filter_id="max_actions_per_turn",
+        filter_id="unsupported_action_type",
         filter_reason=f"Unsupported action type {llm_row.action_type!r}",
     )
 

--- a/simulation_v2/actions/service.py
+++ b/simulation_v2/actions/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from dataclasses import dataclass, field
 from typing import Any
 
 from simulation_v2.actions.llm import invoke_structured_generation
@@ -20,6 +21,13 @@ from simulation_v2.actions.prompts import (
     LIKE_POSTS_PROMPT,
     WRITE_POST_PROMPT,
 )
+from simulation_v2.actions.validators import (
+    ActionValidationOutcome,
+    validate_comment_on_post_action,
+    validate_follow_user_action,
+    validate_like_post_action,
+    validate_write_post_action,
+)
 from simulation_v2.config import ActionConfig, LlmConfig
 from simulation_v2.db.models import (
     AgentMemoryRecord,
@@ -27,10 +35,15 @@ from simulation_v2.db.models import (
     GeneratedFeedRecord,
     GenerationRecord,
     LlmProposedActionRecord,
+    ProposedActionRecord,
     UserRecord,
 )
 from simulation_v2.db.repositories import SimulationRepositories
-from simulation_v2.ids import new_generation_id, new_llm_proposed_action_id
+from simulation_v2.ids import (
+    new_action_id,
+    new_generation_id,
+    new_llm_proposed_action_id,
+)
 from simulation_v2.lib.decorators import progress_items
 from simulation_v2.telemetry.context import SimulationTraceContext
 from simulation_v2.time import get_current_timestamp
@@ -129,6 +142,182 @@ def generate_and_persist_llm_actions(
         )
 
     return generation_records
+
+
+def validate_and_persist_proposed_actions(
+    snapshot: TurnStateSnapshot,
+    feed_records: list[GeneratedFeedRecord],
+    action_config: ActionConfig,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+) -> list[ProposedActionRecord]:
+    feeds_by_user = {record.user_id: record.feed_posts for record in feed_records}
+    llm_rows = repos.list_llm_proposed_actions_for_turn(
+        snapshot.run_id, snapshot.turn_id, conn
+    )
+    llm_rows.sort(key=lambda row: (row.created_at, row.llm_proposed_action_id))
+
+    user_states: dict[str, _UserValidationState] = {}
+    proposed_records: list[ProposedActionRecord] = []
+
+    for llm_row in llm_rows:
+        state = _get_user_validation_state(
+            user_states,
+            llm_row.user_id,
+            feeds_by_user,
+            snapshot,
+        )
+        outcome = _validate_llm_row(llm_row, state, action_config)
+        record = _llm_row_to_proposed_record(outcome, llm_row)
+        repos.insert_proposed_action(record, conn)
+        proposed_records.append(record)
+        if outcome.accepted:
+            _record_accepted_action(state, llm_row)
+
+    return proposed_records
+
+
+@dataclass
+class _UserValidationState:
+    feed_post_ids: set[str]
+    feed_author_by_post_id: dict[str, str]
+    follow_candidate_ids: set[str]
+    snapshot_liked_post_ids: set[str]
+    snapshot_followed_user_ids: set[str]
+    accepted_likes: set[str] = field(default_factory=set)
+    accepted_follows: set[str] = field(default_factory=set)
+    accepted_like_count: int = 0
+    accepted_follow_count: int = 0
+    accepted_write_count: int = 0
+    accepted_comment_count: int = 0
+
+
+def _get_user_validation_state(
+    user_states: dict[str, _UserValidationState],
+    user_id: str,
+    feeds_by_user: dict[str, list[FeedPostView]],
+    snapshot: TurnStateSnapshot,
+) -> _UserValidationState:
+    if user_id not in user_states:
+        feed_posts = feeds_by_user.get(user_id, [])
+        candidates = _candidate_users_from_feed(user_id, feed_posts, snapshot.users)
+        user_states[user_id] = _UserValidationState(
+            feed_post_ids={post.post_id for post in feed_posts},
+            feed_author_by_post_id={
+                post.post_id: post.author_id for post in feed_posts
+            },
+            follow_candidate_ids={user.user_id for user in candidates},
+            snapshot_liked_post_ids={
+                like.post_id for like in snapshot.likes if like.author_id == user_id
+            },
+            snapshot_followed_user_ids={
+                follow.followee_id
+                for follow in snapshot.follows
+                if follow.follower_id == user_id
+            },
+        )
+    return user_states[user_id]
+
+
+def _validate_llm_row(
+    llm_row: LlmProposedActionRecord,
+    state: _UserValidationState,
+    action_config: ActionConfig,
+) -> ActionValidationOutcome:
+    if llm_row.action_type == "like_post":
+        return validate_like_post_action(
+            user_id=llm_row.user_id,
+            post_id=llm_row.target_id or "",
+            feed_post_ids=state.feed_post_ids,
+            feed_author_by_post_id=state.feed_author_by_post_id,
+            snapshot_liked_post_ids=state.snapshot_liked_post_ids,
+            accepted_likes_this_turn=state.accepted_likes,
+            accepted_like_count=state.accepted_like_count,
+            max_likes=action_config.max_likes_per_turn,
+        )
+    if llm_row.action_type == "follow_user":
+        return validate_follow_user_action(
+            user_id=llm_row.user_id,
+            followee_id=llm_row.target_id or "",
+            follow_candidate_ids=state.follow_candidate_ids,
+            snapshot_followed_user_ids=state.snapshot_followed_user_ids,
+            accepted_follows_this_turn=state.accepted_follows,
+            accepted_follow_count=state.accepted_follow_count,
+            max_follows=action_config.max_follows_per_turn,
+        )
+    if llm_row.action_type == "write_post":
+        return validate_write_post_action(
+            content=llm_row.target_content,
+            accepted_write_count=state.accepted_write_count,
+            max_posts=action_config.max_posts_per_turn,
+        )
+    if llm_row.action_type == "comment_on_post":
+        return validate_comment_on_post_action(
+            parent_post_id=llm_row.target_id or "",
+            content=llm_row.target_content,
+            feed_post_ids=state.feed_post_ids,
+            accepted_comment_count=state.accepted_comment_count,
+            max_comments=action_config.max_comments_per_turn,
+        )
+    return ActionValidationOutcome(
+        accepted=False,
+        filter_id="max_actions_per_turn",
+        filter_reason=f"Unsupported action type {llm_row.action_type!r}",
+    )
+
+
+def _record_accepted_action(
+    state: _UserValidationState,
+    llm_row: LlmProposedActionRecord,
+) -> None:
+    if llm_row.action_type == "like_post" and llm_row.target_id is not None:
+        state.accepted_likes.add(llm_row.target_id)
+        state.accepted_like_count += 1
+    elif llm_row.action_type == "follow_user" and llm_row.target_id is not None:
+        state.accepted_follows.add(llm_row.target_id)
+        state.accepted_follow_count += 1
+    elif llm_row.action_type == "write_post":
+        state.accepted_write_count += 1
+    elif llm_row.action_type == "comment_on_post":
+        state.accepted_comment_count += 1
+
+
+def _llm_row_to_proposed_record(
+    outcome: ActionValidationOutcome,
+    llm_row: LlmProposedActionRecord,
+) -> ProposedActionRecord:
+    if outcome.accepted:
+        return ProposedActionRecord(
+            action_id=new_action_id(),
+            record_kind="validated",
+            generation_id=llm_row.generation_id,
+            run_id=llm_row.run_id,
+            turn_id=llm_row.turn_id,
+            user_id=llm_row.user_id,
+            action_type=llm_row.action_type,
+            target_type=llm_row.target_type,
+            target_id=llm_row.target_id,
+            target_content=llm_row.target_content,
+            metadata_json=llm_row.metadata_json,
+            created_at=get_current_timestamp(),
+        )
+    return ProposedActionRecord(
+        action_id=new_action_id(),
+        record_kind="rejected",
+        generation_id=llm_row.generation_id,
+        run_id=llm_row.run_id,
+        turn_id=llm_row.turn_id,
+        user_id=llm_row.user_id,
+        action_type=llm_row.action_type,
+        target_type=llm_row.target_type,
+        target_id=llm_row.target_id,
+        target_content=llm_row.target_content,
+        filter_id=outcome.filter_id,
+        filter_reason=outcome.filter_reason,
+        rejection_stage="business_rules",
+        metadata_json=llm_row.metadata_json,
+        created_at=get_current_timestamp(),
+    )
 
 
 def _append_generation(

--- a/simulation_v2/actions/validators.py
+++ b/simulation_v2/actions/validators.py
@@ -1,0 +1,163 @@
+"""Pure business-rule validators for LLM-proposed actions."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+FilterId = Literal[
+    "no_self_like",
+    "duplicate_like",
+    "missing_target_post",
+    "no_self_follow",
+    "duplicate_follow",
+    "missing_target_user",
+    "empty_content",
+    "missing_parent_post",
+    "max_actions_per_turn",
+]
+
+
+class ActionValidationOutcome(BaseModel):
+    accepted: bool
+    filter_id: FilterId | None = None
+    filter_reason: str | None = None
+
+
+def validate_like_post_action(
+    *,
+    user_id: str,
+    post_id: str,
+    feed_post_ids: set[str],
+    feed_author_by_post_id: dict[str, str],
+    snapshot_liked_post_ids: set[str],
+    accepted_likes_this_turn: set[str],
+    accepted_like_count: int,
+    max_likes: int,
+) -> ActionValidationOutcome:
+    if accepted_like_count >= max_likes:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="max_actions_per_turn",
+            filter_reason=f"Exceeded max like_post per turn ({max_likes})",
+        )
+    if post_id in accepted_likes_this_turn:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="duplicate_like",
+            filter_reason=f"Duplicate like for post {post_id}",
+        )
+    if post_id not in feed_post_ids:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="missing_target_post",
+            filter_reason=f"Post {post_id} not in feed",
+        )
+    author_id = feed_author_by_post_id.get(post_id)
+    if author_id == user_id:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="no_self_like",
+            filter_reason="Cannot like your own post",
+        )
+    if post_id in snapshot_liked_post_ids:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="duplicate_like",
+            filter_reason=f"Duplicate like for post {post_id}",
+        )
+    return ActionValidationOutcome(accepted=True)
+
+
+def validate_follow_user_action(
+    *,
+    user_id: str,
+    followee_id: str,
+    follow_candidate_ids: set[str],
+    snapshot_followed_user_ids: set[str],
+    accepted_follows_this_turn: set[str],
+    accepted_follow_count: int,
+    max_follows: int,
+) -> ActionValidationOutcome:
+    if accepted_follow_count >= max_follows:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="max_actions_per_turn",
+            filter_reason=f"Exceeded max follow_user per turn ({max_follows})",
+        )
+    if followee_id in accepted_follows_this_turn:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="duplicate_follow",
+            filter_reason=f"Duplicate follow for user {followee_id}",
+        )
+    if followee_id == user_id:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="no_self_follow",
+            filter_reason="Cannot follow yourself",
+        )
+    if followee_id not in follow_candidate_ids:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="missing_target_user",
+            filter_reason=f"User {followee_id} not in follow candidates",
+        )
+    if followee_id in snapshot_followed_user_ids:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="duplicate_follow",
+            filter_reason=f"Duplicate follow for user {followee_id}",
+        )
+    return ActionValidationOutcome(accepted=True)
+
+
+def validate_write_post_action(
+    *,
+    content: str | None,
+    accepted_write_count: int,
+    max_posts: int,
+) -> ActionValidationOutcome:
+    if not (content or "").strip():
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="empty_content",
+            filter_reason="Action content is empty",
+        )
+    if accepted_write_count >= max_posts:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="max_actions_per_turn",
+            filter_reason=f"Exceeded max write_post per turn ({max_posts})",
+        )
+    return ActionValidationOutcome(accepted=True)
+
+
+def validate_comment_on_post_action(
+    *,
+    parent_post_id: str,
+    content: str | None,
+    feed_post_ids: set[str],
+    accepted_comment_count: int,
+    max_comments: int,
+) -> ActionValidationOutcome:
+    if not (content or "").strip():
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="empty_content",
+            filter_reason="Action content is empty",
+        )
+    if parent_post_id not in feed_post_ids:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="missing_parent_post",
+            filter_reason=f"Parent post {parent_post_id} not in feed",
+        )
+    if accepted_comment_count >= max_comments:
+        return ActionValidationOutcome(
+            accepted=False,
+            filter_id="max_actions_per_turn",
+            filter_reason=f"Exceeded max comment_on_post per turn ({max_comments})",
+        )
+    return ActionValidationOutcome(accepted=True)

--- a/simulation_v2/actions/validators.py
+++ b/simulation_v2/actions/validators.py
@@ -16,6 +16,7 @@ FilterId = Literal[
     "empty_content",
     "missing_parent_post",
     "max_actions_per_turn",
+    "unsupported_action_type",
 ]
 
 

--- a/simulation_v2/db/repositories.py
+++ b/simulation_v2/db/repositories.py
@@ -976,6 +976,38 @@ class SimulationRepositories:
             ),
         )
 
+    def list_proposed_actions_for_turn(
+        self, run_id: str, turn_id: str, conn: sqlite3.Connection
+    ) -> list[ProposedActionRecord]:
+        rows = conn.execute(
+            """
+            SELECT * FROM proposed_actions
+            WHERE run_id = ? AND turn_id = ?
+            ORDER BY created_at, action_id
+            """,
+            (run_id, turn_id),
+        ).fetchall()
+        return [
+            ProposedActionRecord(
+                action_id=row["action_id"],
+                record_kind=row["record_kind"],
+                generation_id=row["generation_id"],
+                run_id=row["run_id"],
+                turn_id=row["turn_id"],
+                user_id=row["user_id"],
+                action_type=row["action_type"],
+                target_type=row["target_type"],
+                target_id=row["target_id"],
+                target_content=row["target_content"],
+                filter_id=row["filter_id"],
+                filter_reason=row["filter_reason"],
+                rejection_stage=row["rejection_stage"],
+                metadata_json=_loads_json(row["metadata_json"]),
+                created_at=row["created_at"],
+            )
+            for row in rows
+        ]
+
     def get_proposed_action(
         self, action_id: str, conn: sqlite3.Connection
     ) -> ProposedActionRecord | None:

--- a/simulation_v2/worker/turn_executor.py
+++ b/simulation_v2/worker/turn_executor.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import sqlite3
 
-from simulation_v2.actions.service import generate_and_persist_llm_actions
+from simulation_v2.actions.service import (
+    generate_and_persist_llm_actions,
+    validate_and_persist_proposed_actions,
+)
 from simulation_v2.config import LocalSimulationConfig
 from simulation_v2.db.models import TurnRecord
 from simulation_v2.db.repositories import SimulationRepositories
@@ -56,6 +59,13 @@ def execute_turn(
         repos,
         conn,
         trace_ctx=trace_ctx,
+    )
+    validate_and_persist_proposed_actions(
+        snapshot,
+        feed_records,
+        snapshot.config.action,
+        repos,
+        conn,
     )
     repos.update_turn_status(turn_id, "completed", conn)
     return snapshot

--- a/tests/simulation_v2/actions/test_action_service.py
+++ b/tests/simulation_v2/actions/test_action_service.py
@@ -167,6 +167,7 @@ class TestGenerateAndPersistLlmActions:
         assert len(rejected) == 1
         assert rejected[0].record_kind == "rejected"
         assert rejected[0].filter_id == "missing_target_post"
+        assert rejected[0].rejection_stage == "business_rules"
 
     def test_persists_failed_generation_without_proposed_actions(
         self, tmp_path: Path
@@ -302,3 +303,4 @@ class TestExecuteTurnActionValidation:
         assert len(rejected) == 1
         assert rejected[0].record_kind == "rejected"
         assert rejected[0].filter_id == "missing_target_post"
+        assert rejected[0].rejection_stage == "business_rules"

--- a/tests/simulation_v2/actions/test_action_service.py
+++ b/tests/simulation_v2/actions/test_action_service.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 from simulation_v2.actions.models import LlmGenerationResult, LlmLikePostOutput
-from simulation_v2.actions.service import generate_and_persist_llm_actions
+from simulation_v2.actions.service import (
+    generate_and_persist_llm_actions,
+    validate_and_persist_proposed_actions,
+)
 from simulation_v2.config import ActionConfig, FeedConfig, LocalSimulationConfig
 from simulation_v2.db.connection import transaction
 from simulation_v2.db.database import SimulationDatabase
@@ -15,6 +18,7 @@ from simulation_v2.models.seed_data import LoadedPostModel, LoadedUserModel
 from simulation_v2.seed.loader import persist_seed_for_run
 from simulation_v2.seed.models import SeedDataset
 from simulation_v2.worker.state import load_turn_snapshot
+from simulation_v2.worker.turn_executor import execute_turn
 from tests.simulation_v2.db import factories
 
 FIXED_TS = "2026-01-01T00:00:00.000000+00:00"
@@ -123,6 +127,13 @@ class TestGenerateAndPersistLlmActions:
                     db.repos,
                     conn,
                 )
+                validate_and_persist_proposed_actions(
+                    snapshot,
+                    feed_records,
+                    config.action,
+                    db.repos,
+                    conn,
+                )
 
         assert mock_invoke.call_count == 2
         assert len(generations) == 2
@@ -136,6 +147,9 @@ class TestGenerateAndPersistLlmActions:
             loaded_actions = db.repos.list_llm_proposed_actions_for_turn(
                 run.run_id, turn.turn_id, conn
             )
+            proposed_actions = db.repos.list_proposed_actions_for_turn(
+                run.run_id, turn.turn_id, conn
+            )
 
         assert len(loaded_generations) == 2
         assert len(loaded_actions) == 2
@@ -144,6 +158,15 @@ class TestGenerateAndPersistLlmActions:
         }
         assert all(action.action_type == "like_post" for action in loaded_actions)
         assert all(action.target_id == "p2" for action in loaded_actions)
+        assert len(proposed_actions) == 2
+        validated = [action for action in proposed_actions if action.user_id == "u1"]
+        rejected = [action for action in proposed_actions if action.user_id == "u2"]
+        assert len(validated) == 1
+        assert validated[0].record_kind == "validated"
+        assert validated[0].target_id == "p2"
+        assert len(rejected) == 1
+        assert rejected[0].record_kind == "rejected"
+        assert rejected[0].filter_id == "missing_target_post"
 
     def test_persists_failed_generation_without_proposed_actions(
         self, tmp_path: Path
@@ -211,7 +234,71 @@ class TestGenerateAndPersistLlmActions:
             loaded_actions = db.repos.list_llm_proposed_actions_for_turn(
                 run.run_id, turn.turn_id, conn
             )
+            proposed_actions = db.repos.list_proposed_actions_for_turn(
+                run.run_id, turn.turn_id, conn
+            )
 
         assert len(loaded_generations) == 2
         assert all(gen.status == "failed" for gen in loaded_generations)
         assert loaded_actions == []
+        assert proposed_actions == []
+
+
+class TestExecuteTurnActionValidation:
+    def test_turn_executor_persists_proposed_actions(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "test.sqlite3"
+        db = SimulationDatabase(db_path)
+        db.initialize()
+        config = LocalSimulationConfig.default().model_copy(
+            update={
+                "total_turns": 1,
+                "feed": FeedConfig(include_probability=1.0, max_posts=10),
+                "action": ActionConfig(
+                    enable_like_post=True,
+                    enable_write_post=False,
+                    enable_follow_user=False,
+                    enable_comment_on_post=False,
+                ),
+            }
+        )
+        run = factories.RunRecordFactory.create(
+            config_json=config.model_dump(mode="json"),
+            seed_metadata_json=None,
+        )
+        dataset = _tiny_dataset()
+
+        mock_result = LlmGenerationResult(
+            status="completed",
+            parsed=LlmLikePostOutput(post_ids=["p2"]),
+            latency_ms=12.5,
+            prompt_tokens=10,
+            completion_tokens=5,
+            raw_response_json={"post_ids": ["p2"]},
+        )
+
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            persist_seed_for_run(run.run_id, dataset, db.repos, conn)
+
+        with patch(
+            "simulation_v2.actions.service.invoke_structured_generation",
+            return_value=mock_result,
+        ):
+            with transaction(db_path) as conn:
+                execute_turn(run.run_id, 1, config, conn, db.repos)
+
+        with transaction(db_path) as conn:
+            turns = db.repos.list_turns_for_run(run.run_id, conn)
+            proposed_actions = db.repos.list_proposed_actions_for_turn(
+                run.run_id, turns[0].turn_id, conn
+            )
+
+        assert len(proposed_actions) == 2
+        validated = [action for action in proposed_actions if action.user_id == "u1"]
+        rejected = [action for action in proposed_actions if action.user_id == "u2"]
+        assert len(validated) == 1
+        assert validated[0].record_kind == "validated"
+        assert validated[0].target_id == "p2"
+        assert len(rejected) == 1
+        assert rejected[0].record_kind == "rejected"
+        assert rejected[0].filter_id == "missing_target_post"

--- a/tests/simulation_v2/actions/test_action_validation_service.py
+++ b/tests/simulation_v2/actions/test_action_validation_service.py
@@ -1,0 +1,216 @@
+"""Integration tests for validate_and_persist_proposed_actions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from simulation_v2.actions.service import validate_and_persist_proposed_actions
+from simulation_v2.config import ActionConfig, FeedConfig, LocalSimulationConfig
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from simulation_v2.db.models import FeedPostView, GeneratedFeedRecord
+from simulation_v2.ids import new_feed_id
+from simulation_v2.models.seed_data import LoadedPostModel, LoadedUserModel
+from simulation_v2.seed.loader import persist_seed_for_run
+from simulation_v2.seed.models import SeedDataset
+from simulation_v2.worker.state import load_turn_snapshot
+from tests.simulation_v2.db import factories
+
+FIXED_TS = "2026-01-01T00:00:00.000000+00:00"
+
+
+def _tiny_dataset() -> SeedDataset:
+    return SeedDataset(
+        users={
+            "u1": LoadedUserModel(
+                user_id="u1",
+                name="Alice",
+                email="a@example.com",
+                username="alice",
+                created_at=FIXED_TS,
+                num_followers=0,
+                num_follows=0,
+            ),
+            "u2": LoadedUserModel(
+                user_id="u2",
+                name="Bob",
+                email="b@example.com",
+                username="bob",
+                created_at=FIXED_TS,
+                num_followers=0,
+                num_follows=0,
+            ),
+        },
+        posts={
+            "p1": LoadedPostModel(
+                post_id="p1",
+                user_id="u1",
+                content="hello",
+                created_at=FIXED_TS,
+                num_likes=1,
+            ),
+            "p2": LoadedPostModel(
+                post_id="p2",
+                user_id="u2",
+                content="world",
+                created_at=FIXED_TS,
+                num_likes=0,
+            ),
+        },
+        likes={},
+        follows={},
+    )
+
+
+class TestValidateAndPersistProposedActions:
+    def test_persists_validated_and_rejected_rows(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "test.sqlite3"
+        db = SimulationDatabase(db_path)
+        db.initialize()
+        config = LocalSimulationConfig.default().model_copy(
+            update={
+                "feed": FeedConfig(include_probability=1.0, max_posts=10),
+                "action": ActionConfig(
+                    enable_like_post=True,
+                    enable_write_post=False,
+                    enable_follow_user=False,
+                    enable_comment_on_post=False,
+                    max_likes_per_turn=5,
+                ),
+            }
+        )
+        run = factories.RunRecordFactory.create(
+            config_json=config.model_dump(mode="json"),
+            seed_metadata_json=None,
+        )
+        dataset = _tiny_dataset()
+
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            persist_seed_for_run(run.run_id, dataset, db.repos, conn)
+            turn = factories.TurnRecordFactory.create(
+                run_id=run.run_id,
+                turn_number=1,
+                status="pending",
+            )
+            db.repos.insert_turn(turn, conn)
+            snapshot = load_turn_snapshot(run.run_id, turn.turn_id, db.repos, conn)
+            feed_records = [
+                GeneratedFeedRecord(
+                    feed_id=new_feed_id(),
+                    run_id=run.run_id,
+                    turn_id=turn.turn_id,
+                    user_id="u1",
+                    algorithm="test",
+                    feed_post_ids=["p1", "p2"],
+                    feed_posts=[
+                        FeedPostView(
+                            post_id="p1",
+                            author_id="u1",
+                            content="hello",
+                            created_at=FIXED_TS,
+                        ),
+                        FeedPostView(
+                            post_id="p2",
+                            author_id="u2",
+                            content="world",
+                            created_at=FIXED_TS,
+                        ),
+                    ],
+                    created_at=FIXED_TS,
+                )
+            ]
+
+            generation = factories.GenerationRecordFactory.create(
+                run_id=run.run_id,
+                turn_id=turn.turn_id,
+                user_id="u1",
+                action_type="like_post",
+            )
+            db.repos.insert_generation(generation, conn)
+
+            valid_like = factories.LlmProposedActionRecordFactory.create(
+                run_id=run.run_id,
+                turn_id=turn.turn_id,
+                user_id="u1",
+                generation_id=generation.generation_id,
+                action_type="like_post",
+                target_type="post",
+                target_id="p2",
+                created_at="2026-01-01T00:00:01+00:00",
+            )
+            self_like = factories.LlmProposedActionRecordFactory.create(
+                run_id=run.run_id,
+                turn_id=turn.turn_id,
+                user_id="u1",
+                generation_id=generation.generation_id,
+                action_type="like_post",
+                target_type="post",
+                target_id="p1",
+                created_at="2026-01-01T00:00:02+00:00",
+            )
+            db.repos.insert_llm_proposed_action(valid_like, conn)
+            db.repos.insert_llm_proposed_action(self_like, conn)
+
+            proposed = validate_and_persist_proposed_actions(
+                snapshot,
+                feed_records,
+                config.action,
+                db.repos,
+                conn,
+            )
+
+        assert len(proposed) == 2
+        assert proposed[0].record_kind == "validated"
+        assert proposed[0].target_id == "p2"
+        assert proposed[0].filter_id is None
+        assert proposed[1].record_kind == "rejected"
+        assert proposed[1].target_id == "p1"
+        assert proposed[1].filter_id == "no_self_like"
+        assert proposed[1].rejection_stage == "business_rules"
+
+        with transaction(db_path) as conn:
+            loaded = db.repos.list_proposed_actions_for_turn(
+                run.run_id, turn.turn_id, conn
+            )
+
+        assert len(loaded) == 2
+        assert loaded[0].record_kind == "validated"
+        assert loaded[1].record_kind == "rejected"
+
+    def test_returns_empty_when_no_llm_rows(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "test.sqlite3"
+        db = SimulationDatabase(db_path)
+        db.initialize()
+        config = LocalSimulationConfig.default()
+        run = factories.RunRecordFactory.create(
+            config_json=config.model_dump(mode="json"),
+            seed_metadata_json=None,
+        )
+
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            turn = factories.TurnRecordFactory.create(run_id=run.run_id, turn_number=1)
+            db.repos.insert_turn(turn, conn)
+            snapshot = load_turn_snapshot(run.run_id, turn.turn_id, db.repos, conn)
+            feed_records: list[GeneratedFeedRecord] = [
+                GeneratedFeedRecord(
+                    feed_id=new_feed_id(),
+                    run_id=run.run_id,
+                    turn_id=turn.turn_id,
+                    user_id="u1",
+                    algorithm="chronological",
+                    feed_post_ids=[],
+                    feed_posts=[],
+                    created_at=FIXED_TS,
+                )
+            ]
+            proposed = validate_and_persist_proposed_actions(
+                snapshot,
+                feed_records,
+                config.action,
+                db.repos,
+                conn,
+            )
+
+        assert proposed == []

--- a/tests/simulation_v2/actions/test_validators.py
+++ b/tests/simulation_v2/actions/test_validators.py
@@ -1,0 +1,308 @@
+"""Unit tests for action business-rule validators."""
+
+from __future__ import annotations
+
+import pytest
+
+from simulation_v2.actions.validators import (
+    ActionValidationOutcome,
+    validate_comment_on_post_action,
+    validate_follow_user_action,
+    validate_like_post_action,
+    validate_write_post_action,
+)
+
+
+def _accepted() -> ActionValidationOutcome:
+    return ActionValidationOutcome(accepted=True)
+
+
+def _rejected(filter_id: str, reason: str) -> ActionValidationOutcome:
+    return ActionValidationOutcome(
+        accepted=False,
+        filter_id=filter_id,  # type: ignore[arg-type]
+        filter_reason=reason,
+    )
+
+
+FEED_POST_IDS = {"p1", "p2"}
+FEED_AUTHORS = {"p1": "u1", "p2": "u2"}
+FOLLOW_CANDIDATES = {"u2", "u3"}
+
+
+class TestValidateLikePostAction:
+    def test_accepts_valid_like(self) -> None:
+        outcome = validate_like_post_action(
+            user_id="u1",
+            post_id="p2",
+            feed_post_ids=FEED_POST_IDS,
+            feed_author_by_post_id=FEED_AUTHORS,
+            snapshot_liked_post_ids=set(),
+            accepted_likes_this_turn=set(),
+            accepted_like_count=0,
+            max_likes=5,
+        )
+        assert outcome == _accepted()
+
+    @pytest.mark.parametrize(
+        ("kwargs", "filter_id", "reason"),
+        [
+            (
+                {
+                    "user_id": "u1",
+                    "post_id": "p1",
+                    "feed_post_ids": FEED_POST_IDS,
+                    "feed_author_by_post_id": FEED_AUTHORS,
+                    "snapshot_liked_post_ids": set(),
+                    "accepted_likes_this_turn": set(),
+                    "accepted_like_count": 0,
+                    "max_likes": 5,
+                },
+                "no_self_like",
+                "Cannot like your own post",
+            ),
+            (
+                {
+                    "user_id": "u1",
+                    "post_id": "p2",
+                    "feed_post_ids": FEED_POST_IDS,
+                    "feed_author_by_post_id": FEED_AUTHORS,
+                    "snapshot_liked_post_ids": set(),
+                    "accepted_likes_this_turn": {"p2"},
+                    "accepted_like_count": 1,
+                    "max_likes": 5,
+                },
+                "duplicate_like",
+                "Duplicate like for post p2",
+            ),
+            (
+                {
+                    "user_id": "u1",
+                    "post_id": "p2",
+                    "feed_post_ids": FEED_POST_IDS,
+                    "feed_author_by_post_id": FEED_AUTHORS,
+                    "snapshot_liked_post_ids": {"p2"},
+                    "accepted_likes_this_turn": set(),
+                    "accepted_like_count": 0,
+                    "max_likes": 5,
+                },
+                "duplicate_like",
+                "Duplicate like for post p2",
+            ),
+            (
+                {
+                    "user_id": "u1",
+                    "post_id": "p9",
+                    "feed_post_ids": FEED_POST_IDS,
+                    "feed_author_by_post_id": FEED_AUTHORS,
+                    "snapshot_liked_post_ids": set(),
+                    "accepted_likes_this_turn": set(),
+                    "accepted_like_count": 0,
+                    "max_likes": 5,
+                },
+                "missing_target_post",
+                "Post p9 not in feed",
+            ),
+            (
+                {
+                    "user_id": "u1",
+                    "post_id": "p2",
+                    "feed_post_ids": FEED_POST_IDS,
+                    "feed_author_by_post_id": FEED_AUTHORS,
+                    "snapshot_liked_post_ids": set(),
+                    "accepted_likes_this_turn": set(),
+                    "accepted_like_count": 2,
+                    "max_likes": 2,
+                },
+                "max_actions_per_turn",
+                "Exceeded max like_post per turn (2)",
+            ),
+        ],
+    )
+    def test_rejects_invalid_like(
+        self, kwargs: dict, filter_id: str, reason: str
+    ) -> None:
+        outcome = validate_like_post_action(**kwargs)
+        assert outcome == _rejected(filter_id, reason)
+
+
+class TestValidateFollowUserAction:
+    def test_accepts_valid_follow(self) -> None:
+        outcome = validate_follow_user_action(
+            user_id="u1",
+            followee_id="u2",
+            follow_candidate_ids=FOLLOW_CANDIDATES,
+            snapshot_followed_user_ids=set(),
+            accepted_follows_this_turn=set(),
+            accepted_follow_count=0,
+            max_follows=3,
+        )
+        assert outcome == _accepted()
+
+    @pytest.mark.parametrize(
+        ("kwargs", "filter_id", "reason"),
+        [
+            (
+                {
+                    "user_id": "u1",
+                    "followee_id": "u1",
+                    "follow_candidate_ids": FOLLOW_CANDIDATES,
+                    "snapshot_followed_user_ids": set(),
+                    "accepted_follows_this_turn": set(),
+                    "accepted_follow_count": 0,
+                    "max_follows": 3,
+                },
+                "no_self_follow",
+                "Cannot follow yourself",
+            ),
+            (
+                {
+                    "user_id": "u1",
+                    "followee_id": "u2",
+                    "follow_candidate_ids": FOLLOW_CANDIDATES,
+                    "snapshot_followed_user_ids": set(),
+                    "accepted_follows_this_turn": {"u2"},
+                    "accepted_follow_count": 1,
+                    "max_follows": 3,
+                },
+                "duplicate_follow",
+                "Duplicate follow for user u2",
+            ),
+            (
+                {
+                    "user_id": "u1",
+                    "followee_id": "u2",
+                    "follow_candidate_ids": FOLLOW_CANDIDATES,
+                    "snapshot_followed_user_ids": {"u2"},
+                    "accepted_follows_this_turn": set(),
+                    "accepted_follow_count": 0,
+                    "max_follows": 3,
+                },
+                "duplicate_follow",
+                "Duplicate follow for user u2",
+            ),
+            (
+                {
+                    "user_id": "u1",
+                    "followee_id": "u9",
+                    "follow_candidate_ids": FOLLOW_CANDIDATES,
+                    "snapshot_followed_user_ids": set(),
+                    "accepted_follows_this_turn": set(),
+                    "accepted_follow_count": 0,
+                    "max_follows": 3,
+                },
+                "missing_target_user",
+                "User u9 not in follow candidates",
+            ),
+            (
+                {
+                    "user_id": "u1",
+                    "followee_id": "u3",
+                    "follow_candidate_ids": FOLLOW_CANDIDATES,
+                    "snapshot_followed_user_ids": set(),
+                    "accepted_follows_this_turn": set(),
+                    "accepted_follow_count": 1,
+                    "max_follows": 1,
+                },
+                "max_actions_per_turn",
+                "Exceeded max follow_user per turn (1)",
+            ),
+        ],
+    )
+    def test_rejects_invalid_follow(
+        self, kwargs: dict, filter_id: str, reason: str
+    ) -> None:
+        outcome = validate_follow_user_action(**kwargs)
+        assert outcome == _rejected(filter_id, reason)
+
+
+class TestValidateWritePostAction:
+    def test_accepts_non_empty_content(self) -> None:
+        outcome = validate_write_post_action(
+            content="Hello world",
+            accepted_write_count=0,
+            max_posts=2,
+        )
+        assert outcome == _accepted()
+
+    @pytest.mark.parametrize(
+        ("kwargs", "filter_id", "reason"),
+        [
+            (
+                {"content": "   ", "accepted_write_count": 0, "max_posts": 2},
+                "empty_content",
+                "Action content is empty",
+            ),
+            (
+                {"content": None, "accepted_write_count": 0, "max_posts": 2},
+                "empty_content",
+                "Action content is empty",
+            ),
+            (
+                {"content": "ok", "accepted_write_count": 2, "max_posts": 2},
+                "max_actions_per_turn",
+                "Exceeded max write_post per turn (2)",
+            ),
+        ],
+    )
+    def test_rejects_invalid_write(
+        self, kwargs: dict, filter_id: str, reason: str
+    ) -> None:
+        outcome = validate_write_post_action(**kwargs)
+        assert outcome == _rejected(filter_id, reason)
+
+
+class TestValidateCommentOnPostAction:
+    def test_accepts_valid_comment(self) -> None:
+        outcome = validate_comment_on_post_action(
+            parent_post_id="p1",
+            content="Nice post",
+            feed_post_ids=FEED_POST_IDS,
+            accepted_comment_count=0,
+            max_comments=3,
+        )
+        assert outcome == _accepted()
+
+    @pytest.mark.parametrize(
+        ("kwargs", "filter_id", "reason"),
+        [
+            (
+                {
+                    "parent_post_id": "p1",
+                    "content": "",
+                    "feed_post_ids": FEED_POST_IDS,
+                    "accepted_comment_count": 0,
+                    "max_comments": 3,
+                },
+                "empty_content",
+                "Action content is empty",
+            ),
+            (
+                {
+                    "parent_post_id": "p9",
+                    "content": "hi",
+                    "feed_post_ids": FEED_POST_IDS,
+                    "accepted_comment_count": 0,
+                    "max_comments": 3,
+                },
+                "missing_parent_post",
+                "Parent post p9 not in feed",
+            ),
+            (
+                {
+                    "parent_post_id": "p1",
+                    "content": "hi",
+                    "feed_post_ids": FEED_POST_IDS,
+                    "accepted_comment_count": 1,
+                    "max_comments": 1,
+                },
+                "max_actions_per_turn",
+                "Exceeded max comment_on_post per turn (1)",
+            ),
+        ],
+    )
+    def test_rejects_invalid_comment(
+        self, kwargs: dict, filter_id: str, reason: str
+    ) -> None:
+        outcome = validate_comment_on_post_action(**kwargs)
+        assert outcome == _rejected(filter_id, reason)

--- a/tests/simulation_v2/db/test_repositories_constraints.py
+++ b/tests/simulation_v2/db/test_repositories_constraints.py
@@ -170,6 +170,36 @@ class TestRepositoryRoundTrips:
 
         assert loaded == record
 
+    def test_list_proposed_actions_for_turn(self, db: SimulationDatabase) -> None:
+        run_id, turn_id = _insert_run_and_turn(db)
+        generation = factories.GenerationRecordFactory.create(
+            run_id=run_id, turn_id=turn_id
+        )
+        validated = factories.ProposedActionRecordFactory.create(
+            run_id=run_id,
+            turn_id=turn_id,
+            generation_id=generation.generation_id,
+            record_kind="validated",
+            created_at="2026-01-01T00:00:01+00:00",
+        )
+        rejected = factories.ProposedActionRecordFactory.create(
+            run_id=run_id,
+            turn_id=turn_id,
+            generation_id=generation.generation_id,
+            record_kind="rejected",
+            rejection_stage="business_rules",
+            filter_id="duplicate_like",
+            filter_reason="Duplicate like for post p1",
+            created_at="2026-01-01T00:00:02+00:00",
+        )
+        with transaction(db._db_path) as conn:
+            db.repos.insert_generation(generation, conn)
+            db.repos.insert_proposed_action(validated, conn)
+            db.repos.insert_proposed_action(rejected, conn)
+            loaded = db.repos.list_proposed_actions_for_turn(run_id, turn_id, conn)
+
+        assert loaded == [validated, rejected]
+
     def test_eval_run_round_trip(self, db: SimulationDatabase) -> None:
         run_id, turn_id = _insert_run_and_turn(db)
         record = factories.EvalRunRecordFactory.create(run_id=run_id, turn_id=turn_id)


### PR DESCRIPTION
## Overview

PR 8 persists raw LLM outputs to `llm_proposed_actions`. PR 9 adds the next pipeline stage: apply named business validators to those rows, emit structured accept/reject outcomes with stable `filter_id` / `filter_reason` values (for PR 13 eval plugins like `invalid_action_rate`), and persist one append-only `ProposedActionRecord` per validated outcome to `proposed_actions`. Validators live in a pure module (no SQLite); `simulation_v2/actions/service.py` orchestrates reads/writes; `simulation_v2/worker/turn_executor.py` calls the new service right after LLM generation.

## Problem / motivation

Raw LLM proposals can violate business rules (self-likes, duplicates, missing feed targets, empty content, per-turn caps). PR 8 only captures generation output; downstream execution and evals need auditable validated/rejected records with stable rejection reasons.

## Solution

Add pure validators in `actions/validators.py`, orchestrate validation + persistence in `validate_and_persist_proposed_actions`, add `list_proposed_actions_for_turn` repository read path, and wire validation into `execute_turn` immediately after LLM generation.

## Happy Flow

1. `worker/turn_executor.execute_turn` loads `TurnStateSnapshot`, generates feeds, then calls `generate_and_persist_llm_actions` (PR 8, unchanged).
2. New call: `validate_and_persist_proposed_actions(snapshot, feed_records, action_config, repos, conn)` in `actions/service.py`.
3. Service loads all `LlmProposedActionRecord` rows for the turn via `repos.list_llm_proposed_actions_for_turn`.
4. For each row (stable order: `created_at`, then `llm_proposed_action_id`), service builds per-user context from snapshot + `GeneratedFeedRecord`.
5. Service dispatches to `actions/validators.py` by `action_type`; validators return `ActionValidationOutcome(accepted, filter_id, filter_reason)` — no DB access.
6. Service maps each outcome to a `ProposedActionRecord` (validated or rejected with `rejection_stage="business_rules"`).
7. Service inserts via `repos.insert_proposed_action` using `new_action_id()`.
8. Turn completes as today (execution/diffs remain PR 10).

## Changes

- `docs/plans/2026-05-26_simulation_v2_pr9_action_validators_847297/contracts.md`: frozen symbols, FilterId table, invariants
- `simulation_v2/actions/validators.py`: pure business validators for like/follow/write/comment actions
- `simulation_v2/actions/service.py`: `validate_and_persist_proposed_actions` orchestration
- `simulation_v2/actions/__init__.py`: export new service entrypoint
- `simulation_v2/db/repositories.py`: `list_proposed_actions_for_turn`
- `simulation_v2/worker/turn_executor.py`: call validation after LLM generation
- `tests/simulation_v2/actions/test_validators.py`: unit tests for all filter_id cases
- `tests/simulation_v2/actions/test_action_validation_service.py`: service integration tests
- `tests/simulation_v2/actions/test_action_service.py`: end-to-end turn validation assertions
- `tests/simulation_v2/db/test_repositories_constraints.py`: list proposed actions round-trip

## Manual Verification

- `uv run pytest tests/simulation_v2/actions/test_validators.py -q` — all passed
- `uv run pytest tests/simulation_v2/actions/test_action_validation_service.py tests/simulation_v2/db/test_repositories_constraints.py -q` — all passed
- `uv run pytest tests/simulation_v2/actions/test_action_service.py tests/simulation_v2/test_worker_service.py -q` — all passed
- `uv run ruff check simulation_v2/actions/validators.py simulation_v2/actions/service.py simulation_v2/worker/turn_executor.py simulation_v2/db/repositories.py` — no violations


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validates LLM-proposed social actions (likes, follows, posts, comments) against business rules and persists validated or rejected outcomes with rejection reasons.
  * Turn execution now runs validation and stores validated/rejected proposed actions so turn results reflect applied business rules.

* **Bug Fixes / Improvements**
  * Deterministic ordering and per-user in-turn state ensure consistent validation across proposals.

* **Tests**
  * Added unit and integration tests covering validators, persistence, and end-to-end turn behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/METResearchGroup/social_agent_simulation_platform/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->