### PR TITLE
Add golden dataset eval skeleton for simulation_v2 (PR 14)

### DIFF
--- a/docs/plans/2026-05-27_simulation_v2_pr14_golden_dataset_eval_847302/contracts.md
+++ b/docs/plans/2026-05-27_simulation_v2_pr14_golden_dataset_eval_847302/contracts.md
@@ -1,0 +1,39 @@
+# PR 14 Golden Dataset Eval — Contract Freeze
+
+| Symbol | Contract |
+| --- | --- |
+| `GoldenFixtureFile` | `schema_version: int` (must be `1`), `cases: list[GoldenCase]` |
+| `GoldenCase` | Required: `case_id: str`, `user_id: str`. Optional: `expected_like_post_ids`, `expected_follow_user_ids`, `expected_write_topic` (each `list[str]` or `str` for topic). **Absent key = skip label**; **present empty list = negative label** (predicted must be empty). |
+| `GoldenDatasetPlugin.name` | `"golden_dataset"` |
+| `GoldenDatasetPlugin.scopes` | `frozenset({"turn"})` only |
+| Default fixture path | `Path(__file__).resolve().parent.parent / "fixtures" / "golden_v1.json"` |
+| Predicted sets | From `load_proposed_actions(context)` filtered to `record_kind == "validated"` and `user_id == case.user_id` |
+| `metric_name` | `precision`, `recall`, `f1`, `tp`, `fp`, `fn`, plus informational `cases_evaluated`, `cases_skipped`, `labels_skipped` |
+| `metadata_json` | At minimum `label_type`, `case_id`; macro rows use `label_type` only |
+| `status` | `"passed"` for skeleton unless fixture file missing/invalid (then `"failed"` + warning) |
+| Runner | **No edits** to `runner.py`; registry-only wiring |
+| Config | **Do not** add to default `turn_plugins` / `run_plugins`; tests pass `LocalSimulationConfig` with `golden_dataset` in list |
+
+## P/R/F1 helper
+
+```python
+def prf(predicted: set[str], expected: set[str]) -> tuple[float, float, float, int, int, int]:
+    tp = len(predicted & expected)
+    fp = len(predicted - expected)
+    fn = len(expected - predicted)
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return precision, recall, f1, tp, fp, fn
+```
+
+## Write topic (skeleton)
+
+Case-insensitive equality: `predicted_topic.strip().lower() == expected_write_topic.strip().lower()` where `predicted_topic` is the first validated `write_post` action's `target_content` for that user in scope (empty string if none). Treat as set comparison with singleton sets for P/R/F1.
+
+## Pass/fail
+
+| Condition | `status` |
+| --- | --- |
+| Fixture loads and evaluates | `"passed"` |
+| Fixture file missing or invalid JSON/schema | `"failed"` + warning |

--- a/simulation_v2/evals/fixtures/__init__.py
+++ b/simulation_v2/evals/fixtures/__init__.py
@@ -1,0 +1,15 @@
+"""Golden eval fixture schema and default fixture file."""
+
+from simulation_v2.evals.fixtures.models import (
+    DEFAULT_GOLDEN_FIXTURE_PATH,
+    GoldenCase,
+    GoldenFixtureFile,
+    load_golden_fixture,
+)
+
+__all__ = [
+    "DEFAULT_GOLDEN_FIXTURE_PATH",
+    "GoldenCase",
+    "GoldenFixtureFile",
+    "load_golden_fixture",
+]

--- a/simulation_v2/evals/fixtures/golden_v1.json
+++ b/simulation_v2/evals/fixtures/golden_v1.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "case_id": "partial_likes",
+      "user_id": "golden-user-like",
+      "expected_like_post_ids": ["golden-post-a", "golden-post-b"]
+    },
+    {
+      "case_id": "partial_follows",
+      "user_id": "golden-user-follow",
+      "expected_follow_user_ids": ["golden-target-user"]
+    },
+    {
+      "case_id": "partial_write_topic",
+      "user_id": "golden-user-write",
+      "expected_write_topic": "renewable energy"
+    }
+  ]
+}

