### PR TITLE
Add turn diff execution for validated actions (PR 10)

### DIFF
--- a/docs/plans/2026-05-26_simulation_v2_pr10_turn_diff_execution_847298/contracts.md
+++ b/docs/plans/2026-05-26_simulation_v2_pr10_turn_diff_execution_847298/contracts.md
@@ -1,0 +1,52 @@
+# PR 10: Turn Diff Execution — Contract Freeze
+
+## Frozen symbols
+
+| Symbol | Location | Contract |
+| --- | --- | --- |
+| `build_pending_turn_diffs` | `simulation_v2/actions/executor.py` | `(validated_actions: list[ProposedActionRecord], snapshot: TurnStateSnapshot) -> PendingTurnDiffs` |
+| `persist_turn_diffs` | `simulation_v2/db/repositories.py` | `(diffs: PendingTurnDiffs, conn: sqlite3.Connection) -> None` |
+| `execute_turn` (behavior change) | `simulation_v2/worker/turn_executor.py` | After `validate_and_persist_proposed_actions`, call `build_pending_turn_diffs` then `persist_turn_diffs` on the same `conn` |
+| `PendingTurnDiffs` | `simulation_v2/worker/state.py` | **Unchanged** (PR 6 freeze) |
+| `validate_and_persist_proposed_actions` | `simulation_v2/actions/service.py` | **Unchanged** (PR 9 freeze) |
+
+## Validated action → entity mapping
+
+| `action_type` | Required fields on validated row | Output record |
+| --- | --- | --- |
+| `like_post` | `target_id` = post_id | `LikeRecord(like_id=new_like_id(), author_id=user_id, post_id=target_id, created_at_turn=snapshot.turn_number, ...)` |
+| `follow_user` | `target_id` = followee user_id | `FollowRecord(follow_id=new_follow_id(), follower_id=user_id, followee_id=target_id, ...)` |
+| `write_post` | `target_content` non-empty | `PostRecord(post_id=new_post_id(), author_id=user_id, content=target_content, ...)` |
+| `comment_on_post` | `target_id` = parent_post_id, `target_content` non-empty | `CommentRecord(comment_id=new_comment_id(), author_id=user_id, parent_post_id=target_id, content=target_content, ...)` |
+
+Shared fields for all outputs:
+
+- `run_id = snapshot.run_id`
+- `created_at = get_current_timestamp()` (from `simulation_v2/time.py`)
+- `created_at_turn = snapshot.turn_number`
+- `metadata_json = {"proposed_action_id": action.action_id}` (traceability; optional `generation_id`)
+
+Processing rules:
+
+- Input list order preserved (matches PR 9 ordering: `created_at`, `action_id`).
+- Skip / never pass rejected rows (caller filters).
+- Raise `ValueError` on validated row with unknown `action_type` (programmer error, not user-facing).
+- `memory_diffs` always `[]` in PR 10.
+
+## File-interaction invariants
+
+| Owner | Allowed callers | Forbidden |
+| --- | --- | --- |
+| `actions.executor` | `worker.turn_executor`, tests | No repository imports, no SQLite, no validator rules |
+| `db.repositories.persist_turn_diffs` | `worker.turn_executor`, tests | Must not build diffs or read `proposed_actions` |
+| `worker.turn_executor` | `run_executor`, tests | Must not map action types inline; must not update `agent_memories` |
+| `actions.validators`, `actions.service` (validation) | unchanged | Do not modify (PR 9 freeze) |
+| Legacy `simulation_v2/agents/*` | unchanged | Do not modify |
+
+## Out of scope (explicit)
+
+- `actions/noise.py` stochastic gating
+- `memory/service.py`, memory diff construction, `agent_memories` updates (PR 11)
+- Eval plugins
+- Schema changes / new tables
+- Modifying PR 8–9 frozen LLM/validator contracts

--- a/simulation_v2/actions/__init__.py
+++ b/simulation_v2/actions/__init__.py
@@ -1,8 +1,13 @@
 """Action LLM generation pipeline for simulation_v2."""
 
+from simulation_v2.actions.executor import build_pending_turn_diffs
 from simulation_v2.actions.service import (
     generate_and_persist_llm_actions,
     validate_and_persist_proposed_actions,
 )
 
