### PR TITLE
Fix simulation_v2 pytest collection and memory test mocks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+importmode = "importlib"
 markers = [
     "smoke: smoke tests against a running API (set SIMULATION_API_URL to run).",
     "e2e: end-to-end tests (temp DB + subprocess uvicorn); see tests/api/test_simulation_local_reset_e2e.py.",
@@ -92,6 +93,7 @@ addopts = [
     "--disable-warnings",
     "--tb=short",
     "-v",
+    "--import-mode=importlib",
 ]
 
 [tool.coverage.run]

--- a/tests/simulation_v2/memory/test_service.py
+++ b/tests/simulation_v2/memory/test_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from simulation_v2.config import LocalSimulationConfig
 from simulation_v2.memory.service import (
@@ -56,7 +56,9 @@ class TestFetchMemoryForPrompt:
 
 class TestBuildMemoryDiffs:
     @patch("simulation_v2.memory.service.get_current_timestamp", return_value=FIXED_TS)
-    def test_mixed_actions_emit_up_to_three_diffs(self) -> None:
+    def test_mixed_actions_emit_up_to_three_diffs(
+        self, mock_timestamp: MagicMock
+    ) -> None:
         like = factories.ProposedActionRecordFactory.create(
             run_id=RUN_ID,
             turn_id=TURN_ID,
@@ -100,7 +102,7 @@ class TestBuildMemoryDiffs:
 
 class TestApplyMemoryDiff:
     @patch("simulation_v2.memory.service.get_current_timestamp", return_value=FIXED_TS)
-    def test_appends_episodic_content(self) -> None:
+    def test_appends_episodic_content(self, mock_timestamp: MagicMock) -> None:
         current = factories.AgentMemoryRecordFactory.create(
             episodic="Turn 0: seed",
             updated_at="old-ts",


### PR DESCRIPTION
## Overview

Fixes pre-existing test infrastructure issues that blocked `uv run pytest tests/simulation_v2/` from collecting and running cleanly.

## Problem / motivation

1. **Pytest collection errors:** duplicate basenames (`test_validators.py`, `test_service.py`) across `actions/`, `feeds/`, and `memory/` subdirs caused `import file mismatch` when collecting the full `tests/simulation_v2/` tree.
2. **Memory test failures:** `@patch` on `get_current_timestamp` injects a mock argument, but two tests in `memory/test_service.py` omitted that parameter, causing `TypeError: takes 1 positional argument but 2 were given`.

## Solution

- Set pytest `--import-mode=importlib` in `pyproject.toml` so each test module imports in isolation.
- Add typed `MagicMock` parameters to the patched memory service tests.

## Changes

- `pyproject.toml`: add `--import-mode=importlib` to pytest `addopts` (and `importmode = "importlib"`)
- `tests/simulation_v2/memory/test_service.py`: accept patched mock args with `MagicMock` typing

## Manual Verification

- [x] `uv run pytest tests/simulation_v2/memory/test_service.py -v` — 5 passed
- [x] `uv run pytest tests/simulation_v2/ -q --ignore=tests/simulation_v2/test_control_plane_dispatch.py` — 224 passed
- [x] Pre-commit hooks (ruff, pyright) pass on changed files

## Base branch

Stacks on PR #323 (`feature/simulation-v2-pr12-eval-framework`).

Made with [Cursor](https://cursor.com)