### PR TITLE
Add eval plugin framework with turn and run execution (PR 12)

### DIFF
--- a/docs/plans/2026-05-26_simulation_v2_pr12_eval_framework_847300/contracts.md
+++ b/docs/plans/2026-05-26_simulation_v2_pr12_eval_framework_847300/contracts.md
@@ -1,0 +1,35 @@
+# PR 12 Eval Framework — Contract Freeze
+
+| Symbol | Location | Contract |
+| --- | --- | --- |
+| `EvalScope` | reuse from `simulation_v2/db/models/evals.py` | `"turn" \| "run"` |
+| `EvalMetricDraft` | `simulation_v2/evals/interfaces.py` | `metric_name: str`, `metric_value: float`, `metadata_json: dict \| None = None` — pre-persistence metric payload |
+| `EvalResult` | `simulation_v2/evals/interfaces.py` | `plugin_name: str`, `status: Literal["passed","failed"]`, `metrics: list[EvalMetricDraft]`, `warnings: list[str] = []` |
+| `EvalContext` | `simulation_v2/evals/interfaces.py` | `repos: SimulationRepositories`, `conn: sqlite3.Connection`, `run_id: str`, `config: LocalSimulationConfig`, `scope: EvalScope`, `turn_id: str \| None`, `turn_number: int \| None`, `turn_summary: dict \| None = None` (optional; unused in PR 12) |
+| `EvalPlugin` | `simulation_v2/evals/interfaces.py` | Protocol: `name: str`, `scope: EvalScope`, `run(context: EvalContext) -> EvalResult` |
+| `get_eval_plugin` | `simulation_v2/evals/registry.py` | `(name: str) -> EvalPlugin \| None` — returns `None` for unknown names |
+| `register_eval_plugin` | `simulation_v2/evals/registry.py` | `(plugin: EvalPlugin) -> None` — for tests and PR 13 registration |
+| `EvalPluginRunSummary` | `simulation_v2/evals/runner.py` | Returned per plugin: `eval_run_id`, `plugin_name`, `status`, `metrics: list[EvalMetricRecord]` |
+| `run_turn_evals` | `simulation_v2/evals/runner.py` | `(run_id, turn_id, turn_number, config, repos, conn) -> list[EvalPluginRunSummary]`; no-op when `not config.evals.enabled` |
+| `run_run_evals` | `simulation_v2/evals/runner.py` | `(run_id, config, repos, conn) -> list[EvalPluginRunSummary]`; same enable gate |
+| `insert_eval_run` / `insert_eval_metric` | `simulation_v2/db/repositories.py` | **Already complete** — reuse as-is |
+| `new_eval_run_id` / `new_eval_metric_id` | `simulation_v2/ids.py` | **Already exist** |
+| `EvalConfig` | `simulation_v2/config.py` | **Already exists** — `enabled`, `fail_run_on_error`, `turn_plugins`, `run_plugins`; do not change defaults in PR 12 |
+
+## File-interaction invariants
+
+| Owner | Allowed callers | Forbidden |
+| --- | --- | --- |
+| `evals.runner` | `turn_executor`, `run_executor`, tests | Only module that executes plugins and writes eval rows |
+| `evals.registry` | `evals.runner`, tests, PR 13 plugin modules | No SQLite, no worker imports |
+| Eval plugins | invoked via runner only | Must not mutate run state; read via `EvalContext` only |
+| `db.repositories` | runner (insert/get eval rows) | Must not import `evals.runner` or plugins |
+
+## Eval run status mapping
+
+| Outcome | `eval_runs.status` | `eval_runs.error` |
+| --- | --- | --- |
+| Plugin returns `status="passed"` | `"completed"` | `None` |
+| Plugin returns `status="failed"` | `"failed"` | join `warnings` or fixed message |
+| Plugin raises | `"failed"` | `str(exc)` |
+| Unknown plugin name | *(skip — no row)* | — |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+importmode = "importlib"
 markers = [
     "smoke: smoke tests against a running API (set SIMULATION_API_URL to run).",
     "e2e: end-to-end tests (temp DB + subprocess uvicorn); see tests/api/test_simulation_local_reset_e2e.py.",
@@ -92,6 +93,7 @@ addopts = [
     "--disable-warnings",
     "--tb=short",
     "-v",
+    "--import-mode=importlib",
 ]
 
 [tool.coverage.run]

--- a/simulation_v2/evals/__init__.py
+++ b/simulation_v2/evals/__init__.py
@@ -1,0 +1,15 @@
+"""Eval plugin framework for simulation_v2."""
+
+from simulation_v2.evals.interfaces import (
+    EvalContext,
+    EvalMetricDraft,
+    EvalPlugin,
+    EvalResult,
+)
+
+__all__ = [
+    "EvalContext",
+    "EvalMetricDraft",
+    "EvalPlugin",
+    "EvalResult",
+]

--- a/simulation_v2/evals/interfaces.py
+++ b/simulation_v2/evals/interfaces.py
@@ -1,0 +1,45 @@
+"""Eval plugin contracts for simulation_v2."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import ClassVar, Literal, Protocol
+
+from pydantic import BaseModel, Field
+
+from simulation_v2.config import LocalSimulationConfig
+from simulation_v2.db.models.evals import EvalScope
+from simulation_v2.db.repositories import SimulationRepositories
+
+
+class EvalMetricDraft(BaseModel):
+    metric_name: str
+    metric_value: float
+    metadata_json: dict | None = None
+
+
+class EvalResult(BaseModel):
+    plugin_name: str
+    status: Literal["passed", "failed"]
+    metrics: list[EvalMetricDraft]
+    warnings: list[str] = Field(default_factory=list)
+
+
+class EvalContext(BaseModel):
+    repos: SimulationRepositories
+    conn: sqlite3.Connection
+    run_id: str
+    config: LocalSimulationConfig
+    scope: EvalScope
+    turn_id: str | None
+    turn_number: int | None
+    turn_summary: dict | None = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class EvalPlugin(Protocol):
+    name: ClassVar[str]
+    scope: ClassVar[EvalScope]
+
+    def run(self, context: EvalContext) -> EvalResult: ...

--- a/simulation_v2/evals/registry.py
+++ b/simulation_v2/evals/registry.py
@@ -1,0 +1,15 @@
+"""Name-based registry for eval plugins."""
+
+from __future__ import annotations
+
+from simulation_v2.evals.interfaces import EvalPlugin
+
+_PLUGINS: dict[str, EvalPlugin] = {}
+
+
+def register_eval_plugin(plugin: EvalPlugin) -> None:
+    _PLUGINS[plugin.name] = plugin
+
+
+def get_eval_plugin(name: str) -> EvalPlugin | None:
+    return _PLUGINS.get(name)

--- a/simulation_v2/evals/runner.py
+++ b/simulation_v2/evals/runner.py
@@ -1,0 +1,234 @@
+"""Execute configured eval plugins and persist eval run/metric rows."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass
+
+from simulation_v2.config import LocalSimulationConfig
+from simulation_v2.db.models.evals import EvalMetricRecord, EvalRunRecord, EvalScope
+from simulation_v2.db.repositories import SimulationRepositories
+from simulation_v2.evals.interfaces import EvalContext, EvalResult
+from simulation_v2.evals.registry import get_eval_plugin
+from simulation_v2.ids import new_eval_metric_id, new_eval_run_id
+from simulation_v2.time import get_current_timestamp
+
+logger = logging.getLogger(__name__)
+
+_FAILED_STATUS_MESSAGE = "eval plugin returned failed status"
+
+
+class EvalExecutionError(Exception):
+    """Raised when eval execution fails and fail_run_on_error is enabled."""
+
+
+@dataclass(frozen=True)
+class EvalPluginRunSummary:
+    eval_run_id: str
+    plugin_name: str
+    status: str
+    metrics: list[EvalMetricRecord]
+
+
+def run_turn_evals(
+    run_id: str,
+    turn_id: str,
+    turn_number: int,
+    config: LocalSimulationConfig,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+) -> list[EvalPluginRunSummary]:
+    if not config.evals.enabled:
+        return []
+    return _run_evals(
+        run_id=run_id,
+        config=config,
+        repos=repos,
+        conn=conn,
+        scope="turn",
+        turn_id=turn_id,
+        turn_number=turn_number,
+        plugin_names=config.evals.turn_plugins,
+    )
+
+
+def run_run_evals(
+    run_id: str,
+    config: LocalSimulationConfig,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+) -> list[EvalPluginRunSummary]:
+    if not config.evals.enabled:
+        return []
+    return _run_evals(
+        run_id=run_id,
+        config=config,
+        repos=repos,
+        conn=conn,
+        scope="run",
+        turn_id=None,
+        turn_number=None,
+        plugin_names=config.evals.run_plugins,
+    )
+
+
+def _run_evals(
+    *,
+    run_id: str,
+    config: LocalSimulationConfig,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+    scope: EvalScope,
+    turn_id: str | None,
+    turn_number: int | None,
+    plugin_names: list[str],
+) -> list[EvalPluginRunSummary]:
+    summaries: list[EvalPluginRunSummary] = []
+    for plugin_name in plugin_names:
+        plugin = get_eval_plugin(plugin_name)
+        if plugin is None:
+            logger.warning("unknown eval plugin %r", plugin_name)
+            continue
+        if plugin.scope != scope:
+            logger.warning(
+                "eval plugin %r has scope %r but invoked for scope %r; skipping",
+                plugin_name,
+                plugin.scope,
+                scope,
+            )
+            continue
+
+        context = EvalContext(
+            repos=repos,
+            conn=conn,
+            run_id=run_id,
+            config=config,
+            scope=scope,
+            turn_id=turn_id,
+            turn_number=turn_number,
+        )
+        summary = _execute_plugin(
+            plugin_name=plugin.name,
+            scope=scope,
+            run_id=run_id,
+            turn_id=turn_id,
+            context=context,
+            repos=repos,
+            conn=conn,
+            plugin_run=plugin.run,
+        )
+        summaries.append(summary)
+        if summary.status == "failed" and config.evals.fail_run_on_error:
+            raise EvalExecutionError(
+                f"eval plugin {plugin_name!r} failed with status {summary.status!r}"
+            )
+    return summaries
+
+
+def _execute_plugin(
+    *,
+    plugin_name: str,
+    scope: EvalScope,
+    run_id: str,
+    turn_id: str | None,
+    context: EvalContext,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+    plugin_run,
+) -> EvalPluginRunSummary:
+    finished_at = get_current_timestamp()
+    eval_run_id = new_eval_run_id()
+
+    try:
+        result = plugin_run(context)
+    except Exception as exc:
+        logger.exception("eval plugin %r raised during execution", plugin_name)
+        eval_run = EvalRunRecord(
+            eval_run_id=eval_run_id,
+            run_id=run_id,
+            turn_id=turn_id,
+            scope=scope,
+            plugin_name=plugin_name,
+            status="failed",
+            created_at=finished_at,
+            finished_at=finished_at,
+            error=str(exc),
+        )
+        repos.insert_eval_run(eval_run, conn)
+        return EvalPluginRunSummary(
+            eval_run_id=eval_run_id,
+            plugin_name=plugin_name,
+            status="failed",
+            metrics=[],
+        )
+
+    status, error = _map_result_status(result)
+    eval_run = EvalRunRecord(
+        eval_run_id=eval_run_id,
+        run_id=run_id,
+        turn_id=turn_id,
+        scope=scope,
+        plugin_name=plugin_name,
+        status=status,
+        created_at=finished_at,
+        finished_at=finished_at,
+        error=error,
+    )
+    repos.insert_eval_run(eval_run, conn)
+    metric_records = _persist_metrics(
+        result=result,
+        eval_run_id=eval_run_id,
+        run_id=run_id,
+        turn_id=turn_id,
+        repos=repos,
+        conn=conn,
+    )
+    logger.info(
+        "eval plugin %r finished with status %r (%d metrics)",
+        plugin_name,
+        status,
+        len(metric_records),
+    )
+    return EvalPluginRunSummary(
+        eval_run_id=eval_run_id,
+        plugin_name=plugin_name,
+        status=status,
+        metrics=metric_records,
+    )
+
+
+def _map_result_status(result: EvalResult) -> tuple[str, str | None]:
+    if result.status == "passed":
+        return "completed", None
+    if result.warnings:
+        return "failed", "; ".join(result.warnings)
+    return "failed", _FAILED_STATUS_MESSAGE
+
+
+def _persist_metrics(
+    *,
+    result: EvalResult,
+    eval_run_id: str,
+    run_id: str,
+    turn_id: str | None,
+    repos: SimulationRepositories,
+    conn: sqlite3.Connection,
+) -> list[EvalMetricRecord]:
+    created_at = get_current_timestamp()
+    metric_records: list[EvalMetricRecord] = []
+    for draft in result.metrics:
+        record = EvalMetricRecord(
+            eval_metric_id=new_eval_metric_id(),
+            eval_run_id=eval_run_id,
+            run_id=run_id,
+            turn_id=turn_id,
+            plugin_name=result.plugin_name,
+            metric_name=draft.metric_name,
+            metric_value=draft.metric_value,
+            metadata_json=draft.metadata_json,
+            created_at=created_at,
+        )
+        repos.insert_eval_metric(record, conn)
+        metric_records.append(record)
+    return metric_records

--- a/simulation_v2/worker/run_executor.py
+++ b/simulation_v2/worker/run_executor.py
@@ -6,6 +6,7 @@ import sqlite3
 
 from simulation_v2.config import LocalSimulationConfig
 from simulation_v2.db.repositories import SimulationRepositories
+from simulation_v2.evals.runner import run_run_evals
 from simulation_v2.telemetry.opik import configure_opik
 from simulation_v2.worker.turn_executor import execute_turn
 
@@ -19,3 +20,4 @@ def execute_run(
     configure_opik()
     for turn_number in range(1, config.total_turns + 1):
         execute_turn(run_id, turn_number, config, conn, repos)
+    run_run_evals(run_id, config, repos, conn)

--- a/simulation_v2/worker/turn_executor.py
+++ b/simulation_v2/worker/turn_executor.py
@@ -12,6 +12,7 @@ from simulation_v2.actions.service import (
 from simulation_v2.config import LocalSimulationConfig
 from simulation_v2.db.models import TurnRecord
 from simulation_v2.db.repositories import SimulationRepositories
+from simulation_v2.evals.runner import run_turn_evals
 from simulation_v2.feeds.service import generate_and_persist_feeds
 from simulation_v2.ids import new_turn_id
 from simulation_v2.telemetry.context import SimulationTraceContext
@@ -72,4 +73,12 @@ def execute_turn(
     diffs = build_pending_turn_diffs(validated, snapshot)
     repos.persist_turn_diffs(diffs, conn)
     repos.update_turn_status(turn_id, "completed", conn)
+    run_turn_evals(
+        run_id=run_id,
+        turn_id=turn_id,
+        turn_number=snapshot.turn_number,
+        config=snapshot.config,
+        repos=repos,
+        conn=conn,
+    )
     return snapshot

--- a/tests/simulation_v2/evals/test_runner.py
+++ b/tests/simulation_v2/evals/test_runner.py
@@ -1,0 +1,252 @@
+"""Unit tests for simulation_v2 eval runner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from simulation_v2.config import EvalConfig, LocalSimulationConfig
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from simulation_v2.db.models.evals import EvalScope
+from simulation_v2.evals.interfaces import EvalContext, EvalMetricDraft, EvalResult
+from simulation_v2.evals.registry import _PLUGINS, register_eval_plugin
+from simulation_v2.evals.runner import (
+    EvalExecutionError,
+    run_run_evals,
+    run_turn_evals,
+)
+from tests.simulation_v2.db import factories
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "test.sqlite3"
+    SimulationDatabase(path).initialize()
+    return path
+
+
+@pytest.fixture
+def clean_eval_registry():
+    original = _PLUGINS.copy()
+    yield
+    _PLUGINS.clear()
+    _PLUGINS.update(original)
+
+
+class _PassingTurnPlugin:
+    name: ClassVar[str] = "test_pass"
+    scope: ClassVar[EvalScope] = "turn"
+
+    def run(self, context: EvalContext) -> EvalResult:
+        return EvalResult(
+            plugin_name=self.name,
+            status="passed",
+            metrics=[
+                EvalMetricDraft(
+                    metric_name="example_metric",
+                    metric_value=1.0,
+                    metadata_json={"source": "test"},
+                )
+            ],
+        )
+
+
+class _FailingTurnPlugin:
+    name: ClassVar[str] = "test_fail"
+    scope: ClassVar[EvalScope] = "turn"
+
+    def run(self, context: EvalContext) -> EvalResult:
+        return EvalResult(
+            plugin_name=self.name,
+            status="failed",
+            metrics=[],
+            warnings=["deliberate failure"],
+        )
+
+
+class _RaisingTurnPlugin:
+    name: ClassVar[str] = "test_raise"
+    scope: ClassVar[EvalScope] = "turn"
+
+    def run(self, context: EvalContext) -> EvalResult:
+        raise RuntimeError("plugin exploded")
+
+
+class _PassingRunPlugin:
+    name: ClassVar[str] = "test_run_pass"
+    scope: ClassVar[EvalScope] = "run"
+
+    def run(self, context: EvalContext) -> EvalResult:
+        return EvalResult(
+            plugin_name=self.name,
+            status="passed",
+            metrics=[EvalMetricDraft(metric_name="run_metric", metric_value=2.0)],
+        )
+
+
+def _eval_config(**overrides: object) -> EvalConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "fail_run_on_error": False,
+        "turn_plugins": [],
+        "run_plugins": [],
+    }
+    defaults.update(overrides)
+    return EvalConfig.model_validate(defaults)
+
+
+def _insert_run_and_turn(db_path: Path) -> tuple[SimulationDatabase, str, str, int]:
+    db = SimulationDatabase(db_path)
+    run = factories.RunRecordFactory.create()
+    turn = factories.TurnRecordFactory.create(run_id=run.run_id, turn_number=1)
+    with transaction(db_path) as conn:
+        db.repos.insert_run(run, conn)
+        db.repos.insert_turn(turn, conn)
+    return db, run.run_id, turn.turn_id, turn.turn_number
+
+
+def _count_eval_runs(db_path: Path) -> int:
+    with transaction(db_path) as conn:
+        row = conn.execute("SELECT COUNT(*) AS count FROM eval_runs").fetchone()
+    return int(row["count"])
+
+
+def _count_eval_metrics(db_path: Path) -> int:
+    with transaction(db_path) as conn:
+        row = conn.execute("SELECT COUNT(*) AS count FROM eval_metrics").fetchone()
+    return int(row["count"])
+
+
+def _list_eval_runs(db_path: Path) -> list[dict[str, object]]:
+    with transaction(db_path) as conn:
+        rows = conn.execute("SELECT * FROM eval_runs ORDER BY created_at").fetchall()
+    return [dict(row) for row in rows]
+
+
+class TestRunTurnEvals:
+    def test_passing_turn_plugin_persists_completed_eval_run(
+        self, db_path: Path, clean_eval_registry
+    ) -> None:
+        register_eval_plugin(_PassingTurnPlugin())
+        db, run_id, turn_id, turn_number = _insert_run_and_turn(db_path)
+        config = LocalSimulationConfig.default().model_copy(
+            update={"evals": _eval_config(turn_plugins=["test_pass"])}
+        )
+
+        with transaction(db_path) as conn:
+            summaries = run_turn_evals(
+                run_id, turn_id, turn_number, config, db.repos, conn
+            )
+
+        assert len(summaries) == 1
+        assert summaries[0].plugin_name == "test_pass"
+        assert summaries[0].status == "completed"
+        assert len(summaries[0].metrics) == 1
+        assert _count_eval_runs(db_path) == 1
+        assert _count_eval_metrics(db_path) == 1
+
+        eval_runs = _list_eval_runs(db_path)
+        assert eval_runs[0]["status"] == "completed"
+        assert eval_runs[0]["error"] is None
+        assert eval_runs[0]["turn_id"] == turn_id
+
+    def test_failing_turn_plugin_persists_failed_eval_run_without_raising(
+        self, db_path: Path, clean_eval_registry
+    ) -> None:
+        register_eval_plugin(_FailingTurnPlugin())
+        db, run_id, turn_id, turn_number = _insert_run_and_turn(db_path)
+        config = LocalSimulationConfig.default().model_copy(
+            update={"evals": _eval_config(turn_plugins=["test_fail"])}
+        )
+
+        with transaction(db_path) as conn:
+            summaries = run_turn_evals(
+                run_id, turn_id, turn_number, config, db.repos, conn
+            )
+
+        assert len(summaries) == 1
+        assert summaries[0].status == "failed"
+        eval_runs = _list_eval_runs(db_path)
+        assert eval_runs[0]["status"] == "failed"
+        assert eval_runs[0]["error"] == "deliberate failure"
+
+    def test_fail_run_on_error_raises(self, db_path: Path, clean_eval_registry) -> None:
+        register_eval_plugin(_FailingTurnPlugin())
+        db, run_id, turn_id, turn_number = _insert_run_and_turn(db_path)
+        config = LocalSimulationConfig.default().model_copy(
+            update={
+                "evals": _eval_config(
+                    turn_plugins=["test_fail"],
+                    fail_run_on_error=True,
+                )
+            }
+        )
+
+        with transaction(db_path) as conn:
+            with pytest.raises(EvalExecutionError):
+                run_turn_evals(run_id, turn_id, turn_number, config, db.repos, conn)
+
+        assert _count_eval_runs(db_path) == 1
+
+    def test_evals_disabled_writes_no_rows(
+        self, db_path: Path, clean_eval_registry
+    ) -> None:
+        register_eval_plugin(_PassingTurnPlugin())
+        db, run_id, turn_id, turn_number = _insert_run_and_turn(db_path)
+        config = LocalSimulationConfig.default().model_copy(
+            update={"evals": _eval_config(enabled=False, turn_plugins=["test_pass"])}
+        )
+
+        with transaction(db_path) as conn:
+            summaries = run_turn_evals(
+                run_id, turn_id, turn_number, config, db.repos, conn
+            )
+
+        assert summaries == []
+        assert _count_eval_runs(db_path) == 0
+        assert _count_eval_metrics(db_path) == 0
+
+    def test_raising_plugin_persists_failed_eval_run(
+        self, db_path: Path, clean_eval_registry
+    ) -> None:
+        register_eval_plugin(_RaisingTurnPlugin())
+        db, run_id, turn_id, turn_number = _insert_run_and_turn(db_path)
+        config = LocalSimulationConfig.default().model_copy(
+            update={"evals": _eval_config(turn_plugins=["test_raise"])}
+        )
+
+        with transaction(db_path) as conn:
+            summaries = run_turn_evals(
+                run_id, turn_id, turn_number, config, db.repos, conn
+            )
+
+        assert summaries[0].status == "failed"
+        eval_runs = _list_eval_runs(db_path)
+        assert eval_runs[0]["error"] == "plugin exploded"
+
+
+class TestRunRunEvals:
+    def test_run_scope_sets_turn_id_none(
+        self, db_path: Path, clean_eval_registry
+    ) -> None:
+        register_eval_plugin(_PassingRunPlugin())
+        db = SimulationDatabase(db_path)
+        run = factories.RunRecordFactory.create()
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+
+        config = LocalSimulationConfig.default().model_copy(
+            update={"evals": _eval_config(run_plugins=["test_run_pass"])}
+        )
+
+        with transaction(db_path) as conn:
+            summaries = run_run_evals(run.run_id, config, db.repos, conn)
+
+        assert len(summaries) == 1
+        assert summaries[0].status == "completed"
+        eval_runs = _list_eval_runs(db_path)
+        assert eval_runs[0]["scope"] == "run"
+        assert eval_runs[0]["turn_id"] is None

--- a/tests/simulation_v2/memory/test_service.py
+++ b/tests/simulation_v2/memory/test_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from simulation_v2.config import LocalSimulationConfig
 from simulation_v2.memory.service import (
@@ -56,7 +56,9 @@ class TestFetchMemoryForPrompt:
 
 class TestBuildMemoryDiffs:
     @patch("simulation_v2.memory.service.get_current_timestamp", return_value=FIXED_TS)
-    def test_mixed_actions_emit_up_to_three_diffs(self) -> None:
+    def test_mixed_actions_emit_up_to_three_diffs(
+        self, mock_timestamp: MagicMock
+    ) -> None:
         like = factories.ProposedActionRecordFactory.create(
             run_id=RUN_ID,
             turn_id=TURN_ID,
@@ -100,7 +102,7 @@ class TestBuildMemoryDiffs:
 
 class TestApplyMemoryDiff:
     @patch("simulation_v2.memory.service.get_current_timestamp", return_value=FIXED_TS)
-    def test_appends_episodic_content(self) -> None:
+    def test_appends_episodic_content(self, mock_timestamp: MagicMock) -> None:
         current = factories.AgentMemoryRecordFactory.create(
             episodic="Turn 0: seed",
             updated_at="old-ts",


### PR DESCRIPTION
## Overview

PR 12 adds the plugin-style eval execution layer: typed `EvalPlugin` / `EvalContext` / `EvalResult` contracts, a name-based registry, and a runner that executes configured turn- and run-scope plugins, persists rows to `eval_runs` / `eval_metrics`, and records failures without failing the simulation run by default. PR 13 will register the four deterministic plugins; PR 12 intentionally ships an empty production registry so the framework can be tested with inline stub plugins and the existing smoke path keeps working.

## Problem / motivation

The simulation worker completes turns and runs but has no execution layer for eval plugins. Default config already lists PR 13 plugin names, so the framework must skip unknown plugins without breaking smoke runs.

## Solution

Add `simulation_v2/evals/` with interfaces, an empty registry, and a runner that persists eval rows after each completed turn and after the run loop. Wire the runner into `turn_executor` and `run_executor` on the same SQLite connection.

## Happy Flow

1. **Turn completes** in `simulation_v2/worker/turn_executor.py`: feeds → LLM actions → validation → `persist_turn_diffs` → turn status `completed`.
2. **Turn-scope evals** (if `config.evals.enabled`): `simulation_v2/evals/runner.py` `run_turn_evals(...)` iterates `config.evals.turn_plugins`, resolves each via registry, builds `EvalContext`, calls `plugin.run(context)`, writes `EvalRunRecord` + `EvalMetricRecord` rows.
3. **Run loop** in `simulation_v2/worker/run_executor.py` repeats step 1–2 for each turn.
4. **Run-scope evals** after the loop: `run_run_evals(...)` with `turn_id=None`, iterating `config.evals.run_plugins`.
5. **Failure handling:** plugin exceptions or `EvalResult.status == "failed"` → `eval_runs.status="failed"`, `error` populated; run continues unless `config.evals.fail_run_on_error=True`.
6. **Unknown plugin names:** log warning, skip (no DB row) — keeps `simulation_v2/main.py` smoke green before PR 13 registers plugins.

## Changes

- `simulation_v2/evals/interfaces.py`: `EvalMetricDraft`, `EvalResult`, `EvalContext`, `EvalPlugin` protocol
- `simulation_v2/evals/registry.py`: empty production map with `register_eval_plugin` / `get_eval_plugin`
- `simulation_v2/evals/runner.py`: `run_turn_evals`, `run_run_evals`, persistence, `fail_run_on_error` gate
- `simulation_v2/worker/turn_executor.py`: call `run_turn_evals` after turn completion
- `simulation_v2/worker/run_executor.py`: call `run_run_evals` after turn loop
- `tests/simulation_v2/evals/test_runner.py`: passing/failing/raising stub plugin coverage
- `docs/plans/2026-05-26_simulation_v2_pr12_eval_framework_847300/contracts.md`: contract freeze

## Manual Verification

- [x] `uv run pytest tests/simulation_v2/evals/test_runner.py -v` — 6 passed
- [x] `uv run pytest tests/simulation_v2/test_worker_service.py -v --import-mode=importlib` — 5 passed
- [x] `PYTHONPATH=. uv run python simulation_v2/main.py` — run completes, `completed_turns=3/3`; unknown default plugin warnings only

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a plugin-based evaluation framework for simulations.
  * Evaluations now run automatically at turn completion and after a full run.
  * Persisted eval run results and metrics; eval failures can mark runs accordingly.

* **Tests**
  * Added comprehensive tests covering passing, failing, and erroring plugins, scope behavior, and enable/disable flags.



<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/METResearchGroup/social_agent_simulation_platform/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->