--- a/simulation_v2/evals/fixtures/models.py
+++ b/simulation_v2/evals/fixtures/models.py
@@ -1,0 +1,36 @@
+"""Pydantic models and loader for golden eval fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import BaseModel, Field, field_validator
+
+DEFAULT_GOLDEN_FIXTURE_PATH = Path(__file__).resolve().parent / "golden_v1.json"
+
+
+class GoldenCase(BaseModel):
+    case_id: str
+    user_id: str
+    expected_like_post_ids: list[str] | None = None
+    expected_follow_user_ids: list[str] | None = None
+    expected_write_topic: str | None = None
+
+
+class GoldenFixtureFile(BaseModel):
+    schema_version: int
+    cases: list[GoldenCase] = Field(default_factory=list)
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, value: int) -> int:
+        if value != 1:
+            raise ValueError(f"unsupported schema_version: {value}")
+        return value
+
+
+def load_golden_fixture(path: Path | None = None) -> GoldenFixtureFile:
+    fixture_path = path or DEFAULT_GOLDEN_FIXTURE_PATH
+    raw = json.loads(fixture_path.read_text(encoding="utf-8"))
+    return GoldenFixtureFile.model_validate(raw)

--- a/simulation_v2/evals/plugins/golden_dataset.py
+++ b/simulation_v2/evals/plugins/golden_dataset.py
@@ -6,27 +6,58 @@ from collections import defaultdict
 from pathlib import Path
 from typing import ClassVar
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
+from simulation_v2.db.models.actions import ProposedActionRecord
 from simulation_v2.db.models.evals import EvalScope
 from simulation_v2.evals.fixtures.models import GoldenCase, load_golden_fixture
 from simulation_v2.evals.interfaces import EvalContext, EvalMetricDraft, EvalResult
 from simulation_v2.evals.query_helpers import load_proposed_actions
 
 
-def prf(
+class PrecisionRecallF1Metrics(BaseModel):
+    precision: float
+    recall: float
+    f1: float
+    true_positives: int
+    false_positives: int
+    false_negatives: int
+
+
+def compute_precision_recall_f1(
     predicted: set[str], expected: set[str]
-) -> tuple[float, float, float, int, int, int]:
-    tp = len(predicted & expected)
-    fp = len(predicted - expected)
-    fn = len(expected - predicted)
-    precision = tp / (tp + fp) if (tp + fp) else 0.0
-    recall = tp / (tp + fn) if (tp + fn) else 0.0
+) -> PrecisionRecallF1Metrics:
+    """Compute precision, recall, and F1 from predicted and expected string sets.
+
+    Treats set membership as binary classification: true positives are items in
+    both sets; false positives are predicted-only; false negatives are expected-only.
+    """
+    true_positives = len(predicted & expected)
+    false_positives = len(predicted - expected)
+    false_negatives = len(expected - predicted)
+    precision = (
+        true_positives / (true_positives + false_positives)
+        if (true_positives + false_positives)
+        else 0.0
+    )
+    recall = (
+        true_positives / (true_positives + false_negatives)
+        if (true_positives + false_negatives)
+        else 0.0
+    )
     f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
-    return precision, recall, f1, tp, fp, fn
+    return PrecisionRecallF1Metrics(
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        true_positives=true_positives,
+        false_positives=false_positives,
+        false_negatives=false_negatives,
+    )
 
 
 def _normalize_topic(value: str) -> str:
+    """Normalize a write topic for case-insensitive golden-label comparison."""
     return value.strip().lower()
 
 
@@ -35,9 +66,11 @@ class GoldenDatasetPlugin:
     scopes: ClassVar[frozenset[EvalScope]] = frozenset({"turn"})
 
     def __init__(self, fixture_path: Path | None = None) -> None:
+        """Optionally override the default golden fixture JSON path (for tests)."""
         self._fixture_path = fixture_path
 
     def run(self, context: EvalContext) -> EvalResult:
+        """Load the golden fixture and score validated proposed actions per labeled case."""
         try:
             fixture = load_golden_fixture(self._fixture_path)
         except (OSError, ValidationError, ValueError) as exc:
@@ -53,7 +86,7 @@ class GoldenDatasetPlugin:
             for user in context.repos.list_users_for_run(context.run_id, context.conn)
         }
         proposed = load_proposed_actions(context)
-        validated_by_user: dict[str, list] = defaultdict(list)
+        validated_by_user: dict[str, list[ProposedActionRecord]] = defaultdict(list)
         for action in proposed:
             if action.record_kind != "validated":
                 continue
@@ -113,8 +146,9 @@ class GoldenDatasetPlugin:
 
 
 def _evaluate_case(
-    case: GoldenCase, user_actions: list
+    case: GoldenCase, user_actions: list[ProposedActionRecord]
 ) -> tuple[list[EvalMetricDraft], list[str], int]:
+    """Score one golden case against a user's validated actions for present label fields."""
     metrics: list[EvalMetricDraft] = []
     warnings: list[str] = []
     labels_skipped = 0
