### PR TITLE
Add deterministic eval plugins for simulation_v2

### DIFF
--- a/docs/plans/2026-05-26_simulation_v2_pr13_deterministic_eval_plugins_847301/contracts.md
+++ b/docs/plans/2026-05-26_simulation_v2_pr13_deterministic_eval_plugins_847301/contracts.md
@@ -1,0 +1,39 @@
+# PR 13 Deterministic Eval Plugins — Contract Freeze
+
+| Symbol | Location | Contract |
+| --- | --- | --- |
+| `EvalPlugin.scopes` | `simulation_v2/evals/interfaces.py` | `ClassVar[frozenset[EvalScope]]` — default `frozenset({"turn", "run"})` for all four PR 13 plugins |
+| `EvalScope` | reuse from `simulation_v2/db/models/evals.py` | `"turn" \| "run"` |
+| Metric naming | this file (table below) | Stable dot-separated `metric_name` values per plugin |
+| `load_*` helpers | `simulation_v2/evals/query_helpers.py` | Scope-aware reads via `context.repos` only; no imports from `worker/`, `actions/`, `feeds/` |
+| Plugin registration | `simulation_v2/evals/registry.py` | `register_builtin_eval_plugins()` called at import from `simulation_v2/evals/__init__.py` |
+| Pass/fail gates | each plugin | See per-plugin table below |
+
+## Metric names
+
+| Plugin | `metric_name` | `metadata_json` |
+| --- | --- | --- |
+| `action_counts` | `proposed`, `accepted`, `rejected`, `executed` | `{"action_type": "<canonical>"}` |
+| `invalid_action_rate` | `rate`, `rejected_count`, `proposed_count` | `{"action_type", "filter_id", "filter_reason"}` |
+| `feed_coverage` | `users_total`, `users_with_feed`, `users_missing_feed`, `empty_feeds`, `duplicate_post_feeds`, `self_authored_feeds` | optional `{"user_id"}` on violations |
+| `llm_structured_output` | `generation_count`, `success_rate` | `{"action_type", "status"}` where status ∈ `completed`, `failed`, `schema_failed` |
+
+Canonical `action_type` strings: `like_post`, `write_post`, `follow_user`, `comment_on_post`.
+
+## Pass/fail
+
+| Plugin | `status="failed"` when |
+| --- | --- |
+| `action_counts` | any `accepted != executed` for an action type |
+| `invalid_action_rate` | never (informational) |
+| `feed_coverage` | `users_missing_feed > 0` OR `duplicate_post_feeds > 0` OR `self_authored_feeds > 0` |
+| `llm_structured_output` | never (informational) |
+
+## File-interaction invariants
+
+| Owner | Allowed callers | Forbidden |
+| --- | --- | --- |
+| `evals.runner` | `turn_executor`, `run_executor`, tests | Only module that executes plugins and writes eval rows |
+| `evals.registry` | `evals.runner`, tests, plugin registration | No SQLite, no worker imports |
+| Eval plugins | invoked via runner only | Must not mutate run state; read via `EvalContext` only |
+| `evals.query_helpers` | eval plugins | No imports from `worker/`, `actions/`, `feeds/` |

--- a/simulation_v2/evals/__init__.py
+++ b/simulation_v2/evals/__init__.py
@@ -6,6 +6,9 @@ from simulation_v2.evals.interfaces import (
     EvalPlugin,
     EvalResult,
 )