-__all__ = ["generate_and_persist_llm_actions", "validate_and_persist_proposed_actions"]
+__all__ = [
+    "build_pending_turn_diffs",
+    "generate_and_persist_llm_actions",
+    "validate_and_persist_proposed_actions",
+]

--- a/simulation_v2/actions/executor.py
+++ b/simulation_v2/actions/executor.py
@@ -1,0 +1,99 @@
+"""Convert validated proposed actions into pending turn entity diffs."""
+
+from __future__ import annotations
+
+from simulation_v2.db.models import (
+    CommentRecord,
+    FollowRecord,
+    LikeRecord,
+    PostRecord,
+    ProposedActionRecord,
+)
+from simulation_v2.ids import (
+    new_comment_id,
+    new_follow_id,
+    new_like_id,
+    new_post_id,
+)
+from simulation_v2.time import get_current_timestamp
+from simulation_v2.worker.state import PendingTurnDiffs, TurnStateSnapshot
+
+
+def build_pending_turn_diffs(
+    validated_actions: list[ProposedActionRecord],
+    snapshot: TurnStateSnapshot,
+) -> PendingTurnDiffs:
+    posts: list[PostRecord] = []
+    likes: list[LikeRecord] = []
+    follows: list[FollowRecord] = []
+    comments: list[CommentRecord] = []
+
+    for action in validated_actions:
+        metadata_json = _metadata_for_action(action)
+        created_at = get_current_timestamp()
+        if action.action_type == "like_post":
+            likes.append(
+                LikeRecord(
+                    like_id=new_like_id(),
+                    run_id=snapshot.run_id,
+                    post_id=action.target_id or "",
+                    author_id=action.user_id,
+                    created_at=created_at,
+                    created_at_turn=snapshot.turn_number,
+                    metadata_json=metadata_json,
+                )
+            )
+        elif action.action_type == "follow_user":
+            follows.append(
+                FollowRecord(
+                    follow_id=new_follow_id(),
+                    run_id=snapshot.run_id,
+                    follower_id=action.user_id,
+                    followee_id=action.target_id or "",
+                    created_at=created_at,
+                    created_at_turn=snapshot.turn_number,
+                    metadata_json=metadata_json,
+                )
+            )
+        elif action.action_type == "write_post":
+            posts.append(
+                PostRecord(
+                    post_id=new_post_id(),
+                    run_id=snapshot.run_id,
+                    author_id=action.user_id,
+                    content=action.target_content or "",
+                    created_at=created_at,
+                    created_at_turn=snapshot.turn_number,
+                    metadata_json=metadata_json,
+                )
+            )
+        elif action.action_type == "comment_on_post":
+            comments.append(
+                CommentRecord(
+                    comment_id=new_comment_id(),
+                    run_id=snapshot.run_id,
+                    parent_post_id=action.target_id or "",
+                    author_id=action.user_id,
+                    content=action.target_content or "",
+                    created_at=created_at,
+                    created_at_turn=snapshot.turn_number,
+                    metadata_json=metadata_json,
+                )
+            )
+        else:
+            raise ValueError(f"Unsupported action type {action.action_type!r}")
+
+    return PendingTurnDiffs(
+        posts=posts,
+        likes=likes,
+        follows=follows,
+        comments=comments,
+        memory_diffs=[],
+    )
+
+
+def _metadata_for_action(action: ProposedActionRecord) -> dict[str, str]:
+    metadata: dict[str, str] = {"proposed_action_id": action.action_id}
+    if action.generation_id is not None:
+        metadata["generation_id"] = action.generation_id
+    return metadata

--- a/simulation_v2/db/repositories.py
+++ b/simulation_v2/db/repositories.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from simulation_v2.worker.state import PendingTurnDiffs
 
 from simulation_v2.db.errors import (
     InvalidStatusTransitionError,
@@ -614,6 +617,20 @@ class SimulationRepositories:
             )
             for row in rows
         ]