@@ -164,15 +198,15 @@ def _evaluate_case(
         warnings.append(f"skipped label_type=write_topic for case_id={case.case_id}")
 
     for label_type, case_id, predicted, expected in label_specs:
-        precision, recall, f1, tp, fp, fn = prf(predicted, expected)
+        scores = compute_precision_recall_f1(predicted, expected)
         metadata = {"label_type": label_type, "case_id": case_id}
         for metric_name, value in (
-            ("precision", precision),
-            ("recall", recall),
-            ("f1", f1),
-            ("tp", float(tp)),
-            ("fp", float(fp)),
-            ("fn", float(fn)),
+            ("precision", scores.precision),
+            ("recall", scores.recall),
+            ("f1", scores.f1),
+            ("tp", float(scores.true_positives)),
+            ("fp", float(scores.false_positives)),
+            ("fn", float(scores.false_negatives)),
         ):
             metrics.append(
                 EvalMetricDraft(

--- a/simulation_v2/evals/plugins/golden_dataset.py
+++ b/simulation_v2/evals/plugins/golden_dataset.py
@@ -1,0 +1,185 @@
+"""Compare validated proposed actions against golden fixture labels."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+from typing import ClassVar
+
+from pydantic import ValidationError
+
+from simulation_v2.db.models.evals import EvalScope
+from simulation_v2.evals.fixtures.models import GoldenCase, load_golden_fixture
+from simulation_v2.evals.interfaces import EvalContext, EvalMetricDraft, EvalResult
+from simulation_v2.evals.query_helpers import load_proposed_actions
+
+
+def prf(
+    predicted: set[str], expected: set[str]
+) -> tuple[float, float, float, int, int, int]:
+    tp = len(predicted & expected)
+    fp = len(predicted - expected)
+    fn = len(expected - predicted)
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return precision, recall, f1, tp, fp, fn
+
+
+def _normalize_topic(value: str) -> str:
+    return value.strip().lower()
+
+
+class GoldenDatasetPlugin:
+    name: ClassVar[str] = "golden_dataset"
+    scopes: ClassVar[frozenset[EvalScope]] = frozenset({"turn"})
+
+    def __init__(self, fixture_path: Path | None = None) -> None:
+        self._fixture_path = fixture_path
+
+    def run(self, context: EvalContext) -> EvalResult:
+        try:
+            fixture = load_golden_fixture(self._fixture_path)
+        except (OSError, ValidationError, ValueError) as exc:
+            return EvalResult(
+                plugin_name=self.name,
+                status="failed",
+                metrics=[],
+                warnings=[f"failed to load golden fixture: {exc}"],
+            )
+
+        run_user_ids = {
+            user.user_id
+            for user in context.repos.list_users_for_run(context.run_id, context.conn)
+        }
+        proposed = load_proposed_actions(context)
+        validated_by_user: dict[str, list] = defaultdict(list)
+        for action in proposed:
+            if action.record_kind != "validated":
+                continue
+            validated_by_user[action.user_id].append(action)
+
+        metrics: list[EvalMetricDraft] = []
+        warnings: list[str] = []
+        cases_evaluated = 0
+        cases_skipped = 0
+        labels_skipped = 0
+        f1_by_label_type: dict[str, list[float]] = defaultdict(list)
+
+        for case in fixture.cases:
+            if case.user_id not in run_user_ids:
+                cases_skipped += 1
+                continue
+
+            cases_evaluated += 1
+            user_actions = validated_by_user.get(case.user_id, [])
+            case_metrics, case_warnings, case_labels_skipped = _evaluate_case(
+                case, user_actions
+            )
+            metrics.extend(case_metrics)
+            warnings.extend(case_warnings)
+            labels_skipped += case_labels_skipped
+
+            for metric in case_metrics:
+                if metric.metric_name != "f1":
+                    continue
+                label_type = (metric.metadata_json or {}).get("label_type")
+                if label_type:
+                    f1_by_label_type[str(label_type)].append(metric.metric_value)
+
+        for label_type, f1_values in sorted(f1_by_label_type.items()):
+            macro_f1 = sum(f1_values) / len(f1_values)
+            metrics.append(
+                EvalMetricDraft(
+                    metric_name="f1",
+                    metric_value=macro_f1,
+                    metadata_json={"label_type": label_type, "aggregate": "macro"},
+                )
+            )
+
+        for metric_name, value in (
+            ("cases_evaluated", float(cases_evaluated)),
+            ("cases_skipped", float(cases_skipped)),
+            ("labels_skipped", float(labels_skipped)),
+        ):
+            metrics.append(EvalMetricDraft(metric_name=metric_name, metric_value=value))
+
+        return EvalResult(
+            plugin_name=self.name,
+            status="passed",
+            metrics=metrics,
+            warnings=warnings,
+        )
+
+
+def _evaluate_case(
+    case: GoldenCase, user_actions: list
+) -> tuple[list[EvalMetricDraft], list[str], int]:
+    metrics: list[EvalMetricDraft] = []
+    warnings: list[str] = []
+    labels_skipped = 0
+    fields_set = case.model_fields_set
+
+    label_specs: list[tuple[str, str, set[str], set[str]]] = []
+
+    if "expected_like_post_ids" in fields_set:
+        predicted = {
+            action.target_id
+            for action in user_actions
+            if action.action_type == "like_post" and action.target_id
+        }
+        expected = set(case.expected_like_post_ids or [])
+        label_specs.append(("like", case.case_id, predicted, expected))
+    else:
+        labels_skipped += 1
+        warnings.append(f"skipped label_type=like for case_id={case.case_id}")
+
+    if "expected_follow_user_ids" in fields_set:
+        predicted = {
+            action.target_id
+            for action in user_actions
+            if action.action_type == "follow_user" and action.target_id
+        }
+        expected = set(case.expected_follow_user_ids or [])
+        label_specs.append(("follow", case.case_id, predicted, expected))
+    else:
+        labels_skipped += 1
+        warnings.append(f"skipped label_type=follow for case_id={case.case_id}")
+
+    if "expected_write_topic" in fields_set:
+        predicted_topic = next(
+            (
+                action.target_content or ""
+                for action in user_actions
+                if action.action_type == "write_post"
+            ),
+            "",
+        )
+        predicted = {_normalize_topic(predicted_topic)} if predicted_topic else set()
+        expected_value = case.expected_write_topic or ""
+        expected = {_normalize_topic(expected_value)} if expected_value else set()
+        label_specs.append(("write_topic", case.case_id, predicted, expected))
+    else:
+        labels_skipped += 1
+        warnings.append(f"skipped label_type=write_topic for case_id={case.case_id}")
+
+    for label_type, case_id, predicted, expected in label_specs:
+        precision, recall, f1, tp, fp, fn = prf(predicted, expected)
+        metadata = {"label_type": label_type, "case_id": case_id}
+        for metric_name, value in (
+            ("precision", precision),
+            ("recall", recall),
+            ("f1", f1),
+            ("tp", float(tp)),
+            ("fp", float(fp)),
+            ("fn", float(fn)),
+        ):
+            metrics.append(
+                EvalMetricDraft(
+                    metric_name=metric_name,
+                    metric_value=value,
+                    metadata_json=metadata,
+                )
+            )
+
+    return metrics, warnings, labels_skipped

--- a/simulation_v2/evals/registry.py
+++ b/simulation_v2/evals/registry.py
@@ -18,6 +18,7 @@ def get_eval_plugin(name: str) -> EvalPlugin | None:
 def register_builtin_eval_plugins() -> None:
     from simulation_v2.evals.plugins.action_counts import ActionCountsPlugin
     from simulation_v2.evals.plugins.feed_coverage import FeedCoveragePlugin
+    from simulation_v2.evals.plugins.golden_dataset import GoldenDatasetPlugin
     from simulation_v2.evals.plugins.invalid_action_rate import (
         InvalidActionRatePlugin,
     )
@@ -28,4 +29,5 @@ def register_builtin_eval_plugins() -> None:
     register_eval_plugin(ActionCountsPlugin())
     register_eval_plugin(InvalidActionRatePlugin())
     register_eval_plugin(FeedCoveragePlugin())
+    register_eval_plugin(GoldenDatasetPlugin())
     register_eval_plugin(LlmStructuredOutputPlugin())

--- a/tests/simulation_v2/evals/plugins/test_golden_dataset.py
+++ b/tests/simulation_v2/evals/plugins/test_golden_dataset.py
@@ -1,0 +1,373 @@
+"""Tests for golden_dataset eval plugin."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+import simulation_v2.evals  # noqa: F401 — registers builtins
+from simulation_v2.config import EvalConfig, LocalSimulationConfig
+from simulation_v2.db.connection import transaction
+from simulation_v2.db.database import SimulationDatabase
+from simulation_v2.evals.interfaces import EvalContext
+from simulation_v2.evals.plugins.golden_dataset import GoldenDatasetPlugin
+from simulation_v2.evals.runner import run_turn_evals
+from tests.simulation_v2.db import factories
+
+
+@dataclass(frozen=True)
+class GoldenEvalFixture:
+    db_path: Path
+    run_id: str
+    turn_id: str
+    turn_number: int
+
+
+def _insert_run_turn(conn, db: SimulationDatabase, run, turn) -> None:
+    db.repos.insert_run(run, conn)
+    db.repos.insert_turn(turn, conn)
+
+
+def _build_context(fixture: GoldenEvalFixture, conn, repos) -> EvalContext:
+    return EvalContext(
+        repos=repos,
+        conn=conn,
+        run_id=fixture.run_id,
+        config=LocalSimulationConfig.default(),
+        scope="turn",
+        turn_id=fixture.turn_id,
+        turn_number=fixture.turn_number,
+    )
+
+
+def _metric(
+    result,
+    metric_name: str,
+    *,
+    case_id: str | None = None,
+    label_type: str | None = None,
+):
+    for metric in result.metrics:
+        if metric.metric_name != metric_name:
+            continue
+        metadata = metric.metadata_json or {}
+        if case_id is not None and metadata.get("case_id") != case_id:
+            continue
+        if label_type is not None and metadata.get("label_type") != label_type:
+            continue
+        if metadata.get("aggregate") == "macro":
+            continue
+        return metric
+    raise AssertionError(
+        f"metric {metric_name!r} not found for case_id={case_id!r} label_type={label_type!r}"
+    )
+
+
+def seed_partial_likes_db(db_path: Path) -> GoldenEvalFixture:
+    db = SimulationDatabase(db_path)
+    db.initialize()
+
+    run = factories.RunRecordFactory.create()
+    turn = factories.TurnRecordFactory.create(
+        run_id=run.run_id, turn_number=1, status="completed"
+    )
+    user = factories.UserRecordFactory.create(
+        run_id=run.run_id, user_id="golden-user-like"
+    )
+    gen = factories.GenerationRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user.user_id,
+        action_type="like_post",
+        status="completed",
+    )
+    proposed = factories.ProposedActionRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user.user_id,
+        action_type="like_post",
+        record_kind="validated",
+        generation_id=gen.generation_id,
+        target_id="golden-post-a",
+    )
+
+    with transaction(db_path) as conn:
+        _insert_run_turn(conn, db, run, turn)
+        db.repos.insert_user(user, conn)
+        db.repos.insert_generation(gen, conn)
+        db.repos.insert_proposed_action(proposed, conn)
+
+    return GoldenEvalFixture(
+        db_path=db_path,
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        turn_number=turn.turn_number,
+    )
+
+
+def seed_perfect_follow_db(db_path: Path) -> GoldenEvalFixture:
+    db = SimulationDatabase(db_path)
+    db.initialize()
+
+    run = factories.RunRecordFactory.create()
+    turn = factories.TurnRecordFactory.create(
+        run_id=run.run_id, turn_number=1, status="completed"
+    )
+    user = factories.UserRecordFactory.create(
+        run_id=run.run_id, user_id="golden-user-follow"
+    )
+    target = factories.UserRecordFactory.create(
+        run_id=run.run_id, user_id="golden-target-user"
+    )
+    gen = factories.GenerationRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user.user_id,
+        action_type="follow_user",
+        status="completed",
+    )
+    proposed = factories.ProposedActionRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user.user_id,
+        action_type="follow_user",
+        record_kind="validated",
+        generation_id=gen.generation_id,
+        target_id=target.user_id,
+    )
+
+    with transaction(db_path) as conn:
+        _insert_run_turn(conn, db, run, turn)
+        db.repos.insert_user(user, conn)
+        db.repos.insert_user(target, conn)
+        db.repos.insert_generation(gen, conn)
+        db.repos.insert_proposed_action(proposed, conn)
+
+    return GoldenEvalFixture(
+        db_path=db_path,
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        turn_number=turn.turn_number,
+    )
+
+
+def seed_write_topic_db(db_path: Path) -> GoldenEvalFixture:
+    db = SimulationDatabase(db_path)
+    db.initialize()
+
+    run = factories.RunRecordFactory.create()
+    turn = factories.TurnRecordFactory.create(
+        run_id=run.run_id, turn_number=1, status="completed"
+    )
+    user = factories.UserRecordFactory.create(
+        run_id=run.run_id, user_id="golden-user-write"
+    )
+    gen = factories.GenerationRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user.user_id,
+        action_type="write_post",
+        status="completed",
+    )
+    proposed = factories.ProposedActionRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user.user_id,
+        action_type="write_post",
+        record_kind="validated",
+        generation_id=gen.generation_id,
+        target_content="Renewable Energy",
+    )
+
+    with transaction(db_path) as conn:
+        _insert_run_turn(conn, db, run, turn)
+        db.repos.insert_user(user, conn)
+        db.repos.insert_generation(gen, conn)
+        db.repos.insert_proposed_action(proposed, conn)
+
+    return GoldenEvalFixture(
+        db_path=db_path,
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        turn_number=turn.turn_number,
+    )
+
+
+def seed_negative_like_db(db_path: Path, fixture_path: Path) -> GoldenEvalFixture:
+    db = SimulationDatabase(db_path)
+    db.initialize()
+
+    fixture_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "cases": [
+                    {
+                        "case_id": "negative_likes",
+                        "user_id": "golden-user-negative",
+                        "expected_like_post_ids": [],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    run = factories.RunRecordFactory.create()
+    turn = factories.TurnRecordFactory.create(
+        run_id=run.run_id, turn_number=1, status="completed"
+    )
+    user = factories.UserRecordFactory.create(
+        run_id=run.run_id, user_id="golden-user-negative"
+    )
+    gen = factories.GenerationRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user.user_id,
+        action_type="like_post",
+        status="completed",
+    )
+    proposed = factories.ProposedActionRecordFactory.create(
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        user_id=user.user_id,
+        action_type="like_post",
+        record_kind="validated",
+        generation_id=gen.generation_id,
+        target_id="unexpected-post",
+    )
+
+    with transaction(db_path) as conn:
+        _insert_run_turn(conn, db, run, turn)
+        db.repos.insert_user(user, conn)
+        db.repos.insert_generation(gen, conn)
+        db.repos.insert_proposed_action(proposed, conn)
+
+    return GoldenEvalFixture(
+        db_path=db_path,
+        run_id=run.run_id,
+        turn_id=turn.turn_id,
+        turn_number=turn.turn_number,
+    )
+
+
+class TestGoldenDatasetPlugin:
+    def test_partial_likes_recall_below_one_precision_one(self, tmp_path: Path) -> None:
+        fixture = seed_partial_likes_db(tmp_path / "partial_likes.sqlite3")
+        db = SimulationDatabase(fixture.db_path)
+        with transaction(fixture.db_path) as conn:
+            result = GoldenDatasetPlugin().run(_build_context(fixture, conn, db.repos))
+
+        assert result.status == "passed"
+        assert _metric(
+            result, "precision", case_id="partial_likes", label_type="like"
+        ).metric_value == pytest.approx(1.0)
+        assert _metric(
+            result, "recall", case_id="partial_likes", label_type="like"
+        ).metric_value == pytest.approx(0.5)
+        assert any(
+            "skipped label_type=follow" in warning for warning in result.warnings
+        )
+        assert any(
+            "skipped label_type=write_topic" in warning for warning in result.warnings
+        )
+
+    def test_partial_follows_perfect_f1(self, tmp_path: Path) -> None:
+        fixture = seed_perfect_follow_db(tmp_path / "follows.sqlite3")
+        db = SimulationDatabase(fixture.db_path)
+        with transaction(fixture.db_path) as conn:
+            result = GoldenDatasetPlugin().run(_build_context(fixture, conn, db.repos))
+
+        assert _metric(
+            result, "f1", case_id="partial_follows", label_type="follow"
+        ).metric_value == pytest.approx(1.0)
+
+    def test_write_topic_case_insensitive_match(self, tmp_path: Path) -> None:
+        fixture = seed_write_topic_db(tmp_path / "write_topic.sqlite3")
+        db = SimulationDatabase(fixture.db_path)
+        with transaction(fixture.db_path) as conn:
+            result = GoldenDatasetPlugin().run(_build_context(fixture, conn, db.repos))
+
+        assert _metric(
+            result, "f1", case_id="partial_write_topic", label_type="write_topic"
+        ).metric_value == pytest.approx(1.0)
+
+    def test_absent_labels_skipped_with_warnings(self, tmp_path: Path) -> None:
+        fixture = seed_partial_likes_db(tmp_path / "absent_labels.sqlite3")
+        db = SimulationDatabase(fixture.db_path)
+        with transaction(fixture.db_path) as conn:
+            result = GoldenDatasetPlugin().run(_build_context(fixture, conn, db.repos))
+
+        follow_metrics = [
+            m
+            for m in result.metrics
+            if (m.metadata_json or {}).get("label_type") == "follow"
+            and (m.metadata_json or {}).get("case_id") == "partial_likes"
+        ]
+        write_metrics = [
+            m
+            for m in result.metrics
+            if (m.metadata_json or {}).get("label_type") == "write_topic"
+            and (m.metadata_json or {}).get("case_id") == "partial_likes"
+        ]
+        assert follow_metrics == []
+        assert write_metrics == []
+        assert any("skipped label_type=follow" in w for w in result.warnings)
+        assert any("skipped label_type=write_topic" in w for w in result.warnings)
+
+    def test_negative_label_zero_precision(self, tmp_path: Path) -> None:
+        fixture_path = tmp_path / "negative_fixture.json"
+        fixture = seed_negative_like_db(
+            tmp_path / "negative_like.sqlite3", fixture_path
+        )
+        db = SimulationDatabase(fixture.db_path)
+        with transaction(fixture.db_path) as conn:
+            result = GoldenDatasetPlugin(fixture_path=fixture_path).run(
+                _build_context(fixture, conn, db.repos)
+            )
+
+        assert _metric(
+            result, "precision", case_id="negative_likes", label_type="like"
+        ).metric_value == pytest.approx(0.0)
+        assert _metric(
+            result, "f1", case_id="negative_likes", label_type="like"
+        ).metric_value == pytest.approx(0.0)
+
+    def test_runner_persists_golden_dataset_metrics(self, tmp_path: Path) -> None:
+        fixture = seed_partial_likes_db(tmp_path / "runner.sqlite3")
+        db = SimulationDatabase(fixture.db_path)
+        config = LocalSimulationConfig.default().model_copy(
+            update={
+                "evals": EvalConfig(
+                    enabled=True,
+                    fail_run_on_error=False,
+                    turn_plugins=["golden_dataset"],
+                    run_plugins=[],
+                )
+            }
+        )
+
+        with transaction(fixture.db_path) as conn:
+            summaries = run_turn_evals(
+                fixture.run_id,
+                fixture.turn_id,
+                fixture.turn_number,
+                config,
+                db.repos,
+                conn,
+            )
+
+        assert len(summaries) == 1
+        assert summaries[0].plugin_name == "golden_dataset"
+
+        with transaction(fixture.db_path) as conn:
+            row = conn.execute("SELECT COUNT(*) AS count FROM eval_runs").fetchone()
+            metric_row = conn.execute(
+                "SELECT COUNT(*) AS count FROM eval_metrics"
+            ).fetchone()
+
+        assert int(row["count"]) == 1
+        assert int(metric_row["count"]) > 0


### PR DESCRIPTION
## Overview

PR 14 adds **Layer 2 golden regression skeleton**: labeled single-turn cases with optional `expected_like_post_ids`, `expected_follow_user_ids`, and `expected_write_topic`. The `golden_dataset` plugin loads a small versioned JSON fixture, reads **validated** proposed actions from SQLite via `EvalContext` (same pattern as PR 13 plugins), computes precision/recall/F1 per label type when labels exist, skips missing optional labels explicitly, and returns `EvalMetricDraft` rows for `evals.runner` to persist. It is **optional in default config** (not added to `EvalConfig` default plugin lists) but registered in `register_builtin_eval_plugins` so tests and future CI can enable it by name.

## Problem / motivation

The eval framework (PR 12–13) supports deterministic metrics on proposed actions, feed coverage, and LLM output quality, but there is no way to compare model output against labeled golden cases for regression testing. PR 14 establishes the skeleton so future runs can opt into golden-dataset evaluation without requiring LLM calls in tests.

## Solution

Add a versioned JSON fixture (`golden_v1.json`), Pydantic schema models, and a turn-scoped `golden_dataset` eval plugin that compares scope-filtered validated proposed actions to optional per-case labels, emitting P/R/F1 metrics and skip warnings. Prove the skeleton with SQLite-seeded tests and runner integration.

## Happy Flow

1. **Fixture on disk** — `simulation_v2/evals/fixtures/golden_v1.json` declares `schema_version: 1` and a `cases[]` array with stable `case_id`, `user_id`, and optional label fields.
2. **Test or run seeds SQLite** — Tests insert a run/turn/users/posts and **validated** `proposed_actions` with `target_id` / `target_content` matching fixture IDs (no LLM).
3. **Runner invokes plugin** — `run_turn_evals` builds `EvalContext` with `scope="turn"`; if `golden_dataset` is in `config.evals.turn_plugins`, runner calls `GoldenDatasetPlugin.run(context)`.
4. **Plugin parses fixture** — `golden_dataset.py` resolves fixture path (package-relative default), validates with Pydantic models, loads cases.
5. **Per-case comparison** — For each case whose `user_id` exists in the run: build predicted sets from scope-filtered validated proposed actions. If a label field is **absent**, skip that label type for that case. If present (including `[]` for negative-action), compute TP/FP/FN and P/R/F1.
6. **Metrics out** — Plugin returns `EvalResult` with `metric_name` in `{precision, recall, f1, tp, fp, fn}` and `metadata_json` including `label_type`, `case_id`, and macro aggregates.
7. **Persistence** — Runner writes `eval_runs` / `eval_metrics` unchanged from PR 12.

## Data Flow

```
golden_v1.json → GoldenDatasetPlugin ← EvalContext + SQLite
GoldenDatasetPlugin → EvalResult → evals.runner → eval_metrics
```

## Changes

- `docs/plans/2026-05-27_simulation_v2_pr14_golden_dataset_eval_847302/contracts.md`: fixture schema, metric names, skip rules, pass/fail contract
- `simulation_v2/evals/fixtures/models.py`: Pydantic models and `load_golden_fixture()`
- `simulation_v2/evals/fixtures/golden_v1.json`: 3 partial-label golden cases
- `simulation_v2/evals/plugins/golden_dataset.py`: turn-scoped plugin with P/R/F1 comparison
- `simulation_v2/evals/registry.py`: register `GoldenDatasetPlugin`
- `tests/simulation_v2/evals/plugins/test_golden_dataset.py`: 6 SQLite-seeded tests including runner integration

## Manual Verification

- [x] `uv run pytest tests/simulation_v2/evals/plugins/test_golden_dataset.py -q` — 6 passed
- [x] `uv run pytest tests/simulation_v2/evals/ -q` — 20 passed (PR 12–13 regressions green)
- [x] `uv run python -c "from simulation_v2.evals.registry import get_eval_plugin; p=get_eval_plugin('golden_dataset'); print(p.name, p.scopes)"` — `golden_dataset frozenset({'turn'})`
- [x] Confirm `golden_dataset` **not** in `EvalConfig` default lists (optional plugin only)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a golden-dataset evaluation plugin that computes precision, recall and F1 per case, aggregates macro F1 by label type, and emits summary counts for evaluated/skipped cases and labels.

* **Fixtures / Public API**
  * Added a default golden fixture with three scenarios and a package-level loader and exports to load/validate fixture data.

* **Tests**
  * Added comprehensive tests covering partial recommendations, perfect matches, case-insensitive matching, absent labels handling, negative-label behavior, and metric persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/METResearchGroup/social_agent_simulation_platform/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->