+from simulation_v2.evals.registry import register_builtin_eval_plugins
+
+register_builtin_eval_plugins()
 
 __all__ = [
     "EvalContext",

--- a/simulation_v2/evals/interfaces.py
+++ b/simulation_v2/evals/interfaces.py
@@ -40,6 +40,6 @@ class EvalContext(BaseModel):
 
 class EvalPlugin(Protocol):
     name: ClassVar[str]
-    scope: ClassVar[EvalScope]
+    scopes: ClassVar[frozenset[EvalScope]]
 
     def run(self, context: EvalContext) -> EvalResult: ...

--- a/simulation_v2/evals/plugins/__init__.py
+++ b/simulation_v2/evals/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in deterministic eval plugins."""

--- a/simulation_v2/evals/plugins/action_counts.py
+++ b/simulation_v2/evals/plugins/action_counts.py
@@ -1,0 +1,64 @@
+"""Count proposed, accepted, rejected, and executed actions per action type."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from simulation_v2.db.models.evals import EvalScope
+from simulation_v2.evals.interfaces import EvalContext, EvalMetricDraft, EvalResult
+from simulation_v2.evals.query_helpers import (
+    count_executed_by_action_type,
+    load_proposed_actions,
+)
+
+
+class ActionCountsPlugin:
+    name: ClassVar[str] = "action_counts"
+    scopes: ClassVar[frozenset[EvalScope]] = frozenset({"turn", "run"})
+
+    def run(self, context: EvalContext) -> EvalResult:
+        proposed = load_proposed_actions(context)
+        executed = count_executed_by_action_type(context)
+
+        by_type_kind: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+        for action in proposed:
+            by_type_kind[action.action_type][action.record_kind] += 1
+
+        action_types = sorted(set(by_type_kind) | set(executed))
+        metrics: list[EvalMetricDraft] = []
+        warnings: list[str] = []
+
+        for action_type in action_types:
+            kinds = by_type_kind.get(action_type, {})
+            proposed_count = sum(kinds.values())
+            accepted = kinds.get("validated", 0)
+            rejected = kinds.get("rejected", 0)
+            executed_count = executed.get(action_type, 0)
+
+            for metric_name, value in (
+                ("proposed", proposed_count),
+                ("accepted", accepted),
+                ("rejected", rejected),
+                ("executed", executed_count),
+            ):
+                metrics.append(
+                    EvalMetricDraft(
+                        metric_name=metric_name,
+                        metric_value=float(value),
+                        metadata_json={"action_type": action_type},
+                    )
+                )
+
+            if accepted != executed_count:
+                warnings.append(
+                    f"{action_type}: accepted ({accepted}) != executed ({executed_count})"
+                )
+
+        status = "failed" if warnings else "passed"
+        return EvalResult(
+            plugin_name=self.name,
+            status=status,
+            metrics=metrics,
+            warnings=warnings,
+        )

--- a/simulation_v2/evals/plugins/feed_coverage.py
+++ b/simulation_v2/evals/plugins/feed_coverage.py
@@ -1,0 +1,116 @@
+"""Report feed coverage and sanity violations."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from simulation_v2.db.models import GeneratedFeedRecord
+from simulation_v2.db.models.evals import EvalScope
+from simulation_v2.evals.interfaces import EvalContext, EvalMetricDraft, EvalResult
+from simulation_v2.evals.query_helpers import load_feeds_for_scope, load_users
+
+
+class FeedCoveragePlugin:
+    name: ClassVar[str] = "feed_coverage"
+    scopes: ClassVar[frozenset[EvalScope]] = frozenset({"turn", "run"})
+
+    def run(self, context: EvalContext) -> EvalResult:
+        users = load_users(context)
+        feeds = load_feeds_for_scope(context)
+        feeds_by_user = {feed.user_id: feed for feed in feeds}
+
+        empty_feeds = 0
+        duplicate_post_feeds = 0
+        self_authored_feeds = 0
+        warnings: list[str] = []
+
+        if context.scope == "turn":
+            users_missing_feed = sum(
+                1 for user in users if user.user_id not in feeds_by_user
+            )
+            users_with_feed = len(users) - users_missing_feed
+            for feed in feeds:
+                empty, duplicate, self_authored, feed_warnings = _inspect_feed(feed)
+                empty_feeds += empty
+                duplicate_post_feeds += duplicate
+                self_authored_feeds += self_authored
+                warnings.extend(feed_warnings)
+        else:
+            turns = context.repos.list_turns_for_run(context.run_id, context.conn)
+            users_missing_feed = 0
+            users_with_feed = 0
+            for turn in turns:
+                turn_feeds = [f for f in feeds if f.turn_id == turn.turn_id]
+                turn_feed_users = {feed.user_id for feed in turn_feeds}
+                users_missing_feed += sum(
+                    1 for user in users if user.user_id not in turn_feed_users
+                )
+                users_with_feed += sum(
+                    1 for user in users if user.user_id in turn_feed_users
+                )
+                for feed in turn_feeds:
+                    empty, duplicate, self_authored, feed_warnings = _inspect_feed(feed)
+                    empty_feeds += empty
+                    duplicate_post_feeds += duplicate
+                    self_authored_feeds += self_authored
+                    warnings.extend(feed_warnings)
+
+        metrics = [
+            EvalMetricDraft(metric_name="users_total", metric_value=float(len(users))),
+            EvalMetricDraft(
+                metric_name="users_with_feed", metric_value=float(users_with_feed)
+            ),
+            EvalMetricDraft(
+                metric_name="users_missing_feed",
+                metric_value=float(users_missing_feed),
+            ),
+            EvalMetricDraft(metric_name="empty_feeds", metric_value=float(empty_feeds)),
+            EvalMetricDraft(
+                metric_name="duplicate_post_feeds",
+                metric_value=float(duplicate_post_feeds),
+            ),
+            EvalMetricDraft(
+                metric_name="self_authored_feeds",
+                metric_value=float(self_authored_feeds),
+            ),
+        ]
+
+        status = (
+            "failed"
+            if users_missing_feed > 0
+            or duplicate_post_feeds > 0
+            or self_authored_feeds > 0
+            else "passed"
+        )
+        return EvalResult(
+            plugin_name=self.name,
+            status=status,
+            metrics=metrics,
+            warnings=warnings,
+        )
+
+
+def _inspect_feed(
+    feed: GeneratedFeedRecord,
+) -> tuple[int, int, int, list[str]]:
+    views = feed.feed_posts
+    warnings: list[str] = []
+    empty = 1 if len(views) == 0 else 0
+    duplicate = 0
+    self_authored = 0
+
+    seen_post_ids: set[str] = set()
+    for view in views:
+        if view.post_id in seen_post_ids:
+            duplicate += 1
+            warnings.append(
+                f"duplicate post_id {view.post_id!r} in feed for user {feed.user_id!r}"
+            )
+        seen_post_ids.add(view.post_id)
+        if view.author_id == feed.user_id:
+            self_authored += 1
+            warnings.append(
+                f"self-authored post {view.post_id!r} in feed for user {feed.user_id!r}"
+            )
+
+    return empty, duplicate, self_authored, warnings

--- a/simulation_v2/evals/plugins/invalid_action_rate.py
+++ b/simulation_v2/evals/plugins/invalid_action_rate.py
@@ -1,0 +1,64 @@
+"""Compute rejected/proposed rates by action type and filter."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from simulation_v2.db.models.evals import EvalScope
+from simulation_v2.evals.interfaces import EvalContext, EvalMetricDraft, EvalResult
+from simulation_v2.evals.query_helpers import load_proposed_actions
+
+
+class InvalidActionRatePlugin:
+    name: ClassVar[str] = "invalid_action_rate"
+    scopes: ClassVar[frozenset[EvalScope]] = frozenset({"turn", "run"})
+
+    def run(self, context: EvalContext) -> EvalResult:
+        proposed = load_proposed_actions(context)
+
+        proposed_by_type: dict[str, int] = defaultdict(int)
+        rejected_groups: dict[tuple[str, str | None, str | None], int] = defaultdict(
+            int
+        )
+
+        for action in proposed:
+            proposed_by_type[action.action_type] += 1
+            if action.record_kind != "rejected":
+                continue
+            key = (
+                action.action_type,
+                action.filter_id,
+                action.filter_reason,
+            )
+            rejected_groups[key] += 1
+
+        metrics: list[EvalMetricDraft] = []
+        for (action_type, filter_id, filter_reason), rejected_count in sorted(
+            rejected_groups.items()
+        ):
+            proposed_count = proposed_by_type[action_type]
+            rate = rejected_count / proposed_count if proposed_count > 0 else 0.0
+            metadata = {
+                "action_type": action_type,
+                "filter_id": filter_id,
+                "filter_reason": filter_reason,
+            }
+            for metric_name, value in (
+                ("rate", rate),
+                ("rejected_count", float(rejected_count)),
+                ("proposed_count", float(proposed_count)),
+            ):
+                metrics.append(
+                    EvalMetricDraft(
+                        metric_name=metric_name,
+                        metric_value=value,
+                        metadata_json=metadata,
+                    )
+                )
+
+        return EvalResult(
+            plugin_name=self.name,
+            status="passed",
+            metrics=metrics,
+        )

--- a/simulation_v2/evals/plugins/llm_structured_output.py
+++ b/simulation_v2/evals/plugins/llm_structured_output.py
@@ -1,0 +1,60 @@
+"""Report LLM generation outcomes by action type and status."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from simulation_v2.db.models.evals import EvalScope
+from simulation_v2.evals.interfaces import EvalContext, EvalMetricDraft, EvalResult
+from simulation_v2.evals.query_helpers import load_generations
+
+
+class LlmStructuredOutputPlugin:
+    name: ClassVar[str] = "llm_structured_output"
+    scopes: ClassVar[frozenset[EvalScope]] = frozenset({"turn", "run"})
+
+    def run(self, context: EvalContext) -> EvalResult:
+        generations = load_generations(context)
+
+        by_type_status: dict[tuple[str, str], int] = defaultdict(int)
+        by_type_total: dict[str, int] = defaultdict(int)
+        by_type_completed: dict[str, int] = defaultdict(int)
+
+        for generation in generations:
+            key = (generation.action_type, generation.status)
+            by_type_status[key] += 1
+            by_type_total[generation.action_type] += 1
+            if generation.status == "completed":
+                by_type_completed[generation.action_type] += 1
+
+        metrics: list[EvalMetricDraft] = []
+        for (action_type, status), count in sorted(by_type_status.items()):
+            metrics.append(
+                EvalMetricDraft(
+                    metric_name="generation_count",
+                    metric_value=float(count),
+                    metadata_json={
+                        "action_type": action_type,
+                        "status": status,
+                    },
+                )
+            )
+
+        for action_type in sorted(by_type_total):
+            total = by_type_total[action_type]
+            completed = by_type_completed[action_type]
+            success_rate = completed / total if total > 0 else 0.0
+            metrics.append(
+                EvalMetricDraft(
+                    metric_name="success_rate",
+                    metric_value=success_rate,
+                    metadata_json={"action_type": action_type},
+                )
+            )
+
+        return EvalResult(
+            plugin_name=self.name,
+            status="passed",
+            metrics=metrics,
+        )

--- a/simulation_v2/evals/query_helpers.py
+++ b/simulation_v2/evals/query_helpers.py
@@ -1,0 +1,102 @@
+"""Scope-aware SQLite read helpers for eval plugins."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from simulation_v2.db.models import (
+    GeneratedFeedRecord,
+    GenerationRecord,
+    ProposedActionRecord,
+    UserRecord,
+)
+from simulation_v2.evals.interfaces import EvalContext
+
+CANONICAL_ACTION_TYPES = (
+    "like_post",
+    "write_post",
+    "follow_user",
+    "comment_on_post",
+)
+
+
+def load_proposed_actions(context: EvalContext) -> list[ProposedActionRecord]:
+    if context.scope == "turn":
+        if context.turn_id is None:
+            return []
+        return context.repos.list_proposed_actions_for_turn(
+            context.run_id, context.turn_id, context.conn
+        )
+    actions: list[ProposedActionRecord] = []
+    for turn in context.repos.list_turns_for_run(context.run_id, context.conn):
+        actions.extend(
+            context.repos.list_proposed_actions_for_turn(
+                context.run_id, turn.turn_id, context.conn
+            )
+        )
+    return actions
+
+
+def load_generations(context: EvalContext) -> list[GenerationRecord]:
+    if context.scope == "turn":
+        if context.turn_id is None:
+            return []
+        return context.repos.list_generations_for_turn(
+            context.run_id, context.turn_id, context.conn
+        )
+    generations: list[GenerationRecord] = []
+    for turn in context.repos.list_turns_for_run(context.run_id, context.conn):
+        generations.extend(
+            context.repos.list_generations_for_turn(
+                context.run_id, turn.turn_id, context.conn
+            )
+        )
+    return generations
+
+
+def load_feeds_for_scope(context: EvalContext) -> list[GeneratedFeedRecord]:
+    feeds = context.repos.list_generated_feeds_for_run(context.run_id, context.conn)
+    if context.scope == "turn":
+        if context.turn_id is None:
+            return []
+        return [feed for feed in feeds if feed.turn_id == context.turn_id]
+    return feeds
+
+
+def load_users(context: EvalContext) -> list[UserRecord]:
+    return context.repos.list_users_for_run(context.run_id, context.conn)
+
+
+def count_executed_by_action_type(context: EvalContext) -> dict[str, int]:
+    counts: dict[str, int] = defaultdict(int)
+    turn_number = context.turn_number
+
+    for like in context.repos.list_likes_for_run(context.run_id, context.conn):
+        if _matches_turn_scope(like.created_at_turn, turn_number, context.scope):
+            counts["like_post"] += 1
+
+    for follow in context.repos.list_follows_for_run(context.run_id, context.conn):
+        if _matches_turn_scope(follow.created_at_turn, turn_number, context.scope):
+            counts["follow_user"] += 1
+
+    for post in context.repos.list_posts_for_run(context.run_id, context.conn):
+        if post.created_at_turn == 0:
+            continue
+        if _matches_turn_scope(post.created_at_turn, turn_number, context.scope):
+            counts["write_post"] += 1
+
+    for comment in context.repos.list_comments_for_run(context.run_id, context.conn):
+        if _matches_turn_scope(comment.created_at_turn, turn_number, context.scope):
+            counts["comment_on_post"] += 1
+
+    return dict(counts)
+
+
+def _matches_turn_scope(
+    created_at_turn: int, turn_number: int | None, scope: str
+) -> bool:
+    if scope == "run":
+        return created_at_turn > 0
+    if turn_number is None:
+        return False
+    return created_at_turn == turn_number