+
+    def persist_turn_diffs(
+        self, diffs: PendingTurnDiffs, conn: sqlite3.Connection
+    ) -> None:
+        for post in diffs.posts:
+            self.insert_post(post, conn)
+        for like in diffs.likes:
+            self.insert_like(like, conn)
+        for follow in diffs.follows:
+            self.insert_follow(follow, conn)
+        for comment in diffs.comments:
+            self.insert_comment(comment, conn)
+        for memory_diff in diffs.memory_diffs:
+            self.insert_memory_diff(memory_diff, conn)
 
     def insert_agent_memory(
         self, record: AgentMemoryRecord, conn: sqlite3.Connection

--- a/simulation_v2/worker/turn_executor.py
+++ b/simulation_v2/worker/turn_executor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 
+from simulation_v2.actions.executor import build_pending_turn_diffs
 from simulation_v2.actions.service import (
     generate_and_persist_llm_actions,
     validate_and_persist_proposed_actions,
@@ -60,12 +61,15 @@ def execute_turn(
         conn,
         trace_ctx=trace_ctx,
     )
-    validate_and_persist_proposed_actions(
+    proposed_records = validate_and_persist_proposed_actions(
         snapshot,
         feed_records,
         snapshot.config.action,
         repos,
         conn,
     )
+    validated = [r for r in proposed_records if r.record_kind == "validated"]
+    diffs = build_pending_turn_diffs(validated, snapshot)
+    repos.persist_turn_diffs(diffs, conn)
     repos.update_turn_status(turn_id, "completed", conn)
     return snapshot

--- a/tests/simulation_v2/actions/test_action_service.py
+++ b/tests/simulation_v2/actions/test_action_service.py
@@ -293,6 +293,7 @@ class TestExecuteTurnActionValidation:
             proposed_actions = db.repos.list_proposed_actions_for_turn(
                 run.run_id, turns[0].turn_id, conn
             )
+            likes = db.repos.list_likes_for_run(run.run_id, conn)
 
         assert len(proposed_actions) == 2
         validated = [action for action in proposed_actions if action.user_id == "u1"]
@@ -304,3 +305,11 @@ class TestExecuteTurnActionValidation:
         assert rejected[0].record_kind == "rejected"
         assert rejected[0].filter_id == "missing_target_post"
         assert rejected[0].rejection_stage == "business_rules"
+        persisted_like = next(
+            like for like in likes if like.author_id == "u1" and like.post_id == "p2"
+        )
+        assert persisted_like.created_at_turn == 1
+        assert persisted_like.metadata_json == {
+            "proposed_action_id": validated[0].action_id,
+            "generation_id": validated[0].generation_id,
+        }

--- a/tests/simulation_v2/actions/test_executor.py
+++ b/tests/simulation_v2/actions/test_executor.py
@@ -1,0 +1,138 @@
+"""Unit tests for build_pending_turn_diffs."""
+
+from __future__ import annotations
+
+import pytest
+
+from simulation_v2.actions.executor import build_pending_turn_diffs
+from simulation_v2.config import LocalSimulationConfig
+from simulation_v2.worker.state import TurnStateSnapshot
+from tests.simulation_v2.db import factories
+
+RUN_ID = "run-1"
+TURN_ID = "turn-1"
+
+
+def _snapshot(*, turn_number: int = 1) -> TurnStateSnapshot:
+    return TurnStateSnapshot(
+        run_id=RUN_ID,
+        turn_id=TURN_ID,
+        turn_number=turn_number,
+        config=LocalSimulationConfig.default(),
+        users={},
+        posts={},
+        likes=[],
+        follows=[],
+        comments=[],
+        agent_memories={},
+        prior_generated_feeds=[],
+    )
+
+
+class TestBuildPendingTurnDiffs:
+    def test_like_post_maps_to_like_record(self) -> None:
+        action = factories.ProposedActionRecordFactory.create(
+            run_id=RUN_ID,
+            turn_id=TURN_ID,
+            user_id="u1",
+            action_type="like_post",
+            target_id="p2",
+            record_kind="validated",
+        )
+        diffs = build_pending_turn_diffs([action], _snapshot())
+        assert len(diffs.likes) == 1
+        like = diffs.likes[0]
+        assert like.author_id == "u1"
+        assert like.post_id == "p2"
+        assert like.run_id == RUN_ID
+        assert like.created_at_turn == 1
+        assert like.metadata_json == {
+            "proposed_action_id": action.action_id,
+            "generation_id": action.generation_id,
+        }
+
+    def test_follow_user_maps_to_follow_record(self) -> None:
+        action = factories.ProposedActionRecordFactory.create(
+            run_id=RUN_ID,
+            user_id="u1",
+            action_type="follow_user",
+            target_id="u2",
+            record_kind="validated",
+        )
+        diffs = build_pending_turn_diffs([action], _snapshot())
+        assert len(diffs.follows) == 1
+        follow = diffs.follows[0]
+        assert follow.follower_id == "u1"
+        assert follow.followee_id == "u2"
+        assert follow.created_at_turn == 1
+
+    def test_write_post_maps_to_post_record_with_new_id(self) -> None:
+        action = factories.ProposedActionRecordFactory.create(
+            run_id=RUN_ID,
+            user_id="u1",
+            action_type="write_post",
+            target_id=None,
+            target_content="hello world",
+            record_kind="validated",
+        )
+        diffs = build_pending_turn_diffs([action], _snapshot())
+        assert len(diffs.posts) == 1
+        post = diffs.posts[0]
+        assert post.author_id == "u1"
+        assert post.content == "hello world"
+        assert post.post_id
+        assert post.created_at_turn == 1
+
+    def test_comment_on_post_maps_to_comment_record(self) -> None:
+        action = factories.ProposedActionRecordFactory.create(
+            run_id=RUN_ID,
+            user_id="u1",
+            action_type="comment_on_post",
+            target_id="p1",
+            target_content="nice post",
+            record_kind="validated",
+        )
+        diffs = build_pending_turn_diffs([action], _snapshot())
+        assert len(diffs.comments) == 1
+        comment = diffs.comments[0]
+        assert comment.author_id == "u1"
+        assert comment.parent_post_id == "p1"
+        assert comment.content == "nice post"
+        assert comment.created_at_turn == 1
+
+    def test_preserves_input_order_for_multiple_likes(self) -> None:
+        like_a = factories.ProposedActionRecordFactory.create(
+            run_id=RUN_ID,
+            user_id="u1",
+            action_type="like_post",
+            target_id="p1",
+            record_kind="validated",
+        )
+        like_b = factories.ProposedActionRecordFactory.create(
+            run_id=RUN_ID,
+            user_id="u1",
+            action_type="like_post",
+            target_id="p2",
+            record_kind="validated",
+        )
+        diffs = build_pending_turn_diffs([like_a, like_b], _snapshot())
+        assert [like.post_id for like in diffs.likes] == ["p1", "p2"]
+
+    def test_memory_diffs_always_empty(self) -> None:
+        action = factories.ProposedActionRecordFactory.create(
+            run_id=RUN_ID,
+            action_type="like_post",
+            target_id="p1",
+            record_kind="validated",
+        )
+        diffs = build_pending_turn_diffs([action], _snapshot())
+        assert diffs.memory_diffs == []
+
+    def test_unknown_action_type_raises_value_error(self) -> None:
+        action = factories.ProposedActionRecordFactory.create(
+            run_id=RUN_ID,
+            action_type="unsupported",
+            record_kind="validated",
+        )
+        with pytest.raises(ValueError, match="Unsupported action type"):
+            build_pending_turn_diffs([action], _snapshot())

--- a/tests/simulation_v2/db/test_persist_turn_diffs.py
+++ b/tests/simulation_v2/db/test_persist_turn_diffs.py
@@ -1,0 +1,63 @@
+"""Tests for SimulationRepositories.persist_turn_diffs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from simulation_v2.worker.state import PendingTurnDiffs
+from tests.simulation_v2.db import factories
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "test.sqlite3"
+    SimulationDatabase(path).initialize()
+    return path
+
+
+class TestPersistTurnDiffs:
+    def test_persists_mixed_entity_diffs(self, db_path: Path) -> None:
+        run = factories.RunRecordFactory.create()
+        post = factories.PostRecordFactory.create(run_id=run.run_id, post_id="p-new")
+        like = factories.LikeRecordFactory.create(run_id=run.run_id, like_id="l-new")
+        follow = factories.FollowRecordFactory.create(
+            run_id=run.run_id, follow_id="f-new"
+        )
+        comment = factories.CommentRecordFactory.create(
+            run_id=run.run_id, comment_id="c-new"
+        )
+        diffs = PendingTurnDiffs(
+            posts=[post],
+            likes=[like],
+            follows=[follow],
+            comments=[comment],
+        )
+
+        db = SimulationDatabase(db_path)
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            db.repos.persist_turn_diffs(diffs, conn)
+
+            assert len(db.repos.list_posts_for_run(run.run_id, conn)) == 1
+            assert len(db.repos.list_likes_for_run(run.run_id, conn)) == 1
+            assert len(db.repos.list_follows_for_run(run.run_id, conn)) == 1
+            assert len(db.repos.list_comments_for_run(run.run_id, conn)) == 1
+            assert db.repos.get_post(run.run_id, "p-new", conn) == post
+            assert db.repos.get_like("l-new", conn) == like
+            assert db.repos.get_follow("f-new", conn) == follow
+            assert db.repos.get_comment("c-new", conn) == comment
+
+    def test_empty_diff_is_no_op(self, db_path: Path) -> None:
+        run = factories.RunRecordFactory.create()
+        db = SimulationDatabase(db_path)
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            db.repos.persist_turn_diffs(PendingTurnDiffs(), conn)
+            assert db.repos.list_posts_for_run(run.run_id, conn) == []
+            assert db.repos.list_likes_for_run(run.run_id, conn) == []
+            assert db.repos.list_follows_for_run(run.run_id, conn) == []
+            assert db.repos.list_comments_for_run(run.run_id, conn) == []

--- a/tests/simulation_v2/worker/test_turn_diff_execution.py
+++ b/tests/simulation_v2/worker/test_turn_diff_execution.py
@@ -1,0 +1,224 @@
+"""Integration tests for turn diff execution after validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from simulation_v2.actions.models import (
+    LlmGenerationResult,
+    LlmLikePostOutput,
+    LlmWritePostOutput,
+)
+from simulation_v2.config import ActionConfig, FeedConfig, LocalSimulationConfig
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from simulation_v2.models.seed_data import LoadedPostModel, LoadedUserModel
+from simulation_v2.seed.loader import persist_seed_for_run
+from simulation_v2.seed.models import SeedDataset
+from simulation_v2.worker.state import load_turn_snapshot
+from simulation_v2.worker.turn_executor import execute_turn
+from tests.simulation_v2.actions.test_action_service import _tiny_dataset
+from tests.simulation_v2.db import factories
+
+FIXED_TS = "2026-01-01T00:00:00.000000+00:00"
+
+
+def _like_config(*, total_turns: int = 1) -> LocalSimulationConfig:
+    return LocalSimulationConfig.default().model_copy(
+        update={
+            "total_turns": total_turns,
+            "feed": FeedConfig(include_probability=1.0, max_posts=10),
+            "action": ActionConfig(
+                enable_like_post=True,
+                enable_write_post=False,
+                enable_follow_user=False,
+                enable_comment_on_post=False,
+            ),
+        }
+    )
+
+
+def _write_post_config(*, total_turns: int = 2) -> LocalSimulationConfig:
+    return LocalSimulationConfig.default().model_copy(
+        update={
+            "total_turns": total_turns,
+            "feed": FeedConfig(include_probability=1.0, max_posts=10),
+            "action": ActionConfig(
+                enable_like_post=False,
+                enable_write_post=True,
+                enable_follow_user=False,
+                enable_comment_on_post=False,
+            ),
+        }
+    )
+
+
+class TestTurnDiffExecution:
+    def test_single_turn_executes_validated_like(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "test.sqlite3"
+        db = SimulationDatabase(db_path)
+        db.initialize()
+        config = _like_config()
+        run = factories.RunRecordFactory.create(
+            config_json=config.model_dump(mode="json"),
+            seed_metadata_json=None,
+        )
+        dataset = _tiny_dataset()
+        mock_result = LlmGenerationResult(
+            status="completed",
+            parsed=LlmLikePostOutput(post_ids=["p2"]),
+            latency_ms=1.0,
+        )
+
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            persist_seed_for_run(run.run_id, dataset, db.repos, conn)
+            likes_before = len(db.repos.list_likes_for_run(run.run_id, conn))
+
+        with patch(
+            "simulation_v2.actions.service.invoke_structured_generation",
+            return_value=mock_result,
+        ):
+            with transaction(db_path) as conn:
+                execute_turn(run.run_id, 1, config, conn, db.repos)
+
+        with transaction(db_path) as conn:
+            likes = db.repos.list_likes_for_run(run.run_id, conn)
+
+        assert len(likes) == likes_before + 1
+        new_like = next(
+            like for like in likes if like.author_id == "u1" and like.post_id == "p2"
+        )
+        assert new_like.created_at_turn == 1
+
+    def test_turn_two_reads_turn_one_write_post(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "test.sqlite3"
+        db = SimulationDatabase(db_path)
+        db.initialize()
+        config = _write_post_config(total_turns=2)
+        run = factories.RunRecordFactory.create(
+            config_json=config.model_dump(mode="json"),
+            seed_metadata_json=None,
+        )
+        dataset = SeedDataset(
+            users={
+                "u1": LoadedUserModel(
+                    user_id="u1",
+                    name="Alice",
+                    email="a@example.com",
+                    username="alice",
+                    created_at=FIXED_TS,
+                    num_followers=0,
+                    num_follows=0,
+                ),
+            },
+            posts={
+                "p1": LoadedPostModel(
+                    post_id="p1",
+                    user_id="u1",
+                    content="seed",
+                    created_at=FIXED_TS,
+                    num_likes=0,
+                ),
+            },
+            likes={},
+            follows={},
+        )
+        write_result = LlmGenerationResult(
+            status="completed",
+            parsed=LlmWritePostOutput(content="turn one post"),
+            latency_ms=1.0,
+        )
+
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            persist_seed_for_run(run.run_id, dataset, db.repos, conn)
+
+        with patch(
+            "simulation_v2.actions.service.invoke_structured_generation",
+            return_value=write_result,
+        ):
+            with transaction(db_path) as conn:
+                execute_turn(run.run_id, 1, config, conn, db.repos)
+
+        with transaction(db_path) as conn:
+            posts_after_turn_one = db.repos.list_posts_for_run(run.run_id, conn)
+            turn_one_posts = [
+                post
+                for post in posts_after_turn_one
+                if post.content == "turn one post" and post.created_at_turn == 1
+            ]
+            assert len(turn_one_posts) == 1
+            turn_one_post_id = turn_one_posts[0].post_id
+
+        with patch(
+            "simulation_v2.actions.service.invoke_structured_generation",
+            return_value=write_result,
+        ):
+            with transaction(db_path) as conn:
+                execute_turn(run.run_id, 2, config, conn, db.repos)
+                turns = db.repos.list_turns_for_run(run.run_id, conn)
+                turn_two = next(t for t in turns if t.turn_number == 2)
+                snapshot = load_turn_snapshot(
+                    run.run_id, turn_two.turn_id, db.repos, conn
+                )
+
+        assert turn_one_post_id in snapshot.posts
+        assert snapshot.posts[turn_one_post_id].content == "turn one post"
+
+    def test_rejected_actions_do_not_persist_likes(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "test.sqlite3"
+        db = SimulationDatabase(db_path)
+        db.initialize()
+        config = _like_config()
+        run = factories.RunRecordFactory.create(
+            config_json=config.model_dump(mode="json"),
+            seed_metadata_json=None,
+        )
+        dataset = SeedDataset(
+            users={
+                "u1": LoadedUserModel(
+                    user_id="u1",
+                    name="Alice",
+                    email="a@example.com",
+                    username="alice",
+                    created_at=FIXED_TS,
+                    num_followers=0,
+                    num_follows=0,
+                ),
+            },
+            posts={
+                "p1": LoadedPostModel(
+                    post_id="p1",
+                    user_id="u1",
+                    content="solo",
+                    created_at=FIXED_TS,
+                    num_likes=0,
+                ),
+            },
+            likes={},
+            follows={},
+        )
+        mock_result = LlmGenerationResult(
+            status="completed",
+            parsed=LlmLikePostOutput(post_ids=["missing-post"]),
+            latency_ms=1.0,
+        )
+
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            persist_seed_for_run(run.run_id, dataset, db.repos, conn)
+            likes_before = len(db.repos.list_likes_for_run(run.run_id, conn))
+
+        with patch(
+            "simulation_v2.actions.service.invoke_structured_generation",
+            return_value=mock_result,
+        ):
+            with transaction(db_path) as conn:
+                execute_turn(run.run_id, 1, config, conn, db.repos)
+
+        with transaction(db_path) as conn:
+            likes_after = db.repos.list_likes_for_run(run.run_id, conn)
+
+        assert len(likes_after) == likes_before


### PR DESCRIPTION
## Overview

PRs 1–9 persist feeds, LLM generations, and validated/rejected `proposed_actions`, but accepted actions are never written to `posts` / `likes` / `follows` / `comments`. Turn 2 therefore cannot see turn 1 social activity. PR 10 closes that gap: `actions.executor` maps validated rows to typed entity records inside `PendingTurnDiffs`, and `worker.turn_executor` persists them via a new repository helper on the same SQLite connection already used for the turn. Memory diff population and `agent_memories` updates remain PR 11 scope; `memory_diffs` stays empty in this PR.

## Problem / motivation

Validated proposed actions were stored for audit and replay, but no code path converted them into durable social entities. `load_turn_snapshot` filters posts/likes/follows/comments by `created_at_turn < turn_number`, so turn N+1 never observed turn N activity even when validation accepted actions.

## Solution

Add pure conversion in `build_pending_turn_diffs`, repository insertion in `persist_turn_diffs`, and wire both into `execute_turn` immediately after `validate_and_persist_proposed_actions` on the same connection. Only `record_kind == "validated"` rows are converted; rejected rows never reach persistence.

## Happy Flow

1. `simulation_v2/worker/turn_executor.py` loads snapshot via `load_turn_snapshot` (unchanged).
2. Feeds and LLM actions run as today (PRs 7–8).
3. `validate_and_persist_proposed_actions` writes validated/rejected rows (PR 9; frozen contract).
4. **New:** Filter returned records to `record_kind == "validated"`.
5. **New:** `build_pending_turn_diffs(validated, snapshot)` returns `PendingTurnDiffs` with typed entity lists (`memory_diffs` empty).
6. **New:** `repos.persist_turn_diffs(diffs, conn)` inserts all entity rows.
7. Turn status → `completed` (unchanged).
8. Next turn’s `load_turn_snapshot` includes entities where `created_at_turn < turn_number`, so turn 2 sees turn 1 writes.

## Data Flow

```mermaid
flowchart TD
  executeTurn[execute_turn] --> validate[validate_and_persist_proposed_actions]
  validate --> buildDiffs[build_pending_turn_diffs]
  buildDiffs --> persist[persist_turn_diffs]
  persist --> completeTurn[update_turn_status completed]
  nextTurn[execute_turn turn N+1] --> snapshot[load_turn_snapshot]
  snapshot --> readsPrior[reads created_at_turn less than N+1]
```

## Changes

- `docs/plans/2026-05-26_simulation_v2_pr10_turn_diff_execution_847298/contracts.md`: PR 10 contract freeze
- `simulation_v2/actions/executor.py`: `build_pending_turn_diffs` maps validated actions → `PendingTurnDiffs`
- `simulation_v2/db/repositories.py`: `persist_turn_diffs` inserts posts/likes/follows/comments/memory_diffs
- `simulation_v2/worker/turn_executor.py`: wire conversion + persist after validation
- `simulation_v2/actions/__init__.py`: export `build_pending_turn_diffs`
- `tests/simulation_v2/actions/test_executor.py`: executor unit tests
- `tests/simulation_v2/db/test_persist_turn_diffs.py`: repository persist tests
- `tests/simulation_v2/worker/test_turn_diff_execution.py`: two-turn read-after-write integration tests
- `tests/simulation_v2/actions/test_action_service.py`: assert validated like creates `LikeRecord`

## Manual Verification

- [x] Branch `pr10-turn-diff-execution` from `main` after PR #320 merge
- [x] Contract doc at `docs/plans/2026-05-26_simulation_v2_pr10_turn_diff_execution_847298/contracts.md`
- [x] `uv run pytest tests/simulation_v2/actions/test_executor.py -q` — 7 passed
- [x] `uv run pytest tests/simulation_v2/db/test_persist_turn_diffs.py -q` — 2 passed
- [x] `uv run pytest tests/simulation_v2/worker/test_turn_diff_execution.py -q` — 3 passed
- [x] `uv run pytest tests/simulation_v2/actions/test_executor.py tests/simulation_v2/db/test_persist_turn_diffs.py tests/simulation_v2/worker/test_turn_diff_execution.py tests/simulation_v2/actions/test_action_service.py tests/simulation_v2/worker/test_state.py -q` — 18 passed
- [x] `uv run pytest tests/simulation_v2/ -q --import-mode=importlib` (excluding LLM e2e dispatch tests) — 193 passed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Validated user actions (likes, follows, posts, and comments) are now properly persisted to the database with complete metadata tracking and turn information.

* **Tests**
  * Added comprehensive unit and integration test coverage for action persistence, database storage, and turn state handling across multiple scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/METResearchGroup/social_agent_simulation_platform/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->