--- a/simulation_v2/evals/registry.py
+++ b/simulation_v2/evals/registry.py
@@ -13,3 +13,19 @@ def register_eval_plugin(plugin: EvalPlugin) -> None:
 
 def get_eval_plugin(name: str) -> EvalPlugin | None:
     return _PLUGINS.get(name)
+
+
+def register_builtin_eval_plugins() -> None:
+    from simulation_v2.evals.plugins.action_counts import ActionCountsPlugin
+    from simulation_v2.evals.plugins.feed_coverage import FeedCoveragePlugin
+    from simulation_v2.evals.plugins.invalid_action_rate import (
+        InvalidActionRatePlugin,
+    )
+    from simulation_v2.evals.plugins.llm_structured_output import (
+        LlmStructuredOutputPlugin,
+    )
+
+    register_eval_plugin(ActionCountsPlugin())
+    register_eval_plugin(InvalidActionRatePlugin())
+    register_eval_plugin(FeedCoveragePlugin())
+    register_eval_plugin(LlmStructuredOutputPlugin())

--- a/simulation_v2/evals/runner.py
+++ b/simulation_v2/evals/runner.py
@@ -90,11 +90,11 @@ def _run_evals(
         if plugin is None:
             logger.warning("unknown eval plugin %r", plugin_name)
             continue
-        if plugin.scope != scope:
+        if scope not in plugin.scopes:
             logger.warning(
-                "eval plugin %r has scope %r but invoked for scope %r; skipping",
+                "eval plugin %r has scopes %r but invoked for scope %r; skipping",
                 plugin_name,
-                plugin.scope,
+                plugin.scopes,
                 scope,
             )
             continue
@@ -123,7 +123,36 @@ def _run_evals(
             raise EvalExecutionError(
                 f"eval plugin {plugin_name!r} failed with status {summary.status!r}"
             )
+    _log_eval_batch_summary(
+        scope=scope,
+        run_id=run_id,
+        turn_number=turn_number,
+        summaries=summaries,
+    )
     return summaries
+
+
+def _log_eval_batch_summary(
+    *,
+    scope: EvalScope,
+    run_id: str,
+    turn_number: int | None,
+    summaries: list[EvalPluginRunSummary],
+) -> None:
+    if not summaries:
+        return
+    turn_label = str(turn_number) if turn_number is not None else "all"
+    parts = [
+        f"{summary.plugin_name}({summary.status},{len(summary.metrics)})"
+        for summary in summaries
+    ]
+    logger.info(
+        "eval %s summary run_id=%s turn=%s: %s",
+        scope,
+        run_id,
+        turn_label,
+        "; ".join(parts),
+    )
 
 
 def _execute_plugin(

--- a/simulation_v2/main.py
+++ b/simulation_v2/main.py
@@ -13,6 +13,7 @@ Default config: 3 users, 5 posts per user, 3 turns.
 
 from __future__ import annotations
 
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -33,6 +34,42 @@ from simulation_v2.logging_config import configure_simulation_logging
 configure_simulation_logging()
 
 
+def format_eval_summary(run_id: str, conn: sqlite3.Connection) -> str:
+    """One-line summary of persisted eval runs for a completed simulation."""
+    rows = conn.execute(
+        """
+        SELECT scope, plugin_name, status
+        FROM eval_runs
+        WHERE run_id = ?
+        ORDER BY scope DESC, plugin_name
+        """,
+        (run_id,),
+    ).fetchall()
+    if not rows:
+        return "Evals: none recorded"
+
+    metric_count = int(
+        conn.execute(
+            "SELECT COUNT(*) AS count FROM eval_metrics WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()["count"]
+    )
+    turn_count = sum(1 for row in rows if row["scope"] == "turn")
+    run_count = sum(1 for row in rows if row["scope"] == "run")
+    failed = [row["plugin_name"] for row in rows if row["status"] == "failed"]
+    run_scope = ", ".join(
+        f"{row['plugin_name']}={row['status']}" for row in rows if row["scope"] == "run"
+    )
+
+    summary = (
+        f"Evals: {len(rows)} plugin runs "
+        f"({turn_count} turn + {run_count} run scope), {metric_count} metrics"
+    )
+    if failed:
+        return f"{summary}; failed: {', '.join(failed)}"
+    return f"{summary}; all completed. Run-scope: {run_scope}"
+
+
 def main() -> None:
     config = LocalSimulationConfig.default().model_copy(
         update={"seed": SeedConfig(total_users=3, total_posts_per_user=5)}
@@ -48,11 +85,13 @@ def main() -> None:
     db = SimulationDatabase(config.storage.db_path)
     with transaction(config.storage.db_path) as conn:
         counts = db.repos.count_seed_entities_for_run(run_id, conn)
+        eval_summary = format_eval_summary(run_id, conn)
     print(
         f"Run complete: run_id={run_id} status={run.status} "
         f"completed_turns={completed_count}/{len(turns)} "
         f"users={counts['user_count']} posts={counts['post_count']}"
     )
+    print(eval_summary)
 
 
 if __name__ == "__main__":

--- a/tests/simulation_v2/evals/conftest.py
+++ b/tests/simulation_v2/evals/conftest.py
@@ -1,0 +1,249 @@
+"""Shared fixtures for simulation_v2 eval plugin tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from tests.simulation_v2.db import factories
+
+
+@dataclass(frozen=True)
+class EvalFixture:
+    db_path: Path
+    run_id: str
+    turn_id: str
+    turn_number: int
+
+
+def seed_eval_fixture_db(db_path: Path) -> EvalFixture:
+    """Insert a run with representative rows for all four eval plugins."""
+    db = SimulationDatabase(db_path)
+    db.initialize()
+
+    run = factories.RunRecordFactory.create()
+    turn = factories.TurnRecordFactory.create(
+        run_id=run.run_id, turn_number=1, status="completed"
+    )
+
+    user_healthy = factories.UserRecordFactory.create(run_id=run.run_id)
+    user_empty = factories.UserRecordFactory.create(run_id=run.run_id)
+    user_duplicate = factories.UserRecordFactory.create(run_id=run.run_id)
+    user_self = factories.UserRecordFactory.create(run_id=run.run_id)
+    user_missing = factories.UserRecordFactory.create(run_id=run.run_id)
+
+    author_other = factories.UserRecordFactory.create(run_id=run.run_id)
+    post_a = factories.PostRecordFactory.create(
+        run_id=run.run_id,
+        author_id=author_other.user_id,
+        created_at_turn=0,
+    )
+    post_b = factories.PostRecordFactory.create(
+        run_id=run.run_id,
+        author_id=author_other.user_id,
+        created_at_turn=0,
+    )
+    post_self = factories.PostRecordFactory.create(
+        run_id=run.run_id,
+        author_id=user_self.user_id,
+        created_at_turn=0,
+    )
+
+    gen_like_1 = factories.GenerationRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_healthy.user_id,
+        action_type="like_post",
+        status="completed",
+    )
+    gen_like_2 = factories.GenerationRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_healthy.user_id,
+        action_type="like_post",
+        status="completed",
+    )
+    gen_like_schema_fail = factories.GenerationRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_empty.user_id,
+        action_type="like_post",
+        status="schema_failed",
+    )
+    gen_write_fail = factories.GenerationRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_empty.user_id,
+        action_type="write_post",
+        status="failed",
+    )
+    gen_follow = factories.GenerationRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_healthy.user_id,
+        action_type="follow_user",
+        status="completed",
+    )
+    gen_like_rejected = factories.GenerationRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_empty.user_id,
+        action_type="like_post",
+        status="failed",
+    )
+
+    proposed_like_valid_1 = factories.ProposedActionRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_healthy.user_id,
+        action_type="like_post",
+        record_kind="validated",
+        generation_id=gen_like_1.generation_id,
+        target_id=post_a.post_id,
+    )
+    proposed_like_valid_2 = factories.ProposedActionRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_healthy.user_id,
+        action_type="like_post",
+        record_kind="validated",
+        generation_id=gen_like_2.generation_id,
+        target_id=post_b.post_id,
+    )
+    proposed_like_rejected = factories.ProposedActionRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_empty.user_id,
+        action_type="like_post",
+        record_kind="rejected",
+        generation_id=gen_like_rejected.generation_id,
+        filter_id="duplicate_like",
+        filter_reason="Already liked this post",
+        target_id=post_a.post_id,
+    )
+    proposed_follow_valid = factories.ProposedActionRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_healthy.user_id,
+        action_type="follow_user",
+        record_kind="validated",
+        generation_id=gen_follow.generation_id,
+        target_id=author_other.user_id,
+    )
+
+    like_1 = factories.LikeRecordFactory.create(
+        run_id=run.run_id,
+        post_id=post_a.post_id,
+        author_id=user_healthy.user_id,
+        created_at_turn=turn.turn_number,
+    )
+    like_2 = factories.LikeRecordFactory.create(
+        run_id=run.run_id,
+        post_id=post_b.post_id,
+        author_id=user_healthy.user_id,
+        created_at_turn=turn.turn_number,
+    )
+    follow_1 = factories.FollowRecordFactory.create(
+        run_id=run.run_id,
+        follower_id=user_healthy.user_id,
+        followee_id=author_other.user_id,
+        created_at_turn=turn.turn_number,
+    )
+
+    healthy_post = factories.FeedPostViewFactory.create(
+        post_id=post_a.post_id,
+        author_id=author_other.user_id,
+    )
+    duplicate_post = factories.FeedPostViewFactory.create(
+        post_id="dup-post-id",
+        author_id=author_other.user_id,
+    )
+    self_post_view = factories.FeedPostViewFactory.create(
+        post_id=post_self.post_id,
+        author_id=user_self.user_id,
+    )
+
+    feed_healthy = factories.GeneratedFeedRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_healthy.user_id,
+        feed_post_ids=[healthy_post.post_id],
+        feed_posts=[healthy_post],
+    )
+    feed_empty = factories.GeneratedFeedRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_empty.user_id,
+        feed_post_ids=[],
+        feed_posts=[],
+    )
+    feed_duplicate = factories.GeneratedFeedRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_duplicate.user_id,
+        feed_post_ids=[duplicate_post.post_id, duplicate_post.post_id],
+        feed_posts=[duplicate_post, duplicate_post],
+    )
+    feed_self = factories.GeneratedFeedRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user_self.user_id,
+        feed_post_ids=[self_post_view.post_id],
+        feed_posts=[self_post_view],
+    )
+    author_feed_post = factories.FeedPostViewFactory.create(
+        post_id=post_b.post_id,
+        author_id=user_healthy.user_id,
+    )
+    feed_author = factories.GeneratedFeedRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=author_other.user_id,
+        feed_post_ids=[author_feed_post.post_id],
+        feed_posts=[author_feed_post],
+    )
+
+    with transaction(db_path) as conn:
+        db.repos.insert_run(run, conn)
+        db.repos.insert_turn(turn, conn)
+        for user in (
+            user_healthy,
+            user_empty,
+            user_duplicate,
+            user_self,
+            user_missing,
+            author_other,
+        ):
+            db.repos.insert_user(user, conn)
+        for post in (post_a, post_b, post_self):
+            db.repos.insert_post(post, conn)
+        for generation in (
+            gen_like_1,
+            gen_like_2,
+            gen_like_schema_fail,
+            gen_write_fail,
+            gen_follow,
+            gen_like_rejected,
+        ):
+            db.repos.insert_generation(generation, conn)
+        for proposed in (
+            proposed_like_valid_1,
+            proposed_like_valid_2,
+            proposed_like_rejected,
+            proposed_follow_valid,
+        ):
+            db.repos.insert_proposed_action(proposed, conn)
+        for like in (like_1, like_2):
+            db.repos.insert_like(like, conn)
+        db.repos.insert_follow(follow_1, conn)
+        for feed in (feed_healthy, feed_empty, feed_duplicate, feed_self, feed_author):
+            db.repos.insert_generated_feed(feed, conn)
+
+    return EvalFixture(
+        db_path=db_path,
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        turn_number=turn.turn_number,
+    )

--- a/tests/simulation_v2/evals/plugins/test_action_counts.py
+++ b/tests/simulation_v2/evals/plugins/test_action_counts.py
@@ -1,0 +1,97 @@
+"""Tests for action_counts eval plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from simulation_v2.config import LocalSimulationConfig
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from simulation_v2.evals.interfaces import EvalContext
+from simulation_v2.evals.plugins.action_counts import ActionCountsPlugin
+from tests.simulation_v2.db import factories
+from tests.simulation_v2.evals.conftest import EvalFixture, seed_eval_fixture_db
+
+
+@pytest.fixture
+def eval_fixture(tmp_path: Path) -> EvalFixture:
+    return seed_eval_fixture_db(tmp_path / "eval_fixture.sqlite3")
+
+
+def _metric_value(result, metric_name: str, action_type: str) -> float | None:
+    for metric in result.metrics:
+        if (
+            metric.metric_name == metric_name
+            and metric.metadata_json
+            and metric.metadata_json.get("action_type") == action_type
+        ):
+            return metric.metric_value
+    return None
+
+
+class TestActionCountsPlugin:
+    def test_turn_scope_passes_when_accepted_matches_executed(
+        self, eval_fixture: EvalFixture
+    ) -> None:
+        with transaction(eval_fixture.db_path) as conn:
+            context = EvalContext(
+                repos=SimulationDatabase(eval_fixture.db_path).repos,
+                conn=conn,
+                run_id=eval_fixture.run_id,
+                config=LocalSimulationConfig.default(),
+                scope="turn",
+                turn_id=eval_fixture.turn_id,
+                turn_number=eval_fixture.turn_number,
+            )
+            result = ActionCountsPlugin().run(context)
+
+        assert result.status == "passed"
+        assert _metric_value(result, "proposed", "like_post") == 3.0
+        assert _metric_value(result, "accepted", "like_post") == 2.0
+        assert _metric_value(result, "rejected", "like_post") == 1.0
+        assert _metric_value(result, "executed", "like_post") == 2.0
+        assert _metric_value(result, "accepted", "follow_user") == 1.0
+        assert _metric_value(result, "executed", "follow_user") == 1.0
+
+    def test_fails_when_accepted_does_not_match_executed(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "mismatch.sqlite3"
+        db = SimulationDatabase(db_path)
+        db.initialize()
+        run = factories.RunRecordFactory.create()
+        turn = factories.TurnRecordFactory.create(run_id=run.run_id, turn_number=1)
+        generation = factories.GenerationRecordFactory.create(
+            run_id=run.run_id,
+            turn_id=turn.turn_id,
+            action_type="like_post",
+        )
+        with transaction(db_path) as conn:
+            db.repos.insert_run(run, conn)
+            db.repos.insert_turn(turn, conn)
+            db.repos.insert_generation(generation, conn)
+            db.repos.insert_proposed_action(
+                factories.ProposedActionRecordFactory.create(
+                    run_id=run.run_id,
+                    turn_id=turn.turn_id,
+                    action_type="like_post",
+                    record_kind="validated",
+                    generation_id=generation.generation_id,
+                ),
+                conn,
+            )
+
+        with transaction(db_path) as conn:
+            context = EvalContext(
+                repos=db.repos,
+                conn=conn,
+                run_id=run.run_id,
+                config=LocalSimulationConfig.default(),
+                scope="turn",
+                turn_id=turn.turn_id,
+                turn_number=turn.turn_number,
+            )
+            result = ActionCountsPlugin().run(context)
+
+        assert result.status == "failed"
+        assert any("like_post" in warning for warning in result.warnings)

--- a/tests/simulation_v2/evals/plugins/test_feed_coverage.py
+++ b/tests/simulation_v2/evals/plugins/test_feed_coverage.py
@@ -1,0 +1,49 @@
+"""Tests for feed_coverage eval plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from simulation_v2.config import LocalSimulationConfig
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from simulation_v2.evals.interfaces import EvalContext
+from simulation_v2.evals.plugins.feed_coverage import FeedCoveragePlugin
+from tests.simulation_v2.evals.conftest import EvalFixture, seed_eval_fixture_db
+
+
+@pytest.fixture
+def eval_fixture(tmp_path: Path) -> EvalFixture:
+    return seed_eval_fixture_db(tmp_path / "eval_fixture.sqlite3")
+
+
+def _metric(result, name: str) -> float:
+    return next(m.metric_value for m in result.metrics if m.metric_name == name)
+
+
+class TestFeedCoveragePlugin:
+    def test_turn_scope_detects_feed_violations(
+        self, eval_fixture: EvalFixture
+    ) -> None:
+        db = SimulationDatabase(eval_fixture.db_path)
+        with transaction(eval_fixture.db_path) as conn:
+            context = EvalContext(
+                repos=db.repos,
+                conn=conn,
+                run_id=eval_fixture.run_id,
+                config=LocalSimulationConfig.default(),
+                scope="turn",
+                turn_id=eval_fixture.turn_id,
+                turn_number=eval_fixture.turn_number,
+            )
+            result = FeedCoveragePlugin().run(context)
+
+        assert result.status == "failed"
+        assert _metric(result, "users_total") == 6.0
+        assert _metric(result, "users_missing_feed") == 1.0
+        assert _metric(result, "empty_feeds") == 1.0
+        assert _metric(result, "duplicate_post_feeds") == 1.0
+        assert _metric(result, "self_authored_feeds") == 1.0
+        assert result.warnings

--- a/tests/simulation_v2/evals/plugins/test_invalid_action_rate.py
+++ b/tests/simulation_v2/evals/plugins/test_invalid_action_rate.py
@@ -1,0 +1,54 @@
+"""Tests for invalid_action_rate eval plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from simulation_v2.config import LocalSimulationConfig
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from simulation_v2.evals.interfaces import EvalContext
+from simulation_v2.evals.plugins.invalid_action_rate import InvalidActionRatePlugin
+from tests.simulation_v2.evals.conftest import EvalFixture, seed_eval_fixture_db
+
+
+@pytest.fixture
+def eval_fixture(tmp_path: Path) -> EvalFixture:
+    return seed_eval_fixture_db(tmp_path / "eval_fixture.sqlite3")
+
+
+class TestInvalidActionRatePlugin:
+    def test_reports_rejection_rate_for_filter(self, eval_fixture: EvalFixture) -> None:
+        db = SimulationDatabase(eval_fixture.db_path)
+        with transaction(eval_fixture.db_path) as conn:
+            context = EvalContext(
+                repos=db.repos,
+                conn=conn,
+                run_id=eval_fixture.run_id,
+                config=LocalSimulationConfig.default(),
+                scope="turn",
+                turn_id=eval_fixture.turn_id,
+                turn_number=eval_fixture.turn_number,
+            )
+            result = InvalidActionRatePlugin().run(context)
+
+        assert result.status == "passed"
+        rate_metrics = [
+            m
+            for m in result.metrics
+            if m.metric_name == "rate"
+            and m.metadata_json
+            and m.metadata_json.get("filter_id") == "duplicate_like"
+        ]
+        assert len(rate_metrics) == 1
+        assert rate_metrics[0].metric_value == pytest.approx(1 / 3)
+        rejected = next(
+            m
+            for m in result.metrics
+            if m.metric_name == "rejected_count"
+            and m.metadata_json
+            and m.metadata_json.get("filter_id") == "duplicate_like"
+        )
+        assert rejected.metric_value == 1.0

--- a/tests/simulation_v2/evals/plugins/test_llm_structured_output.py
+++ b/tests/simulation_v2/evals/plugins/test_llm_structured_output.py
@@ -1,0 +1,66 @@
+"""Tests for llm_structured_output eval plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from simulation_v2.config import LocalSimulationConfig
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from simulation_v2.evals.interfaces import EvalContext
+from simulation_v2.evals.plugins.llm_structured_output import LlmStructuredOutputPlugin
+from tests.simulation_v2.evals.conftest import EvalFixture, seed_eval_fixture_db
+
+
+@pytest.fixture
+def eval_fixture(tmp_path: Path) -> EvalFixture:
+    return seed_eval_fixture_db(tmp_path / "eval_fixture.sqlite3")
+
+
+class TestLlmStructuredOutputPlugin:
+    def test_reports_generation_counts_by_status(
+        self, eval_fixture: EvalFixture
+    ) -> None:
+        db = SimulationDatabase(eval_fixture.db_path)
+        with transaction(eval_fixture.db_path) as conn:
+            context = EvalContext(
+                repos=db.repos,
+                conn=conn,
+                run_id=eval_fixture.run_id,
+                config=LocalSimulationConfig.default(),
+                scope="turn",
+                turn_id=eval_fixture.turn_id,
+                turn_number=eval_fixture.turn_number,
+            )
+            result = LlmStructuredOutputPlugin().run(context)
+
+        assert result.status == "passed"
+        completed_like = next(
+            m
+            for m in result.metrics
+            if m.metric_name == "generation_count"
+            and m.metadata_json
+            and m.metadata_json.get("action_type") == "like_post"
+            and m.metadata_json.get("status") == "completed"
+        )
+        assert completed_like.metric_value == 2.0
+
+        schema_failed = next(
+            m
+            for m in result.metrics
+            if m.metric_name == "generation_count"
+            and m.metadata_json
+            and m.metadata_json.get("status") == "schema_failed"
+        )
+        assert schema_failed.metric_value == 1.0
+
+        success_rate = next(
+            m
+            for m in result.metrics
+            if m.metric_name == "success_rate"
+            and m.metadata_json
+            and m.metadata_json.get("action_type") == "like_post"
+        )
+        assert success_rate.metric_value == pytest.approx(0.5)

--- a/tests/simulation_v2/evals/test_builtin_plugins.py
+++ b/tests/simulation_v2/evals/test_builtin_plugins.py
@@ -1,0 +1,88 @@
+"""Integration tests for built-in eval plugins via the runner."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+import simulation_v2.evals  # noqa: F401 — registers builtins
+from simulation_v2.config import EvalConfig, LocalSimulationConfig
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from simulation_v2.evals.runner import run_run_evals, run_turn_evals
+from tests.simulation_v2.evals.conftest import EvalFixture, seed_eval_fixture_db
+
+BUILTIN_PLUGINS = [
+    "action_counts",
+    "invalid_action_rate",
+    "feed_coverage",
+    "llm_structured_output",
+]
+
+
+def _eval_config() -> EvalConfig:
+    return EvalConfig(
+        enabled=True,
+        fail_run_on_error=False,
+        turn_plugins=BUILTIN_PLUGINS,
+        run_plugins=BUILTIN_PLUGINS,
+    )
+
+
+@pytest.fixture
+def eval_fixture(tmp_path: Path) -> EvalFixture:
+    return seed_eval_fixture_db(tmp_path / "builtin_eval.sqlite3")
+
+
+def _count_eval_runs(db_path: Path) -> int:
+    with transaction(db_path) as conn:
+        row = conn.execute("SELECT COUNT(*) AS count FROM eval_runs").fetchone()
+    return int(row["count"])
+
+
+class TestBuiltinPluginsIntegration:
+    def test_run_turn_evals_executes_all_builtin_plugins(
+        self, eval_fixture: EvalFixture, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        db = SimulationDatabase(eval_fixture.db_path)
+        config = LocalSimulationConfig.default().model_copy(
+            update={"evals": _eval_config()}
+        )
+
+        with caplog.at_level(logging.INFO, logger="simulation_v2.evals.runner"):
+            with transaction(eval_fixture.db_path) as conn:
+                summaries = run_turn_evals(
+                    eval_fixture.run_id,
+                    eval_fixture.turn_id,
+                    eval_fixture.turn_number,
+                    config,
+                    db.repos,
+                    conn,
+                )
+
+        assert len(summaries) == 4
+        assert {summary.plugin_name for summary in summaries} == set(BUILTIN_PLUGINS)
+        assert _count_eval_runs(eval_fixture.db_path) == 4
+        assert any("eval turn summary" in record.message for record in caplog.records)
+
+    def test_run_run_evals_executes_all_builtin_plugins(
+        self, eval_fixture: EvalFixture
+    ) -> None:
+        db = SimulationDatabase(eval_fixture.db_path)
+        config = LocalSimulationConfig.default().model_copy(
+            update={"evals": _eval_config()}
+        )
+
+        with transaction(eval_fixture.db_path) as conn:
+            summaries = run_run_evals(eval_fixture.run_id, config, db.repos, conn)
+
+        assert len(summaries) == 4
+        assert _count_eval_runs(eval_fixture.db_path) == 4
+
+    def test_default_config_plugin_names_resolve(self) -> None:
+        from simulation_v2.evals.registry import get_eval_plugin
+
+        for name in BUILTIN_PLUGINS:
+            assert get_eval_plugin(name) is not None

--- a/tests/simulation_v2/evals/test_runner.py
+++ b/tests/simulation_v2/evals/test_runner.py
@@ -38,7 +38,7 @@ def clean_eval_registry():
 
 class _PassingTurnPlugin:
     name: ClassVar[str] = "test_pass"
-    scope: ClassVar[EvalScope] = "turn"
+    scopes: ClassVar[frozenset[EvalScope]] = frozenset({"turn"})
 
     def run(self, context: EvalContext) -> EvalResult:
         return EvalResult(
@@ -56,7 +56,7 @@ class _PassingTurnPlugin:
 
 class _FailingTurnPlugin:
     name: ClassVar[str] = "test_fail"
-    scope: ClassVar[EvalScope] = "turn"
+    scopes: ClassVar[frozenset[EvalScope]] = frozenset({"turn"})
 
     def run(self, context: EvalContext) -> EvalResult:
         return EvalResult(
@@ -69,7 +69,7 @@ class _FailingTurnPlugin:
 
 class _RaisingTurnPlugin:
     name: ClassVar[str] = "test_raise"
-    scope: ClassVar[EvalScope] = "turn"
+    scopes: ClassVar[frozenset[EvalScope]] = frozenset({"turn"})
 
     def run(self, context: EvalContext) -> EvalResult:
         raise RuntimeError("plugin exploded")
@@ -77,7 +77,7 @@ class _RaisingTurnPlugin:
 
 class _PassingRunPlugin:
     name: ClassVar[str] = "test_run_pass"
-    scope: ClassVar[EvalScope] = "run"
+    scopes: ClassVar[frozenset[EvalScope]] = frozenset({"run"})
 
     def run(self, context: EvalContext) -> EvalResult:
         return EvalResult(


### PR DESCRIPTION
## Overview

PR 12 shipped the eval execution skeleton (`simulation_v2/evals/runner.py`, empty registry). This PR fills in the four deterministic plugins named in `PROPOSAL.md` and default `EvalConfig`. Each plugin reads run/turn state exclusively via `EvalContext`, returns stable `EvalMetricDraft` rows, and is exercised end-to-end through `run_turn_evals` / `run_run_evals` with fixture SQLite data — matching architecture Layer 1 CI metrics (invalid proposal rate, structured output reliability, feed sanity).

## Problem / motivation

Default `EvalConfig` lists the same four plugin names in both `turn_plugins` and `run_plugins`, but PR 12's `EvalPlugin.scope` allowed only one scope and the runner skipped mismatches — so run-scope evals would never execute. The registry was also empty, so configured plugins were skipped as unknown.

## Solution

Replace single `scope` with `scopes: frozenset[EvalScope]`, add scope-aware `query_helpers`, implement four built-in plugins, register them on `simulation_v2.evals` import, and add fixture-backed unit and runner integration tests.

## Happy Flow

1. **Turn completes** — `worker/turn_executor.py` persists feeds, proposed actions, and executed entity diffs, then calls `run_turn_evals(...)`.
2. **Registry lookup** — `evals/runner.py` iterates `config.evals.turn_plugins`; each name resolves via `get_eval_plugin` (no longer skipped as unknown).
3. **Scope-aware reads** — Plugin `run(context)` calls shared helpers in `simulation_v2/evals/query_helpers.py` to load proposed actions, generations, feeds, users, and executed entities filtered by `context.scope` + `context.turn_id` / `context.turn_number`.
4. **Metric emission** — Plugin returns `EvalResult(plugin_name=..., status="passed"|"failed", metrics=[...])` with numeric values and optional `metadata_json` dimensions (`action_type`, `filter_id`, etc.).
5. **Persistence + logging** — Runner inserts `eval_runs` / `eval_metrics` (unchanged from PR 12) and logs a concise batch summary for the turn.
6. **Run completes** — `worker/run_executor.py` calls `run_run_evals(...)`; same four plugins aggregate across all turns for run scope.

## Data Flow

```mermaid
flowchart TD
  turnExec[turn_executor.execute_turn]
  runEvals[evals.runner.run_turn_evals]
  registry[evals.registry.get_eval_plugin]
  plugin[plugins.action_counts etc]
  helpers[evals.query_helpers]
  repos[db.repositories via EvalContext]
  sqlite[(SQLite fixture DB)]
  persist[insert eval_runs and eval_metrics]

  turnExec --> runEvals
  runEvals --> registry
  registry --> plugin
  plugin --> helpers
  helpers --> repos
  repos --> sqlite
  plugin --> runEvals
  runEvals --> persist
```

## Changes

- `simulation_v2/evals/interfaces.py`: `EvalPlugin.scopes` replaces single `scope`
- `simulation_v2/evals/runner.py`: scope guard + batch INFO summary per turn/run
- `simulation_v2/evals/query_helpers.py`: scope-aware loaders for plugins
- `simulation_v2/evals/plugins/*.py`: `action_counts`, `invalid_action_rate`, `feed_coverage`, `llm_structured_output`
- `simulation_v2/evals/registry.py` + `__init__.py`: `register_builtin_eval_plugins()` on import
- `docs/plans/2026-05-26_simulation_v2_pr13_deterministic_eval_plugins_847301/contracts.md`: metric naming freeze
- `tests/simulation_v2/evals/conftest.py`: `seed_eval_fixture_db` shared fixture
- `tests/simulation_v2/evals/plugins/test_*.py`: per-plugin unit tests
- `tests/simulation_v2/evals/test_builtin_plugins.py`: runner integration for turn + run scope
- `tests/simulation_v2/evals/test_runner.py`: stub plugins use `scopes`

## Manual Verification

- [x] `uv run pytest tests/simulation_v2/evals/ -v` — 14 passed
- [x] `uv run pytest tests/simulation_v2/evals/plugins/ -v` — all plugin tests pass
- [x] `uv run pytest tests/simulation_v2/evals/test_builtin_plugins.py -v` — turn + run integration pass
- [x] `uv run pytest tests/simulation_v2/evals tests/simulation_v2/db tests/simulation_v2/worker tests/simulation_v2/test_config.py -q` — 111 passed (focused adjacent modules)
- [x] Batch summary INFO line captured in `test_run_turn_evals_executes_all_builtin_plugins`
- [x] `python -c "from simulation_v2.evals.registry import get_eval_plugin; assert all(get_eval_plugin(n) for n in ['action_counts','invalid_action_rate','feed_coverage','llm_structured_output'])"`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Four built-in evaluation plugins added (action counts, feed coverage, invalid-action rates, LLM generation metrics) with turn/run scopes and automatic registration
  * Scope-aware data loaders and a post-run eval summary printed after simulation

* **Tests**
  * Extensive unit and integration tests covering all new plugins and runner behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/METResearchGroup/social_agent_simulation_platform/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->